### PR TITLE
feat: validate iteration 2 Dagster project-code runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.terraform
+**/.terraform
+**/.terraform.lock.hcl
+**/terraform.tfstate
+**/terraform.tfstate.*
+__pycache__
+*.pyc
+.pytest_cache
+.venv
+venv
+dist
+build

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 *.yaml      text eol=lf
 *.yml       text eol=lf
 *.toml      text eol=lf
+*.tf        text eol=lf
 *.md        text eol=lf
 *.json      text eol=lf
 Makefile    text eol=lf

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,3 +36,21 @@ jobs:
 
       - name: Check Terraform and Helm
         run: make check-infra
+
+  project-code:
+    name: Validate project-code runtime
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check project-code package
+        run: make check-project-code
+
+      - name: Build project-code image
+        run: make project-code-image

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,27 @@
-.PHONY: help tree check-structure check-infra local-cluster local-destroy-cluster local-up local-down local-status local-forward
+.PHONY: help tree check-structure check-infra check-project-code project-code-image project-code-load local-cluster local-destroy-cluster local-up local-down local-status local-forward local-dagster-smoke
 
 NAMESPACE ?= lakehouse
+PROJECT_CODE_IMAGE_REPOSITORY ?= ghcr.io/openlakeforge/project-code
+PROJECT_CODE_IMAGE_TAG ?= local
+PROJECT_CODE_IMAGE_PULL_POLICY ?= IfNotPresent
 
 help:
 	@printf '%s\n' 'OpenLakeForge bootstrap targets:'
 	@printf '%s\n' '  make tree             Show the repository structure'
 	@printf '%s\n' '  make check-structure  Validate the Iteration 0 repository contract'
 	@printf '%s\n' '  make check-infra      Validate Terraform and render Helm values'
+	@printf '%s\n' '  make check-project-code  Validate the project-code Dagster package'
 	@printf '%s\n' ''
 	@printf '%s\n' 'Local stack:'
 	@printf '%s\n' '  make local-cluster    Create the kind cluster (WSL + kind required)'
+	@printf '%s\n' '  make project-code-image  Build ghcr.io/openlakeforge/project-code:local'
+	@printf '%s\n' '  make project-code-load   Load the project-code image into kind'
 	@printf '%s\n' '  make local-destroy-cluster  Delete the local kind cluster'
-	@printf '%s\n' '  make local-up         Terraform-apply SeaweedFS + Polaris + Trino'
+	@printf '%s\n' '  make local-up         Terraform-apply SeaweedFS + Polaris + Trino + Dagster'
 	@printf '%s\n' '  make local-down       Terraform-destroy the local stack'
 	@printf '%s\n' '  make local-status     Show pod and service status in the lakehouse namespace'
 	@printf '%s\n' '  make local-forward    Port-forward all services to localhost'
+	@printf '%s\n' '  make local-dagster-smoke  Launch the Iteration 2 Dagster smoke job'
 
 tree:
 	@find . -path './.git' -prune -o -print | sort
@@ -25,6 +32,15 @@ check-structure:
 check-infra:
 	@bash scripts/check-infra.sh
 
+check-project-code:
+	@bash scripts/check-project-code.sh
+
+project-code-image:
+	@PROJECT_CODE_IMAGE_REPOSITORY=$(PROJECT_CODE_IMAGE_REPOSITORY) PROJECT_CODE_IMAGE_TAG=$(PROJECT_CODE_IMAGE_TAG) bash scripts/local/build-project-code-image.sh
+
+project-code-load:
+	@PROJECT_CODE_IMAGE_REPOSITORY=$(PROJECT_CODE_IMAGE_REPOSITORY) PROJECT_CODE_IMAGE_TAG=$(PROJECT_CODE_IMAGE_TAG) bash scripts/local/load-project-code-image.sh
+
 local-cluster:
 	@bash scripts/local/create-cluster.sh
 
@@ -32,7 +48,7 @@ local-destroy-cluster:
 	@bash scripts/local/destroy-cluster.sh
 
 local-up:
-	@NAMESPACE=$(NAMESPACE) bash scripts/local/setup.sh
+	@NAMESPACE=$(NAMESPACE) PROJECT_CODE_IMAGE_REPOSITORY=$(PROJECT_CODE_IMAGE_REPOSITORY) PROJECT_CODE_IMAGE_TAG=$(PROJECT_CODE_IMAGE_TAG) PROJECT_CODE_IMAGE_PULL_POLICY=$(PROJECT_CODE_IMAGE_PULL_POLICY) bash scripts/local/setup.sh
 
 local-down:
 	@NAMESPACE=$(NAMESPACE) bash scripts/local/teardown.sh
@@ -45,11 +61,17 @@ local-status:
 local-forward:
 	@echo "Starting port-forwards (Ctrl-C to stop all)..."
 	@set -e; \
+	dagster_pod="$$(kubectl get pods -n $(NAMESPACE) -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep 'dagster-webserver' | head -n 1)"; \
 	kubectl port-forward svc/seaweedfs-s3 9000:8333 -n $(NAMESPACE) & \
 	seaweedfs_pid=$$!; \
 	kubectl port-forward svc/polaris 8181:8181 -n $(NAMESPACE) & \
 	polaris_pid=$$!; \
 	kubectl port-forward svc/trino 8080:8080 -n $(NAMESPACE) & \
 	trino_pid=$$!; \
-	trap 'kill $$seaweedfs_pid $$polaris_pid $$trino_pid 2>/dev/null || true' INT TERM EXIT; \
+	kubectl port-forward pod/$$dagster_pod 3000:80 -n $(NAMESPACE) & \
+	dagster_pid=$$!; \
+	trap 'kill $$seaweedfs_pid $$polaris_pid $$trino_pid $$dagster_pid 2>/dev/null || true' INT TERM EXIT; \
 	wait
+
+local-dagster-smoke:
+	@NAMESPACE=$(NAMESPACE) bash scripts/local/dagster-smoke.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ CSV examples
   -> Dagster asset graph
 ```
 
-Iteration 0 establishes the repository structure and records the first architectural decisions. Runtime infrastructure and local cluster deployment start in Iteration 1, with `k3d` as the default local Kubernetes target.
+Iteration 0 establishes the repository structure and records the first architectural decisions. Iteration 1 creates the local Kubernetes foundation with SeaweedFS, Polaris, and Trino. Iteration 2 adds the `project-code` image and Dagster deployment with a Kubernetes run launcher.
 
 ## Core Principles
 
@@ -126,7 +126,7 @@ The image will contain Dagster code, the Dagster-Floe connector, Floe contracts,
 ## Roadmap
 
 - Iteration 0: repository skeleton, architecture documentation, and validation automation.
-- Iteration 1: local `k3d` foundation with namespaces, PostgreSQL, SeaweedFS, Polaris, and Trino.
+- Iteration 1: local kind foundation with namespaces, SeaweedFS, Polaris, and Trino.
 - Iteration 2: project-code image and Dagster deployment with Kubernetes run launcher.
 - Iteration 3: Sales POC ingestion and Floe Silver materialization.
 - Iteration 4: dbt-duckdb Gold models and Dagster-dbt integration.
@@ -141,3 +141,17 @@ Run the Iteration 0 repository contract check:
 ```sh
 make check-structure
 ```
+
+Run the Iteration 2 local Dagster flow:
+
+```sh
+make local-cluster
+make project-code-image
+make project-code-load
+make local-up
+make local-dagster-smoke
+```
+
+The local shell must have Docker, kind, kubectl, Terraform, Helm, and Python
+available. The Dagster UI is available at `http://localhost:3000` through
+`make local-forward`.

--- a/docs/adr/0003-local-dagster-project-code-runtime.md
+++ b/docs/adr/0003-local-dagster-project-code-runtime.md
@@ -27,6 +27,8 @@ The local Dagster deployment uses:
 - Dagster webserver, daemon, and one sales code server.
 - `K8sRunLauncher` for isolated run pods.
 - Local image loading into kind for `ghcr.io/openlakeforge/project-code:local`.
+- The project-code image for the Dagster webserver, daemon, code server, and run
+  pods so all Dagster components use the same pinned Python dependency set.
 
 The first domain-owned Dagster code lives under:
 

--- a/docs/adr/0003-local-dagster-project-code-runtime.md
+++ b/docs/adr/0003-local-dagster-project-code-runtime.md
@@ -1,0 +1,50 @@
+# ADR 0003: Local Dagster Project-Code Runtime
+
+## Status
+
+Accepted
+
+## Context
+
+Iteration 2 must prove that OpenLakeForge can run domain-owned Dagster code in
+Kubernetes using the single v1 `project-code` runtime image.
+
+The v1 baseline intentionally avoids separate Floe, dbt, and ingestion runner
+images. The first orchestration milestone should therefore validate the runtime
+image and Kubernetes run launcher boundary before adding Sales ingestion,
+Floe, Iceberg writes, or dbt models.
+
+## Decision
+
+OpenLakeForge deploys Dagster in the local Terraform-managed stack using the
+official Dagster Helm chart.
+
+The local Dagster deployment uses:
+
+- Dagster chart version `1.13.6`.
+- Matching `dagster==1.13.6` in the project-code Python package.
+- Chart-managed PostgreSQL for local Dagster metadata.
+- Dagster webserver, daemon, and one sales code server.
+- `K8sRunLauncher` for isolated run pods.
+- Local image loading into kind for `ghcr.io/openlakeforge/project-code:local`.
+
+The first domain-owned Dagster code lives under:
+
+```text
+domains/sales/orchestration/dagster
+```
+
+It exposes a minimal no-data smoke job named `iteration2_smoke_job`. This job
+exists only to prove that Dagster can load the sales code location and launch an
+isolated Kubernetes run pod from the project-code image.
+
+## Consequences
+
+Iteration 2 validates the execution boundary without starting Sales ingestion or
+Silver/Gold processing.
+
+The local workflow now requires Docker, kind, kubectl, Terraform, Helm, and
+Python in the shell used to run the Make targets.
+
+GHCR publication remains out of scope for Iteration 2. The image name is shaped
+for the final registry contract, but local success uses `kind load docker-image`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,3 +6,6 @@ Start with `0001-v1-platform-baseline.md` for the v1 platform baseline.
 
 `0002-local-object-storage-seaweedfs.md` supersedes the Iteration 1 local object
 storage choice from Garage to SeaweedFS.
+
+`0003-local-dagster-project-code-runtime.md` records the Iteration 2 Dagster and
+project-code runtime boundary.

--- a/docs/architecture/local-stack-contracts.md
+++ b/docs/architecture/local-stack-contracts.md
@@ -51,3 +51,22 @@ http://trino:8080
 The Trino Iceberg catalog uses environment-variable secret substitution for all
 credentials. The mounted catalog file must contain placeholders such as
 `${ENV:AWS_ACCESS_KEY_ID}` rather than literal secret values.
+
+## Orchestration Contract
+
+Dagster exposes the local UI and GraphQL API over HTTP at:
+
+```text
+http://dagster-dagster-webserver:80
+```
+
+The orchestration module owns:
+
+- the Dagster Helm release
+- chart-managed local PostgreSQL for Dagster metadata
+- the Sales code server loading `domains.sales.orchestration.dagster.definitions`
+- the Kubernetes run launcher
+- the local project-code image reference `ghcr.io/openlakeforge/project-code:local`
+
+Local validation loads the image into kind and launches `iteration2_smoke_job`.
+The smoke job must complete in an isolated Kubernetes run pod.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -16,7 +16,10 @@ CSV examples
   -> Dagster asset graph
 ```
 
-The first local infrastructure target is `k3d`. Iteration 1 will use it to stand up the local Kubernetes foundation before introducing Dagster runs and domain pipelines.
+The first local infrastructure target is kind. Iteration 1 stands up the local
+Kubernetes foundation before introducing Dagster runs and domain pipelines.
+Iteration 2 adds the project-code image, Dagster webserver, Dagster daemon,
+sales code server, and Kubernetes run launcher.
 
 ## Core Platform Decisions
 
@@ -74,3 +77,8 @@ Dagster webserver / daemon / code server
 ```
 
 Separate Floe and dbt runner images are not part of the v1 baseline.
+
+Iteration 2 loads `ghcr.io/openlakeforge/project-code:local` into the local kind
+cluster and uses it for both the Sales code server and isolated Dagster run
+pods. The first job is `iteration2_smoke_job` under
+`domains/sales/orchestration/dagster`, and it has no data dependencies.

--- a/domains/__init__.py
+++ b/domains/__init__.py
@@ -1,0 +1,1 @@
+"""OpenLakeForge domain packages."""

--- a/domains/sales/README.md
+++ b/domains/sales/README.md
@@ -17,4 +17,10 @@ domains/sales/
 └── tests/
 ```
 
-Iteration 0 creates the directory contract only. Data, pipelines, contracts, models, and assets start in later iterations.
+Iteration 2 adds a minimal Dagster smoke job under
+`orchestration/dagster/definitions.py`. The job only proves that the Sales code
+location can be loaded from the project-code image and launched as an isolated
+Kubernetes run pod.
+
+Data, ingestion pipelines, Floe contracts, dbt models, and real assets start in
+later iterations.

--- a/domains/sales/__init__.py
+++ b/domains/sales/__init__.py
@@ -1,0 +1,1 @@
+"""Sales proof-of-concept domain."""

--- a/domains/sales/orchestration/__init__.py
+++ b/domains/sales/orchestration/__init__.py
@@ -1,0 +1,1 @@
+"""Sales orchestration package."""

--- a/domains/sales/orchestration/dagster/__init__.py
+++ b/domains/sales/orchestration/dagster/__init__.py
@@ -1,0 +1,5 @@
+"""Sales Dagster definitions for OpenLakeForge."""
+
+from domains.sales.orchestration.dagster.definitions import defs
+
+__all__ = ["defs"]

--- a/domains/sales/orchestration/dagster/definitions.py
+++ b/domains/sales/orchestration/dagster/definitions.py
@@ -1,0 +1,22 @@
+from dagster import Definitions, MetadataValue, job, op
+
+
+@op
+def iteration2_smoke_op(context) -> str:
+    context.log.info("OpenLakeForge Iteration 2 Dagster smoke run executed.")
+    context.add_output_metadata(
+        {
+            "iteration": MetadataValue.int(2),
+            "domain": MetadataValue.text("sales"),
+            "purpose": MetadataValue.text("project-code Kubernetes run launcher smoke test"),
+        }
+    )
+    return "ok"
+
+
+@job
+def iteration2_smoke_job() -> None:
+    iteration2_smoke_op()
+
+
+defs = Definitions(jobs=[iteration2_smoke_job])

--- a/domains/sales/tests/test_iteration2_smoke.py
+++ b/domains/sales/tests/test_iteration2_smoke.py
@@ -1,0 +1,7 @@
+from domains.sales.orchestration.dagster.definitions import iteration2_smoke_job
+
+
+def test_iteration2_smoke_job_executes_in_process() -> None:
+    result = iteration2_smoke_job.execute_in_process()
+
+    assert result.success

--- a/images/project-code/Dockerfile
+++ b/images/project-code/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DAGSTER_HOME=/opt/dagster/dagster_home
+
+WORKDIR /opt/openlakeforge
+
+COPY pyproject.toml ./
+COPY domains ./domains
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+RUN mkdir -p "${DAGSTER_HOME}"
+
+CMD ["dagster", "api", "grpc", "--module-name", "domains.sales.orchestration.dagster.definitions", "--host", "0.0.0.0", "--port", "3030"]

--- a/images/project-code/README.md
+++ b/images/project-code/README.md
@@ -10,4 +10,19 @@ ghcr.io/openlakeforge/project-code:<tag>
 
 It will contain Dagster code, dagster-floe integration, Floe contracts, dagster-dbt integration, the dbt-duckdb project, dlt pipelines, domain Python code, and shared OpenLakeForge libraries.
 
-No Dockerfile or Python package is introduced in Iteration 0.
+Iteration 2 introduces the first runtime image:
+
+```bash
+make project-code-image
+make project-code-load
+```
+
+The local image tag is:
+
+```text
+ghcr.io/openlakeforge/project-code:local
+```
+
+The image currently contains the minimal Sales Dagster smoke job used to prove
+that Dagster can launch an isolated Kubernetes run pod through the
+`K8sRunLauncher`. It does not yet contain dlt, Floe, dbt, or OpenLineage code.

--- a/images/project-code/README.md
+++ b/images/project-code/README.md
@@ -23,6 +23,7 @@ The local image tag is:
 ghcr.io/openlakeforge/project-code:local
 ```
 
-The image currently contains the minimal Sales Dagster smoke job used to prove
-that Dagster can launch an isolated Kubernetes run pod through the
-`K8sRunLauncher`. It does not yet contain dlt, Floe, dbt, or OpenLineage code.
+The image currently contains Dagster webserver/daemon/runtime dependencies and
+the minimal Sales Dagster smoke job used to prove that Dagster can launch an
+isolated Kubernetes run pod through the `K8sRunLauncher`. It does not yet
+contain dlt, Floe, dbt, or OpenLineage code.

--- a/infra/README.md
+++ b/infra/README.md
@@ -2,6 +2,6 @@
 
 Infrastructure definitions live under `terraform/` and `helm/`.
 
-Terraform owns the local lakehouse assembly for SeaweedFS, Polaris, and Trino.
-Local kind cluster configuration lives under `kind/local/`; lifecycle scripts
-live under `../scripts/local/`.
+Terraform owns the local lakehouse assembly for SeaweedFS, Polaris, Trino, and
+Dagster. Local kind cluster configuration lives under `kind/local/`; lifecycle
+scripts live under `../scripts/local/`.

--- a/infra/helm/README.md
+++ b/infra/helm/README.md
@@ -13,7 +13,8 @@ infra/helm/
     └── local/
         ├── seaweedfs.yaml
         ├── polaris.yaml
-        └── trino.yaml
+        ├── trino.yaml
+        └── dagster.yaml
 ```
 
 ## Local charts
@@ -24,12 +25,17 @@ infra/helm/
   Chart source: https://downloads.apache.org/polaris/helm-chart
 - **Trino** (`trino/trino`)
   Chart source: https://trinodb.github.io/charts
+- **Dagster** (`dagster/dagster`)
+  Chart source: https://dagster-io.github.io/helm
 
 ## Workflow
 
 ```bash
 make local-cluster
+make project-code-image
+make project-code-load
 make local-up
+make local-dagster-smoke
 make local-forward
 make local-down
 make local-destroy-cluster

--- a/infra/helm/values/local/dagster.yaml
+++ b/infra/helm/values/local/dagster.yaml
@@ -1,0 +1,33 @@
+# Dagster orchestration layer for the local kind cluster.
+dagsterWebserver:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 80
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+
+dagsterDaemon:
+  enabled: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      memory: 1Gi
+
+postgresql:
+  enabled: true
+  postgresqlUsername: dagster
+  postgresqlPassword: dagster
+  postgresqlDatabase: dagster
+
+computeLogManager:
+  type: NoOpComputeLogManager
+
+telemetry:
+  enabled: false

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -37,11 +37,14 @@ make local-down
 
 - Kubernetes namespace creation
 - SeaweedFS, Polaris, and Trino Helm releases
+- Dagster Helm release
 - dynamic Helm values passed to those releases
 - local generated credentials
 - Kubernetes Secrets used as service contracts
 - SeaweedFS bucket creation jobs
 - Polaris catalog and Trino principal bootstrap jobs
+- chart-managed local Dagster PostgreSQL
+- Dagster webserver, daemon, sales code server, and Kubernetes run launcher
 
 Terraform state is local and contains generated development credentials. Treat
 state files as sensitive; they are gitignored.

--- a/infra/terraform/environments/local/main.tf
+++ b/infra/terraform/environments/local/main.tf
@@ -78,3 +78,17 @@ module "trino" {
     module.polaris,
   ]
 }
+
+module "dagster" {
+  source = "../../modules/orchestration/dagster"
+
+  namespace                      = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  base_values_file               = "${path.root}/../../../helm/values/local/dagster.yaml"
+  project_code_image_repository  = var.project_code_image_repository
+  project_code_image_tag         = var.project_code_image_tag
+  project_code_image_pull_policy = var.project_code_image_pull_policy
+
+  depends_on = [
+    module.trino,
+  ]
+}

--- a/infra/terraform/environments/local/outputs.tf
+++ b/infra/terraform/environments/local/outputs.tf
@@ -7,3 +7,13 @@ output "catalog_contract" {
   description = "Non-secret Polaris REST catalog contract consumed by Trino."
   value       = module.polaris.contract
 }
+
+output "dagster_webserver_service_name" {
+  description = "Dagster webserver service name."
+  value       = module.dagster.webserver_service_name
+}
+
+output "dagster_code_location_name" {
+  description = "Dagster code location name."
+  value       = module.dagster.code_location_name
+}

--- a/infra/terraform/environments/local/variables.tf
+++ b/infra/terraform/environments/local/variables.tf
@@ -33,3 +33,21 @@ variable "s3_region" {
   type        = string
   default     = "us-east-1"
 }
+
+variable "project_code_image_repository" {
+  description = "Project-code image repository used by the Dagster code server and run pods."
+  type        = string
+  default     = "ghcr.io/openlakeforge/project-code"
+}
+
+variable "project_code_image_tag" {
+  description = "Project-code image tag used by the Dagster code server and run pods."
+  type        = string
+  default     = "local"
+}
+
+variable "project_code_image_pull_policy" {
+  description = "Project-code image pull policy used by the Dagster code server and run pods."
+  type        = string
+  default     = "IfNotPresent"
+}

--- a/infra/terraform/modules/orchestration/dagster/main.tf
+++ b/infra/terraform/modules/orchestration/dagster/main.tf
@@ -1,0 +1,60 @@
+resource "helm_release" "dagster" {
+  name       = var.release_name
+  repository = var.chart_repository
+  chart      = "dagster"
+  version    = var.chart_version
+  namespace  = var.namespace
+
+  wait    = true
+  timeout = 300
+
+  values = [
+    file(var.base_values_file),
+    yamlencode({
+      "dagster-user-deployments" = {
+        enabled        = true
+        enableSubchart = true
+        deployments = [
+          {
+            name = var.code_location_name
+            image = {
+              repository = var.project_code_image_repository
+              tag        = var.project_code_image_tag
+              pullPolicy = var.project_code_image_pull_policy
+            }
+            dagsterApiGrpcArgs = [
+              "--module-name",
+              var.definitions_module,
+            ]
+            port = 3030
+            includeConfigInLaunchedRuns = {
+              enabled = true
+            }
+          },
+        ]
+      }
+
+      runLauncher = {
+        type = "K8sRunLauncher"
+        config = {
+          k8sRunLauncher = {
+            imagePullPolicy = var.project_code_image_pull_policy
+            image = {
+              repository = var.project_code_image_repository
+              tag        = var.project_code_image_tag
+              pullPolicy = var.project_code_image_pull_policy
+            }
+            jobNamespace        = var.namespace
+            loadInclusterConfig = true
+            failPodOnRunFailure = true
+            runK8sConfig = {
+              jobSpecConfig = {
+                ttlSecondsAfterFinished = 3600
+              }
+            }
+          }
+        }
+      }
+    }),
+  ]
+}

--- a/infra/terraform/modules/orchestration/dagster/main.tf
+++ b/infra/terraform/modules/orchestration/dagster/main.tf
@@ -34,6 +34,22 @@ resource "helm_release" "dagster" {
         ]
       }
 
+      dagsterWebserver = {
+        image = {
+          repository = var.project_code_image_repository
+          tag        = var.project_code_image_tag
+          pullPolicy = var.project_code_image_pull_policy
+        }
+      }
+
+      dagsterDaemon = {
+        image = {
+          repository = var.project_code_image_repository
+          tag        = var.project_code_image_tag
+          pullPolicy = var.project_code_image_pull_policy
+        }
+      }
+
       runLauncher = {
         type = "K8sRunLauncher"
         config = {

--- a/infra/terraform/modules/orchestration/dagster/outputs.tf
+++ b/infra/terraform/modules/orchestration/dagster/outputs.tf
@@ -1,0 +1,14 @@
+output "webserver_service_name" {
+  description = "Dagster webserver service name."
+  value       = "${var.release_name}-dagster-webserver"
+}
+
+output "webserver_port" {
+  description = "Dagster webserver service port."
+  value       = 80
+}
+
+output "code_location_name" {
+  description = "Dagster code location name."
+  value       = var.code_location_name
+}

--- a/infra/terraform/modules/orchestration/dagster/variables.tf
+++ b/infra/terraform/modules/orchestration/dagster/variables.tf
@@ -1,0 +1,57 @@
+variable "namespace" {
+  description = "Kubernetes namespace where Dagster is deployed."
+  type        = string
+}
+
+variable "release_name" {
+  description = "Helm release name."
+  type        = string
+  default     = "dagster"
+}
+
+variable "chart_repository" {
+  description = "Dagster Helm chart repository."
+  type        = string
+  default     = "https://dagster-io.github.io/helm"
+}
+
+variable "chart_version" {
+  description = "Dagster Helm chart version. Keep this aligned with the project-code Dagster Python package."
+  type        = string
+  default     = "1.13.6"
+}
+
+variable "base_values_file" {
+  description = "Path to the non-secret base Helm values file."
+  type        = string
+}
+
+variable "project_code_image_repository" {
+  description = "Project-code image repository used by the Dagster code server and run pods."
+  type        = string
+  default     = "ghcr.io/openlakeforge/project-code"
+}
+
+variable "project_code_image_tag" {
+  description = "Project-code image tag used by the Dagster code server and run pods."
+  type        = string
+  default     = "local"
+}
+
+variable "project_code_image_pull_policy" {
+  description = "Project-code image pull policy used by the Dagster code server and run pods."
+  type        = string
+  default     = "IfNotPresent"
+}
+
+variable "code_location_name" {
+  description = "Dagster user-code deployment and code location name."
+  type        = string
+  default     = "sales-dagster"
+}
+
+variable "definitions_module" {
+  description = "Python module exposing Dagster Definitions."
+  type        = string
+  default     = "domains.sales.orchestration.dagster.definitions"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openlakeforge-project"
+version = "0.1.0"
+description = "OpenLakeForge v1 project-code runtime package."
+requires-python = ">=3.12,<3.13"
+dependencies = [
+  "dagster==1.13.6",
+]
+
+[tool.setuptools.packages.find]
+include = ["domains*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ description = "OpenLakeForge v1 project-code runtime package."
 requires-python = ">=3.12,<3.13"
 dependencies = [
   "dagster==1.13.6",
+  "dagster-k8s==0.29.6",
+  "dagster-postgres==0.29.6",
+  "dagster-webserver==1.13.6",
+  "kubernetes<36",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,12 @@ Local developer and repository validation scripts live here.
 
 Iteration 0 includes `check-structure.sh`, which validates the repository skeleton and documentation contract. Infrastructure checks live in `check-infra.sh`; it runs Terraform formatting/validation and renders the upstream Helm charts with local values.
 
+Iteration 2 adds `check-project-code.sh`, which installs the project-code package
+into an isolated target directory and executes the Sales Dagster smoke job
+in-process.
+
 Local stack scripts under `scripts/local/` are thin wrappers around Terraform for
 the lakehouse deployment and around kind for cluster creation/destruction. The
-local kind cluster config lives under `infra/kind/local/`.
+local kind cluster config lives under `infra/kind/local/`. The project-code
+image helper scripts build the local image, load it into kind, and launch the
+Dagster smoke run.

--- a/scripts/check-infra.sh
+++ b/scripts/check-infra.sh
@@ -27,6 +27,7 @@ echo "==> Helm repo setup"
 helm repo add seaweedfs https://seaweedfs.github.io/seaweedfs/helm --force-update >/dev/null
 helm repo add polaris https://downloads.apache.org/polaris/helm-chart --force-update >/dev/null
 helm repo add trino https://trinodb.github.io/charts --force-update >/dev/null
+helm repo add dagster https://dagster-io.github.io/helm --force-update >/dev/null
 helm repo update >/dev/null
 
 echo "==> Helm template: SeaweedFS"
@@ -46,5 +47,11 @@ helm template trino trino/trino \
   --version 1.42.2 \
   --namespace lakehouse \
   --values infra/helm/values/local/trino.yaml >/dev/null
+
+echo "==> Helm template: Dagster"
+helm template dagster dagster/dagster \
+  --version 1.13.6 \
+  --namespace lakehouse \
+  --values infra/helm/values/local/dagster.yaml >/dev/null
 
 echo "Infrastructure checks passed."

--- a/scripts/check-project-code.sh
+++ b/scripts/check-project-code.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "${cmd}" &>/dev/null; then
+    printf "ERROR: '%s' not found on PATH\n" "${cmd}" >&2
+    exit 1
+  fi
+}
+
+require_cmd python3
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+echo "==> Installing project-code package into an isolated target"
+python3 -m pip install --disable-pip-version-check --target "${tmp_dir}" .
+
+echo "==> Executing Iteration 2 Dagster smoke job in-process"
+PYTHONPATH="${tmp_dir}:${PWD}" python3 - <<'PY'
+from domains.sales.orchestration.dagster.definitions import iteration2_smoke_job
+
+result = iteration2_smoke_job.execute_in_process()
+if not result.success:
+    raise SystemExit("iteration2_smoke_job failed")
+
+print("Project-code smoke job passed.")
+PY

--- a/scripts/check-structure.sh
+++ b/scripts/check-structure.sh
@@ -10,23 +10,38 @@ required_paths=(
   "docs/architecture/overview.md"
   "docs/adr/README.md"
   "docs/adr/0001-v1-platform-baseline.md"
+  "docs/adr/0002-local-object-storage-seaweedfs.md"
+  "docs/adr/0003-local-dagster-project-code-runtime.md"
   "infra/README.md"
   "infra/terraform/README.md"
   "infra/helm/README.md"
+  "infra/helm/values/local/dagster.yaml"
   "images/README.md"
   "images/project-code/README.md"
+  "images/project-code/Dockerfile"
   "libs/README.md"
   "domains/README.md"
+  "domains/__init__.py"
   "domains/sales/README.md"
+  "domains/sales/__init__.py"
   "domains/sales/domain.yaml"
   "domains/sales/examples/raw/.gitkeep"
   "domains/sales/ingestion/dlt/.gitkeep"
   "domains/sales/contracts/floe/.gitkeep"
   "domains/sales/transformations/dbt/.gitkeep"
+  "domains/sales/orchestration/__init__.py"
   "domains/sales/orchestration/dagster/.gitkeep"
+  "domains/sales/orchestration/dagster/__init__.py"
+  "domains/sales/orchestration/dagster/definitions.py"
   "domains/sales/tests/.gitkeep"
+  "domains/sales/tests/test_iteration2_smoke.py"
   "scripts/README.md"
   "scripts/check-structure.sh"
+  "scripts/check-infra.sh"
+  "scripts/check-project-code.sh"
+  "scripts/local/build-project-code-image.sh"
+  "scripts/local/load-project-code-image.sh"
+  "scripts/local/dagster-smoke.sh"
 )
 
 missing=0
@@ -42,4 +57,4 @@ if [[ "${missing}" -ne 0 ]]; then
   exit 1
 fi
 
-printf 'Iteration 0 repository structure is valid.\n'
+printf 'Repository structure is valid.\n'

--- a/scripts/local/build-project-code-image.sh
+++ b/scripts/local/build-project-code-image.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Build the local OpenLakeForge project-code image.
+set -euo pipefail
+
+IMAGE_REPOSITORY="${PROJECT_CODE_IMAGE_REPOSITORY:-ghcr.io/openlakeforge/project-code}"
+IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG:-local}"
+IMAGE="${PROJECT_CODE_IMAGE:-${IMAGE_REPOSITORY}:${IMAGE_TAG}}"
+
+if ! command -v docker &>/dev/null; then
+  echo "ERROR: 'docker' not found on PATH" >&2
+  exit 1
+fi
+
+echo "==> Building project-code image: ${IMAGE}"
+docker build \
+  --file images/project-code/Dockerfile \
+  --tag "${IMAGE}" \
+  .
+
+echo "Built ${IMAGE}"

--- a/scripts/local/dagster-smoke.sh
+++ b/scripts/local/dagster-smoke.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Launch the Iteration 2 Dagster smoke job and verify the Kubernetes run pod.
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-lakehouse}"
+JOB_NAME="${DAGSTER_SMOKE_JOB:-iteration2_smoke_job}"
+LOCAL_PORT="${DAGSTER_LOCAL_PORT:-3000}"
+
+for cmd in kubectl python3; do
+  if ! command -v "${cmd}" &>/dev/null; then
+    echo "ERROR: '${cmd}' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+echo "==> Waiting for Dagster webserver pod..."
+webserver_pod=""
+for _ in $(seq 1 60); do
+  webserver_pod="$(kubectl get pods -n "${NAMESPACE}" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | grep 'dagster-webserver' | head -n 1 || true)"
+  if [[ -n "${webserver_pod}" ]]; then
+    break
+  fi
+  sleep 5
+done
+
+if [[ -z "${webserver_pod}" ]]; then
+  echo "ERROR: Dagster webserver pod not found in namespace '${NAMESPACE}'." >&2
+  exit 1
+fi
+
+kubectl wait --for=condition=Ready "pod/${webserver_pod}" -n "${NAMESPACE}" --timeout=180s
+
+echo "==> Port-forwarding Dagster webserver on http://localhost:${LOCAL_PORT}"
+kubectl port-forward "pod/${webserver_pod}" "${LOCAL_PORT}:80" -n "${NAMESPACE}" >/tmp/openlakeforge-dagster-port-forward.log 2>&1 &
+port_forward_pid=$!
+trap 'kill "${port_forward_pid}" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 30); do
+  if python3 - <<PY >/dev/null 2>&1
+import urllib.request
+urllib.request.urlopen("http://127.0.0.1:${LOCAL_PORT}/server_info", timeout=2).read()
+PY
+  then
+    break
+  fi
+  sleep 2
+done
+
+echo "==> Launching Dagster job '${JOB_NAME}'"
+run_id="$(DAGSTER_URL="http://127.0.0.1:${LOCAL_PORT}/graphql" DAGSTER_JOB_NAME="${JOB_NAME}" python3 - <<'PY'
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+url = os.environ["DAGSTER_URL"]
+job_name = os.environ["DAGSTER_JOB_NAME"]
+
+
+def graphql(query, variables=None):
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=15) as response:
+        data = json.loads(response.read().decode())
+    if data.get("errors"):
+        raise RuntimeError(data["errors"])
+    return data["data"]
+
+
+repositories_query = """
+query Repositories {
+  repositoriesOrError {
+    __typename
+    ... on RepositoryConnection {
+      nodes {
+        name
+        location { name }
+        pipelines { name }
+      }
+    }
+    ... on PythonError {
+      message
+      stack
+    }
+  }
+}
+"""
+
+launch_mutation = """
+mutation LaunchRun($repositoryLocationName: String!, $repositoryName: String!, $jobName: String!) {
+  launchRun(executionParams: {
+    selector: {
+      repositoryLocationName: $repositoryLocationName
+      repositoryName: $repositoryName
+      jobName: $jobName
+    }
+    runConfigData: {}
+  }) {
+    __typename
+    ... on LaunchRunSuccess {
+      run { runId status }
+    }
+    ... on RunConfigValidationInvalid {
+      errors { message }
+    }
+    ... on PythonError {
+      message
+      stack
+    }
+  }
+}
+"""
+
+run_query = """
+query RunStatus($runId: ID!) {
+  runOrError(runId: $runId) {
+    __typename
+    ... on Run {
+      runId
+      status
+    }
+    ... on PythonError {
+      message
+      stack
+    }
+  }
+}
+"""
+
+repo_nodes = None
+for _ in range(60):
+    result = graphql(repositories_query)["repositoriesOrError"]
+    if result["__typename"] == "RepositoryConnection":
+        repo_nodes = result["nodes"]
+        break
+    time.sleep(5)
+
+if repo_nodes is None:
+    raise SystemExit("Dagster repositories did not load")
+
+selector = None
+for repo in repo_nodes:
+    for pipeline in repo.get("pipelines", []):
+        if pipeline["name"] == job_name:
+            selector = {
+                "repositoryLocationName": repo["location"]["name"],
+                "repositoryName": repo["name"],
+                "jobName": job_name,
+            }
+            break
+    if selector:
+        break
+
+if selector is None:
+    available = {
+        repo["location"]["name"]: [pipeline["name"] for pipeline in repo.get("pipelines", [])]
+        for repo in repo_nodes
+    }
+    raise SystemExit(f"Job {job_name!r} not found. Available jobs: {available}")
+
+launch = graphql(launch_mutation, selector)["launchRun"]
+if launch["__typename"] != "LaunchRunSuccess":
+    raise SystemExit(f"Dagster launch failed: {launch}")
+
+run_id = launch["run"]["runId"]
+
+for _ in range(120):
+    run = graphql(run_query, {"runId": run_id})["runOrError"]
+    if run["__typename"] != "Run":
+        raise SystemExit(f"Could not query run {run_id}: {run}")
+    status = run["status"]
+    if status == "SUCCESS":
+        print(run_id)
+        sys.exit(0)
+    if status in {"FAILURE", "CANCELED"}:
+        raise SystemExit(f"Run {run_id} ended with status {status}")
+    time.sleep(5)
+
+raise SystemExit(f"Run {run_id} did not complete before timeout")
+PY
+)"
+
+echo "Dagster run succeeded: ${run_id}"
+
+echo "==> Verifying Kubernetes run pod/job for run id"
+if kubectl get pods,jobs -n "${NAMESPACE}" -o json | python3 -c "import json,sys; data=json.load(sys.stdin); rid='${run_id}'; matches=[item['kind']+'/'+item['metadata']['name'] for item in data.get('items', []) if rid in json.dumps(item.get('metadata', {}))]; print('\n'.join(matches)); sys.exit(0 if matches else 1)"; then
+  echo "Kubernetes run pod/job found for ${run_id}"
+else
+  echo "ERROR: No Kubernetes pod/job metadata matched Dagster run id ${run_id}." >&2
+  exit 1
+fi

--- a/scripts/local/load-project-code-image.sh
+++ b/scripts/local/load-project-code-image.sh
@@ -7,20 +7,42 @@ IMAGE_REPOSITORY="${PROJECT_CODE_IMAGE_REPOSITORY:-ghcr.io/openlakeforge/project
 IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG:-local}"
 IMAGE="${PROJECT_CODE_IMAGE:-${IMAGE_REPOSITORY}:${IMAGE_TAG}}"
 
-for cmd in kind docker; do
+for cmd in docker; do
   if ! command -v "${cmd}" &>/dev/null; then
     echo "ERROR: '${cmd}' not found on PATH" >&2
     exit 1
   fi
 done
 
-if ! kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
-  echo "ERROR: kind cluster '${CLUSTER_NAME}' does not exist." >&2
-  echo "Run 'make local-cluster' first." >&2
+if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+  echo "ERROR: local image '${IMAGE}' does not exist." >&2
+  echo "Run 'make project-code-image' first." >&2
   exit 1
 fi
 
-echo "==> Loading ${IMAGE} into kind cluster '${CLUSTER_NAME}'"
-kind load docker-image "${IMAGE}" --name "${CLUSTER_NAME}"
+if command -v kind &>/dev/null; then
+  if ! kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+    echo "ERROR: kind cluster '${CLUSTER_NAME}' does not exist." >&2
+    echo "Run 'make local-cluster' first." >&2
+    exit 1
+  fi
+
+  echo "==> Loading ${IMAGE} into kind cluster '${CLUSTER_NAME}'"
+  kind load docker-image "${IMAGE}" --name "${CLUSTER_NAME}"
+else
+  node_prefix="${CLUSTER_NAME}-"
+  mapfile -t nodes < <(docker ps --format '{{.Names}}' | grep -E "^${node_prefix}(control-plane|worker)" || true)
+
+  if [[ "${#nodes[@]}" -eq 0 ]]; then
+    echo "ERROR: kind is not installed and no Docker node containers were found for '${CLUSTER_NAME}'." >&2
+    echo "Install kind or run 'make local-cluster' first." >&2
+    exit 1
+  fi
+
+  for node in "${nodes[@]}"; do
+    echo "==> Importing ${IMAGE} into kind node '${node}'"
+    docker save "${IMAGE}" | docker exec -i "${node}" ctr -n k8s.io images import -
+  done
+fi
 
 echo "Loaded ${IMAGE}"

--- a/scripts/local/load-project-code-image.sh
+++ b/scripts/local/load-project-code-image.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Load the local project-code image into the kind cluster.
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-openlakeforge-local}"
+IMAGE_REPOSITORY="${PROJECT_CODE_IMAGE_REPOSITORY:-ghcr.io/openlakeforge/project-code}"
+IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG:-local}"
+IMAGE="${PROJECT_CODE_IMAGE:-${IMAGE_REPOSITORY}:${IMAGE_TAG}}"
+
+for cmd in kind docker; do
+  if ! command -v "${cmd}" &>/dev/null; then
+    echo "ERROR: '${cmd}' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+if ! kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"; then
+  echo "ERROR: kind cluster '${CLUSTER_NAME}' does not exist." >&2
+  echo "Run 'make local-cluster' first." >&2
+  exit 1
+fi
+
+echo "==> Loading ${IMAGE} into kind cluster '${CLUSTER_NAME}'"
+kind load docker-image "${IMAGE}" --name "${CLUSTER_NAME}"
+
+echo "Loaded ${IMAGE}"

--- a/scripts/local/setup.sh
+++ b/scripts/local/setup.sh
@@ -10,6 +10,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TERRAFORM_DIR="${REPO_ROOT}/infra/terraform/environments/local"
 NAMESPACE="${NAMESPACE:-lakehouse}"
+PROJECT_CODE_IMAGE_REPOSITORY="${PROJECT_CODE_IMAGE_REPOSITORY:-ghcr.io/openlakeforge/project-code}"
+PROJECT_CODE_IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG:-local}"
+PROJECT_CODE_IMAGE_PULL_POLICY="${PROJECT_CODE_IMAGE_PULL_POLICY:-IfNotPresent}"
 
 check_prereqs() {
   local missing=0
@@ -29,7 +32,10 @@ echo "==> Applying Terraform local stack..."
 terraform -chdir="${TERRAFORM_DIR}" init
 terraform -chdir="${TERRAFORM_DIR}" apply \
   -auto-approve \
-  -var="namespace=${NAMESPACE}"
+  -var="namespace=${NAMESPACE}" \
+  -var="project_code_image_repository=${PROJECT_CODE_IMAGE_REPOSITORY}" \
+  -var="project_code_image_tag=${PROJECT_CODE_IMAGE_TAG}" \
+  -var="project_code_image_pull_policy=${PROJECT_CODE_IMAGE_PULL_POLICY}"
 
 echo ""
 echo "OpenLakeForge local stack is up."
@@ -38,7 +44,9 @@ echo "Port-forward commands:"
 echo "  kubectl port-forward svc/seaweedfs-s3 9000:8333 -n ${NAMESPACE}"
 echo "  kubectl port-forward svc/polaris 8181:8181 -n ${NAMESPACE}"
 echo "  kubectl port-forward svc/trino 8080:8080 -n ${NAMESPACE}"
+echo "  kubectl port-forward <dagster-webserver-pod> 3000:80 -n ${NAMESPACE}"
 echo ""
 echo "Trino UI:     http://localhost:8080"
 echo "Polaris API:  http://localhost:8181/api/catalog"
 echo "SeaweedFS S3: http://localhost:9000"
+echo "Dagster UI:   http://localhost:3000"

--- a/scripts/local/setup.sh
+++ b/scripts/local/setup.sh
@@ -25,8 +25,35 @@ check_prereqs() {
   [[ $missing -eq 0 ]] || exit 1
 }
 
+prepare_local_project_code_image() {
+  if [[ "${PROJECT_CODE_IMAGE_TAG}" != "local" ]]; then
+    return 0
+  fi
+
+  local image="${PROJECT_CODE_IMAGE_REPOSITORY}:${PROJECT_CODE_IMAGE_TAG}"
+
+  if ! command -v docker &>/dev/null; then
+    echo "ERROR: Docker is required when PROJECT_CODE_IMAGE_TAG=local." >&2
+    echo "Run 'make project-code-image' and 'make project-code-load' from a shell with Docker access." >&2
+    exit 1
+  fi
+
+  if ! docker image inspect "${image}" >/dev/null 2>&1; then
+    echo "ERROR: local project-code image '${image}' does not exist." >&2
+    echo "Run 'make project-code-image' before 'make local-up'." >&2
+    exit 1
+  fi
+
+  echo "==> Ensuring local project-code image is available to kind..."
+  PROJECT_CODE_IMAGE_REPOSITORY="${PROJECT_CODE_IMAGE_REPOSITORY}" \
+    PROJECT_CODE_IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG}" \
+    bash "${SCRIPT_DIR}/load-project-code-image.sh"
+}
+
 echo "==> Checking prerequisites..."
 check_prereqs
+
+prepare_local_project_code_image
 
 echo "==> Applying Terraform local stack..."
 terraform -chdir="${TERRAFORM_DIR}" init


### PR DESCRIPTION
## Summary
- Add the project-code Dagster runtime image and Sales smoke job.
- Deploy Dagster via Terraform/Helm with Kubernetes run launcher.
- Add local image loading, smoke-test workflow, and Iteration 2 docs/ADR updates.

## Validation
- `make local-up` completed successfully.
- `make local-dagster-smoke` passed and launched a Kubernetes run pod.
- `terraform fmt -check -recursive infra/terraform`
- `terraform -chdir=infra/terraform/environments/local validate`
- `bash scripts/check-project-code.sh`