### PR TITLE
fix(floe): Repair local Floe ingestion runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,11 @@ Install these tools on the host:
 | uv | Runs the `tools/olf` deployment tooling (contracts, artifacts, REST calls). Install from https://docs.astral.sh/uv/. |
 | Make | Provides the local workflow entrypoints. |
 
-The `floe` CLI is optional locally because manifest generation falls back to the
-Floe runner image. The helper scripts create local caches under `.tmp/` as
-needed, including a small Python virtual environment for OpenMetadata metadata
+The `floe` CLI is optional locally because OpenLakeForge can generate manifests
+through a Dockerized Floe CLI. Runtime execution does not depend on a host
+installation: Dagster launches the manifest-declared Floe runner image in
+Kubernetes. The helper scripts create local caches under `.tmp/` as needed,
+including a small Python virtual environment for OpenMetadata metadata
 deployment if the active host Python does not already include `PyYAML`.
 
 For a new macOS/Colima setup, a typical tool bootstrap is:

--- a/docs/adr/0004-manifest-first-floe-sales-ingestion.md
+++ b/docs/adr/0004-manifest-first-floe-sales-ingestion.md
@@ -31,7 +31,7 @@ Kubernetes Floe execution uses explicit remote manifest access:
 `OPENLAKEFORGE_FLOE_MANIFEST_ACCESS_MODE=remote`. Local/CD artifact upload
 publishes the same generated product manifests to the SeaweedFS ops bucket, and
 Dagster passes those `s3://...` manifest URIs to the separate
-`ghcr.io/malon64/floe:0.6.7` runner pods. `local` manifest access is reserved
+`ghcr.io/malon64/floe:0.6.8` runner pods. `local` manifest access is reserved
 for same-container local-process execution because the separate runner image
 cannot read the project-code image filesystem.
 

--- a/docs/adr/0004-manifest-first-floe-sales-ingestion.md
+++ b/docs/adr/0004-manifest-first-floe-sales-ingestion.md
@@ -31,7 +31,7 @@ Kubernetes Floe execution uses explicit remote manifest access:
 `OPENLAKEFORGE_FLOE_MANIFEST_ACCESS_MODE=remote`. Local/CD artifact upload
 publishes the same generated product manifests to the SeaweedFS ops bucket, and
 Dagster passes those `s3://...` manifest URIs to the separate
-`ghcr.io/malon64/floe:0.6.3` runner pods. `local` manifest access is reserved
+`ghcr.io/malon64/floe:0.6.7` runner pods. `local` manifest access is reserved
 for same-container local-process execution because the separate runner image
 cannot read the project-code image filesystem.
 

--- a/domains/sales/contracts/floe/manifests/customer_health.manifest.json
+++ b/domains/sales/contracts/floe/manifests/customer_health.manifest.json
@@ -1,15 +1,17 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.3",
+  "floe_version": "0.6.7",
   "spec_version": "0.2",
   "manifest_name": "sales.customer_health.local",
   "manifest_id": "mfv1-037fc1c3058e852a",
-  "manifest_revision": "sha256:1b6b2fc551c87087ea51f7baee8aaf1cfbe427f12800bff11c8a0b854898141c",
+  "manifest_revision": "sha256:6c0e9bd0444b4e205e2f2bbba5888b9d3ec92670cd6850b37da27e8f92d1dbb0",
+  "runtime_env": "image",
+  "work_root": "/work",
   "config_uri": "local:///work/domains/sales/contracts/floe/customer_health.yml",
   "config_checksum": "sha256:15589410574a14d739d47f07109b55e27787ab711f82d1bb04cf82d5a911f187",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:2da09d6d0371661747745ae89b2d95af18e5ec8a7179950a5e479d55cd4f6149",
+  "profile_checksum": "sha256:3b60ae92c8cd2b56ef059822bf691a39d529dde3f14e72c484b66f55c727ca91",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/sales/customer_health",
   "domains": [],
   "execution": {
@@ -76,7 +78,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.3",
+        "image": "ghcr.io/malon64/floe:0.6.7",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,
@@ -85,7 +87,7 @@
           "AWS_DEFAULT_REGION": "us-east-1",
           "AWS_EC2_METADATA_DISABLED": "true",
           "AWS_ENDPOINT_URL": "http://seaweedfs-s3:8333",
-          "AWS_ENDPOINT_URL_S3": "http://lakehouse.svc.cluster.local:8333",
+          "AWS_ENDPOINT_URL_S3": "http://seaweedfs-s3:8333",
           "AWS_REGION": "us-east-1",
           "AWS_S3_FORCE_PATH_STYLE": "true"
         },

--- a/domains/sales/contracts/floe/manifests/customer_health.manifest.json
+++ b/domains/sales/contracts/floe/manifests/customer_health.manifest.json
@@ -1,15 +1,15 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.6",
+  "floe_version": "0.6.3",
   "spec_version": "0.2",
   "manifest_name": "sales.customer_health.local",
   "manifest_id": "mfv1-037fc1c3058e852a",
-  "manifest_revision": "sha256:49a8f92b2d9399efc3d2ef47f8a76ccb1e2c41e4ba4be1113d8ff18acb1977b6",
+  "manifest_revision": "sha256:1b6b2fc551c87087ea51f7baee8aaf1cfbe427f12800bff11c8a0b854898141c",
   "config_uri": "local:///work/domains/sales/contracts/floe/customer_health.yml",
   "config_checksum": "sha256:15589410574a14d739d47f07109b55e27787ab711f82d1bb04cf82d5a911f187",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:58573fe005026cbdf3d95a2e61fa74b843d23d62e8376b7d18f81a4c8e2e2e2c",
+  "profile_checksum": "sha256:2da09d6d0371661747745ae89b2d95af18e5ec8a7179950a5e479d55cd4f6149",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/sales/customer_health",
   "domains": [],
   "execution": {
@@ -76,7 +76,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.6",
+        "image": "ghcr.io/malon64/floe:0.6.3",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,

--- a/domains/sales/contracts/floe/manifests/customer_health.manifest.json
+++ b/domains/sales/contracts/floe/manifests/customer_health.manifest.json
@@ -1,17 +1,17 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.7",
+  "floe_version": "0.6.8",
   "spec_version": "0.2",
   "manifest_name": "sales.customer_health.local",
   "manifest_id": "mfv1-037fc1c3058e852a",
-  "manifest_revision": "sha256:6c0e9bd0444b4e205e2f2bbba5888b9d3ec92670cd6850b37da27e8f92d1dbb0",
+  "manifest_revision": "sha256:cf1d57866521b4701af46ea1d5bc02e2ee863552f1cca29aab3a68d214472d66",
   "runtime_env": "image",
   "work_root": "/work",
   "config_uri": "local:///work/domains/sales/contracts/floe/customer_health.yml",
   "config_checksum": "sha256:15589410574a14d739d47f07109b55e27787ab711f82d1bb04cf82d5a911f187",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:3b60ae92c8cd2b56ef059822bf691a39d529dde3f14e72c484b66f55c727ca91",
+  "profile_checksum": "sha256:d46aa2bbd1e660aed1da7b62b3c74037cda7e7e602f717bf3ae6c6424d60530e",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/sales/customer_health",
   "domains": [],
   "execution": {
@@ -78,7 +78,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.7",
+        "image": "ghcr.io/malon64/floe:0.6.8",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,
@@ -118,7 +118,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/customer_health/accounts",
-        "path": "s3://lakehouse-bronze/sales/customer_health/accounts",
+        "path": "sales/customer_health/accounts",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -144,7 +144,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/customer_health/accounts",
-          "path": "s3://lakehouse-silver/sales/customer_health/accounts",
+          "path": "sales/customer_health/accounts",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -157,7 +157,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/customer_health/accounts",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/customer_health/accounts",
+          "path": "floe/rejected/sales/customer_health/accounts",
           "resolved": true
         },
         "archive": null
@@ -225,7 +225,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/customer_health/nps_responses",
-        "path": "s3://lakehouse-bronze/sales/customer_health/nps_responses",
+        "path": "sales/customer_health/nps_responses",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -251,7 +251,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/customer_health/nps_responses",
-          "path": "s3://lakehouse-silver/sales/customer_health/nps_responses",
+          "path": "sales/customer_health/nps_responses",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -264,7 +264,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/customer_health/nps_responses",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/customer_health/nps_responses",
+          "path": "floe/rejected/sales/customer_health/nps_responses",
           "resolved": true
         },
         "archive": null
@@ -322,7 +322,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/customer_health/subscriptions",
-        "path": "s3://lakehouse-bronze/sales/customer_health/subscriptions",
+        "path": "sales/customer_health/subscriptions",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -348,7 +348,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/customer_health/subscriptions",
-          "path": "s3://lakehouse-silver/sales/customer_health/subscriptions",
+          "path": "sales/customer_health/subscriptions",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -361,7 +361,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/customer_health/subscriptions",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/customer_health/subscriptions",
+          "path": "floe/rejected/sales/customer_health/subscriptions",
           "resolved": true
         },
         "archive": null
@@ -434,7 +434,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/customer_health/support_tickets",
-        "path": "s3://lakehouse-bronze/sales/customer_health/support_tickets",
+        "path": "sales/customer_health/support_tickets",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -460,7 +460,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/customer_health/support_tickets",
-          "path": "s3://lakehouse-silver/sales/customer_health/support_tickets",
+          "path": "sales/customer_health/support_tickets",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -473,7 +473,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/customer_health/support_tickets",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/customer_health/support_tickets",
+          "path": "floe/rejected/sales/customer_health/support_tickets",
           "resolved": true
         },
         "archive": null

--- a/domains/sales/contracts/floe/manifests/order_revenue.manifest.json
+++ b/domains/sales/contracts/floe/manifests/order_revenue.manifest.json
@@ -1,17 +1,17 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.7",
+  "floe_version": "0.6.8",
   "spec_version": "0.2",
   "manifest_name": "sales.order_revenue.local",
   "manifest_id": "mfv1-1faf0a276d5999f5",
-  "manifest_revision": "sha256:0ea6e9a1d24fe8b1575bc9d3a5f0d27772e35e2638b3693db00d289843d17a31",
+  "manifest_revision": "sha256:5fc5f3d1baecfe4514394897e2ec7f99d5ab42b7988f09e634314dda13e034a3",
   "runtime_env": "image",
   "work_root": "/work",
   "config_uri": "local:///work/domains/sales/contracts/floe/order_revenue.yml",
   "config_checksum": "sha256:4ec74b837e4ba6204ba34e5f5031b655d679984e76c4824f345c41d69e2b09de",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:3b60ae92c8cd2b56ef059822bf691a39d529dde3f14e72c484b66f55c727ca91",
+  "profile_checksum": "sha256:d46aa2bbd1e660aed1da7b62b3c74037cda7e7e602f717bf3ae6c6424d60530e",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/sales/order_revenue",
   "domains": [],
   "execution": {
@@ -78,7 +78,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.7",
+        "image": "ghcr.io/malon64/floe:0.6.8",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,
@@ -118,7 +118,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/order_revenue/channels",
-        "path": "s3://lakehouse-bronze/sales/order_revenue/channels",
+        "path": "sales/order_revenue/channels",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -144,7 +144,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/order_revenue/channels",
-          "path": "s3://lakehouse-silver/sales/order_revenue/channels",
+          "path": "sales/order_revenue/channels",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -157,7 +157,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/channels",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/channels",
+          "path": "floe/rejected/sales/order_revenue/channels",
           "resolved": true
         },
         "archive": null
@@ -210,7 +210,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/order_revenue/order_lines",
-        "path": "s3://lakehouse-bronze/sales/order_revenue/order_lines",
+        "path": "sales/order_revenue/order_lines",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -236,7 +236,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/order_revenue/order_lines",
-          "path": "s3://lakehouse-silver/sales/order_revenue/order_lines",
+          "path": "sales/order_revenue/order_lines",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -249,7 +249,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/order_lines",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/order_lines",
+          "path": "floe/rejected/sales/order_revenue/order_lines",
           "resolved": true
         },
         "archive": null
@@ -317,7 +317,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/order_revenue/orders",
-        "path": "s3://lakehouse-bronze/sales/order_revenue/orders",
+        "path": "sales/order_revenue/orders",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -343,7 +343,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/order_revenue/orders",
-          "path": "s3://lakehouse-silver/sales/order_revenue/orders",
+          "path": "sales/order_revenue/orders",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -356,7 +356,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/orders",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/orders",
+          "path": "floe/rejected/sales/order_revenue/orders",
           "resolved": true
         },
         "archive": null
@@ -429,7 +429,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/order_revenue/products",
-        "path": "s3://lakehouse-bronze/sales/order_revenue/products",
+        "path": "sales/order_revenue/products",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -455,7 +455,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/order_revenue/products",
-          "path": "s3://lakehouse-silver/sales/order_revenue/products",
+          "path": "sales/order_revenue/products",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -468,7 +468,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/products",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/products",
+          "path": "floe/rejected/sales/order_revenue/products",
           "resolved": true
         },
         "archive": null
@@ -526,7 +526,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/sales/order_revenue/promotions",
-        "path": "s3://lakehouse-bronze/sales/order_revenue/promotions",
+        "path": "sales/order_revenue/promotions",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -552,7 +552,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/sales/order_revenue/promotions",
-          "path": "s3://lakehouse-silver/sales/order_revenue/promotions",
+          "path": "sales/order_revenue/promotions",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -565,7 +565,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/promotions",
-          "path": "s3://lakehouse-silver/floe/rejected/sales/order_revenue/promotions",
+          "path": "floe/rejected/sales/order_revenue/promotions",
           "resolved": true
         },
         "archive": null

--- a/domains/sales/contracts/floe/manifests/order_revenue.manifest.json
+++ b/domains/sales/contracts/floe/manifests/order_revenue.manifest.json
@@ -1,15 +1,15 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.6",
+  "floe_version": "0.6.3",
   "spec_version": "0.2",
   "manifest_name": "sales.order_revenue.local",
   "manifest_id": "mfv1-1faf0a276d5999f5",
-  "manifest_revision": "sha256:0cf42565862858a475c729a2f2d253d033dca19b320015e65f4ca59fe7685e73",
+  "manifest_revision": "sha256:bfa3249cde5da98437e4128c9c3cab8ba9fbd5719426c5822112b2da13934aa1",
   "config_uri": "local:///work/domains/sales/contracts/floe/order_revenue.yml",
   "config_checksum": "sha256:4ec74b837e4ba6204ba34e5f5031b655d679984e76c4824f345c41d69e2b09de",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:58573fe005026cbdf3d95a2e61fa74b843d23d62e8376b7d18f81a4c8e2e2e2c",
+  "profile_checksum": "sha256:2da09d6d0371661747745ae89b2d95af18e5ec8a7179950a5e479d55cd4f6149",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/sales/order_revenue",
   "domains": [],
   "execution": {
@@ -76,7 +76,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.6",
+        "image": "ghcr.io/malon64/floe:0.6.3",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,

--- a/domains/sales/contracts/floe/manifests/order_revenue.manifest.json
+++ b/domains/sales/contracts/floe/manifests/order_revenue.manifest.json
@@ -1,15 +1,17 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.3",
+  "floe_version": "0.6.7",
   "spec_version": "0.2",
   "manifest_name": "sales.order_revenue.local",
   "manifest_id": "mfv1-1faf0a276d5999f5",
-  "manifest_revision": "sha256:bfa3249cde5da98437e4128c9c3cab8ba9fbd5719426c5822112b2da13934aa1",
+  "manifest_revision": "sha256:0ea6e9a1d24fe8b1575bc9d3a5f0d27772e35e2638b3693db00d289843d17a31",
+  "runtime_env": "image",
+  "work_root": "/work",
   "config_uri": "local:///work/domains/sales/contracts/floe/order_revenue.yml",
   "config_checksum": "sha256:4ec74b837e4ba6204ba34e5f5031b655d679984e76c4824f345c41d69e2b09de",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:2da09d6d0371661747745ae89b2d95af18e5ec8a7179950a5e479d55cd4f6149",
+  "profile_checksum": "sha256:3b60ae92c8cd2b56ef059822bf691a39d529dde3f14e72c484b66f55c727ca91",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/sales/order_revenue",
   "domains": [],
   "execution": {
@@ -76,7 +78,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.3",
+        "image": "ghcr.io/malon64/floe:0.6.7",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,
@@ -85,7 +87,7 @@
           "AWS_DEFAULT_REGION": "us-east-1",
           "AWS_EC2_METADATA_DISABLED": "true",
           "AWS_ENDPOINT_URL": "http://seaweedfs-s3:8333",
-          "AWS_ENDPOINT_URL_S3": "http://lakehouse.svc.cluster.local:8333",
+          "AWS_ENDPOINT_URL_S3": "http://seaweedfs-s3:8333",
           "AWS_REGION": "us-east-1",
           "AWS_S3_FORCE_PATH_STYLE": "true"
         },

--- a/domains/supply_chain/contracts/floe/manifests/inventory_reliability.manifest.json
+++ b/domains/supply_chain/contracts/floe/manifests/inventory_reliability.manifest.json
@@ -1,15 +1,15 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.6",
+  "floe_version": "0.6.3",
   "spec_version": "0.2",
   "manifest_name": "supply_chain.inventory_reliability.local",
   "manifest_id": "mfv1-33ef4a55e13b0add",
-  "manifest_revision": "sha256:8e92de5a3ead53493a0cc8aae140a9557b006a10d3311b9fd6f8a2aeac75d799",
+  "manifest_revision": "sha256:68e0079f73e758056822ce605576d0e7d0107cca753b200e9654a19bc1e733d7",
   "config_uri": "local:///work/domains/supply_chain/contracts/floe/inventory_reliability.yml",
   "config_checksum": "sha256:2991619176cc8f8990bbde7a34bb76fa494e9fc72c72b8b62a905f0519d4d399",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:58573fe005026cbdf3d95a2e61fa74b843d23d62e8376b7d18f81a4c8e2e2e2c",
+  "profile_checksum": "sha256:2da09d6d0371661747745ae89b2d95af18e5ec8a7179950a5e479d55cd4f6149",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/supply_chain/inventory_reliability",
   "domains": [],
   "execution": {
@@ -76,7 +76,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.6",
+        "image": "ghcr.io/malon64/floe:0.6.3",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,

--- a/domains/supply_chain/contracts/floe/manifests/inventory_reliability.manifest.json
+++ b/domains/supply_chain/contracts/floe/manifests/inventory_reliability.manifest.json
@@ -1,17 +1,17 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.7",
+  "floe_version": "0.6.8",
   "spec_version": "0.2",
   "manifest_name": "supply_chain.inventory_reliability.local",
   "manifest_id": "mfv1-33ef4a55e13b0add",
-  "manifest_revision": "sha256:691804b8a7432dd39d595c8fb6699dad65c70046ff0b8f97b6d6ce20908935b9",
+  "manifest_revision": "sha256:2b3aeb230674077df669bfb5b60497342ef1867715ca9027c2c80cb5a4ef2248",
   "runtime_env": "image",
   "work_root": "/work",
   "config_uri": "local:///work/domains/supply_chain/contracts/floe/inventory_reliability.yml",
   "config_checksum": "sha256:2991619176cc8f8990bbde7a34bb76fa494e9fc72c72b8b62a905f0519d4d399",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:3b60ae92c8cd2b56ef059822bf691a39d529dde3f14e72c484b66f55c727ca91",
+  "profile_checksum": "sha256:d46aa2bbd1e660aed1da7b62b3c74037cda7e7e602f717bf3ae6c6424d60530e",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/supply_chain/inventory_reliability",
   "domains": [],
   "execution": {
@@ -78,7 +78,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.7",
+        "image": "ghcr.io/malon64/floe:0.6.8",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,
@@ -118,7 +118,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/supply_chain/inventory_reliability/inventory_snapshots",
-        "path": "s3://lakehouse-bronze/supply_chain/inventory_reliability/inventory_snapshots",
+        "path": "supply_chain/inventory_reliability/inventory_snapshots",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -144,7 +144,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/supply_chain/inventory_reliability/inventory_snapshots",
-          "path": "s3://lakehouse-silver/supply_chain/inventory_reliability/inventory_snapshots",
+          "path": "supply_chain/inventory_reliability/inventory_snapshots",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -157,7 +157,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/inventory_snapshots",
-          "path": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/inventory_snapshots",
+          "path": "floe/rejected/supply_chain/inventory_reliability/inventory_snapshots",
           "resolved": true
         },
         "archive": null
@@ -230,7 +230,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/supply_chain/inventory_reliability/purchase_orders",
-        "path": "s3://lakehouse-bronze/supply_chain/inventory_reliability/purchase_orders",
+        "path": "supply_chain/inventory_reliability/purchase_orders",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -256,7 +256,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/supply_chain/inventory_reliability/purchase_orders",
-          "path": "s3://lakehouse-silver/supply_chain/inventory_reliability/purchase_orders",
+          "path": "supply_chain/inventory_reliability/purchase_orders",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -269,7 +269,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/purchase_orders",
-          "path": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/purchase_orders",
+          "path": "floe/rejected/supply_chain/inventory_reliability/purchase_orders",
           "resolved": true
         },
         "archive": null
@@ -342,7 +342,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/supply_chain/inventory_reliability/shipments",
-        "path": "s3://lakehouse-bronze/supply_chain/inventory_reliability/shipments",
+        "path": "supply_chain/inventory_reliability/shipments",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -368,7 +368,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/supply_chain/inventory_reliability/shipments",
-          "path": "s3://lakehouse-silver/supply_chain/inventory_reliability/shipments",
+          "path": "supply_chain/inventory_reliability/shipments",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -381,7 +381,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/shipments",
-          "path": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/shipments",
+          "path": "floe/rejected/supply_chain/inventory_reliability/shipments",
           "resolved": true
         },
         "archive": null
@@ -444,7 +444,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/supply_chain/inventory_reliability/stockout_events",
-        "path": "s3://lakehouse-bronze/supply_chain/inventory_reliability/stockout_events",
+        "path": "supply_chain/inventory_reliability/stockout_events",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -470,7 +470,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/supply_chain/inventory_reliability/stockout_events",
-          "path": "s3://lakehouse-silver/supply_chain/inventory_reliability/stockout_events",
+          "path": "supply_chain/inventory_reliability/stockout_events",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -483,7 +483,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/stockout_events",
-          "path": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/stockout_events",
+          "path": "floe/rejected/supply_chain/inventory_reliability/stockout_events",
           "resolved": true
         },
         "archive": null
@@ -551,7 +551,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/supply_chain/inventory_reliability/suppliers",
-        "path": "s3://lakehouse-bronze/supply_chain/inventory_reliability/suppliers",
+        "path": "supply_chain/inventory_reliability/suppliers",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -577,7 +577,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/supply_chain/inventory_reliability/suppliers",
-          "path": "s3://lakehouse-silver/supply_chain/inventory_reliability/suppliers",
+          "path": "supply_chain/inventory_reliability/suppliers",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -590,7 +590,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/suppliers",
-          "path": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/suppliers",
+          "path": "floe/rejected/supply_chain/inventory_reliability/suppliers",
           "resolved": true
         },
         "archive": null
@@ -648,7 +648,7 @@
         "format": "csv",
         "storage": "lakehouse_bronze",
         "uri": "s3://lakehouse-bronze/supply_chain/inventory_reliability/warehouses",
-        "path": "s3://lakehouse-bronze/supply_chain/inventory_reliability/warehouses",
+        "path": "supply_chain/inventory_reliability/warehouses",
         "resolved": true,
         "cast_mode": "strict",
         "options": {
@@ -674,7 +674,7 @@
           "format": "iceberg",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/supply_chain/inventory_reliability/warehouses",
-          "path": "s3://lakehouse-silver/supply_chain/inventory_reliability/warehouses",
+          "path": "supply_chain/inventory_reliability/warehouses",
           "resolved": true,
           "iceberg": {
             "catalog": "iceberg_catalog",
@@ -687,7 +687,7 @@
           "format": "csv",
           "storage": "lakehouse_silver",
           "uri": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/warehouses",
-          "path": "s3://lakehouse-silver/floe/rejected/supply_chain/inventory_reliability/warehouses",
+          "path": "floe/rejected/supply_chain/inventory_reliability/warehouses",
           "resolved": true
         },
         "archive": null

--- a/domains/supply_chain/contracts/floe/manifests/inventory_reliability.manifest.json
+++ b/domains/supply_chain/contracts/floe/manifests/inventory_reliability.manifest.json
@@ -1,15 +1,17 @@
 {
   "schema": "floe.manifest.v1",
   "generated_at_ts_ms": 0,
-  "floe_version": "0.6.3",
+  "floe_version": "0.6.7",
   "spec_version": "0.2",
   "manifest_name": "supply_chain.inventory_reliability.local",
   "manifest_id": "mfv1-33ef4a55e13b0add",
-  "manifest_revision": "sha256:68e0079f73e758056822ce605576d0e7d0107cca753b200e9654a19bc1e733d7",
+  "manifest_revision": "sha256:691804b8a7432dd39d595c8fb6699dad65c70046ff0b8f97b6d6ce20908935b9",
+  "runtime_env": "image",
+  "work_root": "/work",
   "config_uri": "local:///work/domains/supply_chain/contracts/floe/inventory_reliability.yml",
   "config_checksum": "sha256:2991619176cc8f8990bbde7a34bb76fa494e9fc72c72b8b62a905f0519d4d399",
   "profile_uri": "local:///work/libs/floe/profiles/local-k8s.yml",
-  "profile_checksum": "sha256:2da09d6d0371661747745ae89b2d95af18e5ec8a7179950a5e479d55cd4f6149",
+  "profile_checksum": "sha256:3b60ae92c8cd2b56ef059822bf691a39d529dde3f14e72c484b66f55c727ca91",
   "report_base_uri": "s3://openlakeforge-ops/floe/reports/supply_chain/inventory_reliability",
   "domains": [],
   "execution": {
@@ -76,7 +78,7 @@
             "key": "POLARIS_FLOE_CLIENT_SECRET"
           }
         ],
-        "image": "ghcr.io/malon64/floe:0.6.3",
+        "image": "ghcr.io/malon64/floe:0.6.7",
         "namespace": "lakehouse",
         "service_account": "dagster",
         "resources": null,
@@ -85,7 +87,7 @@
           "AWS_DEFAULT_REGION": "us-east-1",
           "AWS_EC2_METADATA_DISABLED": "true",
           "AWS_ENDPOINT_URL": "http://seaweedfs-s3:8333",
-          "AWS_ENDPOINT_URL_S3": "http://lakehouse.svc.cluster.local:8333",
+          "AWS_ENDPOINT_URL_S3": "http://seaweedfs-s3:8333",
           "AWS_REGION": "us-east-1",
           "AWS_S3_FORCE_PATH_STYLE": "true"
         },

--- a/images/project-code/pyproject.toml
+++ b/images/project-code/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "dagster==1.13.6",
   "dagster-aws==0.29.6",
   "dagster-dbt==0.29.6",
-  "dagster-floe[kubernetes]==0.2.3",
+  "dagster-floe[kubernetes]==0.2.5",
   "dagster-k8s==0.29.6",
   "dagster-postgres==0.29.6",
   "dagster-webserver==1.13.6",

--- a/infra/helm/values/local/seaweedfs.yaml
+++ b/infra/helm/values/local/seaweedfs.yaml
@@ -26,7 +26,10 @@ volume:
   dataDirs:
     - name: data1
       type: "emptyDir"
-      maxVolumes: 0
+      # The local demo uses one volume server for multiple collections
+      # (ops plus bronze/silver/gold). Keep enough writable slots available
+      # so first writes to the medallion buckets do not stall on assignment.
+      maxVolumes: 32
   logs:
     type: "emptyDir"
   resources:

--- a/libs/floe/profiles/aws-eks.yml
+++ b/libs/floe/profiles/aws-eks.yml
@@ -24,7 +24,7 @@ execution:
     strategy: sequential
   runner:
     type: kubernetes_job
-    image: ghcr.io/malon64/floe:0.6.6
+    image: ghcr.io/malon64/floe:0.6.7
     namespace: lakehouse
     service_account: dagster
     timeout_seconds: 600

--- a/libs/floe/profiles/aws-eks.yml
+++ b/libs/floe/profiles/aws-eks.yml
@@ -24,7 +24,7 @@ execution:
     strategy: sequential
   runner:
     type: kubernetes_job
-    image: ghcr.io/malon64/floe:0.6.7
+    image: ghcr.io/malon64/floe:0.6.8
     namespace: lakehouse
     service_account: dagster
     timeout_seconds: 600

--- a/libs/floe/profiles/local-k8s.yml
+++ b/libs/floe/profiles/local-k8s.yml
@@ -26,7 +26,7 @@ execution:
     strategy: sequential
   runner:
     type: kubernetes_job
-    image: ghcr.io/malon64/floe:0.6.3
+    image: ghcr.io/malon64/floe:0.6.7
     namespace: lakehouse
     service_account: dagster
     timeout_seconds: 600
@@ -39,7 +39,7 @@ execution:
       AWS_EC2_METADATA_DISABLED: "true"
       AWS_ALLOW_HTTP: "true"
       AWS_ENDPOINT_URL: "http://seaweedfs-s3:8333"
-      AWS_ENDPOINT_URL_S3: "http://lakehouse.svc.cluster.local:8333"
+      AWS_ENDPOINT_URL_S3: "http://seaweedfs-s3:8333"
     secrets:
       - name: AWS_ACCESS_KEY_ID
         secret_name: seaweedfs-s3-creds

--- a/libs/floe/profiles/local-k8s.yml
+++ b/libs/floe/profiles/local-k8s.yml
@@ -26,7 +26,7 @@ execution:
     strategy: sequential
   runner:
     type: kubernetes_job
-    image: ghcr.io/malon64/floe:0.6.7
+    image: ghcr.io/malon64/floe:0.6.8
     namespace: lakehouse
     service_account: dagster
     timeout_seconds: 600

--- a/libs/floe/profiles/local-k8s.yml
+++ b/libs/floe/profiles/local-k8s.yml
@@ -26,7 +26,7 @@ execution:
     strategy: sequential
   runner:
     type: kubernetes_job
-    image: ghcr.io/malon64/floe:0.6.6
+    image: ghcr.io/malon64/floe:0.6.3
     namespace: lakehouse
     service_account: dagster
     timeout_seconds: 600

--- a/scripts/artifacts/floe-manifest.sh
+++ b/scripts/artifacts/floe-manifest.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 NAMESPACE="${NAMESPACE:-lakehouse}"
-FLOE_VERSION="${FLOE_VERSION:-0.6.6}"
-FLOE_IMAGE="${FLOE_IMAGE:-ghcr.io/malon64/floe:${FLOE_VERSION}}"
 FLOE_PLATFORM="${FLOE_PLATFORM:-}"
 USING_DOCKER="false"
 
@@ -18,6 +16,13 @@ source "${REPO_ROOT}/scripts/lib/python.sh"
 source "${REPO_ROOT}/scripts/contracts/load-runtime-env.sh"
 
 cd "${REPO_ROOT}"
+
+default_floe_version="0.6.6"
+if [[ "${OPENLAKEFORGE_STORAGE_PROVIDER:-}" == "local" ]]; then
+  default_floe_version="0.6.3"
+fi
+FLOE_VERSION="${FLOE_VERSION:-${default_floe_version}}"
+FLOE_IMAGE="${FLOE_IMAGE:-ghcr.io/malon64/floe:${FLOE_VERSION}}"
 
 if [[ -z "${FLOE_RUNTIME_PROFILE_URI:-}" ]]; then
   if [[ "${OPENLAKEFORGE_STORAGE_IMPLEMENTATION}" == "storage.aws_s3" &&

--- a/scripts/artifacts/floe-manifest.sh
+++ b/scripts/artifacts/floe-manifest.sh
@@ -17,12 +17,10 @@ source "${REPO_ROOT}/scripts/contracts/load-runtime-env.sh"
 
 cd "${REPO_ROOT}"
 
-default_floe_version="0.6.6"
-if [[ "${OPENLAKEFORGE_STORAGE_PROVIDER:-}" == "local" ]]; then
-  default_floe_version="0.6.3"
-fi
+default_floe_version="0.6.7"
 FLOE_VERSION="${FLOE_VERSION:-${default_floe_version}}"
 FLOE_IMAGE="${FLOE_IMAGE:-ghcr.io/malon64/floe:${FLOE_VERSION}}"
+FLOE_RUNTIME="${FLOE_RUNTIME:-image}"
 
 if [[ -z "${FLOE_RUNTIME_PROFILE_URI:-}" ]]; then
   if [[ "${OPENLAKEFORGE_STORAGE_IMPLEMENTATION}" == "storage.aws_s3" &&
@@ -35,6 +33,9 @@ if [[ -z "${FLOE_RUNTIME_PROFILE_URI:-}" ]]; then
 fi
 export FLOE_RUNTIME_PROFILE_URI
 
+# Manifest generation is image-targeted by default because OpenLakeForge replays
+# these manifests in separate Floe runner images. Set FLOE_RUNTIME=cli for
+# same-host debugging where relative paths are preferable.
 # Runner selection. Docker is the default so manifest generation does not require
 # a host-installed Floe CLI; set FLOE_PREFER_CLI=true to use the native CLI.
 FLOE_PREFER_CLI="${FLOE_PREFER_CLI:-false}"
@@ -298,6 +299,7 @@ generate_manifest() {
     --manifest-name "${domain}.${product}.local" \
     --default-domain "${domain}_${product}" \
     --manifest-path-mode resolved-uri \
+    --runtime "${FLOE_RUNTIME}" \
     --output "${floe_manifest_path}"
 
   echo "Generated ${manifest_path}"

--- a/scripts/artifacts/floe-manifest.sh
+++ b/scripts/artifacts/floe-manifest.sh
@@ -17,7 +17,7 @@ source "${REPO_ROOT}/scripts/contracts/load-runtime-env.sh"
 
 cd "${REPO_ROOT}"
 
-default_floe_version="0.6.7"
+default_floe_version="0.6.8"
 FLOE_VERSION="${FLOE_VERSION:-${default_floe_version}}"
 FLOE_IMAGE="${FLOE_IMAGE:-ghcr.io/malon64/floe:${FLOE_VERSION}}"
 FLOE_RUNTIME="${FLOE_RUNTIME:-image}"
@@ -298,7 +298,6 @@ generate_manifest() {
     --deterministic \
     --manifest-name "${domain}.${product}.local" \
     --default-domain "${domain}_${product}" \
-    --manifest-path-mode resolved-uri \
     --runtime "${FLOE_RUNTIME}" \
     --output "${floe_manifest_path}"
 

--- a/scripts/lib/kube.sh
+++ b/scripts/lib/kube.sh
@@ -89,13 +89,17 @@ prepare_polaris_bootstrap_generation() {
 
   if olf_run polaris check-credentials; then
     return 0
+  else
+    status=$?
   fi
-  status=$?
 
   if [[ "${status}" -eq 3 ]]; then
     POLARIS_BOOTSTRAP_GENERATION="rebootstrap-$(date -u +%Y%m%d%H%M%S)"
     cleanup_jobs_by_prefix "polaris-bootstrap-"
     cleanup_jobs_by_prefix "openmetadata-bootstrap-"
     cleanup_failed_jobs_by_prefix "openmetadata-polaris-refresh-"
+    return 0
   fi
+
+  return "${status}"
 }

--- a/scripts/local/cluster/prefetch-images.sh
+++ b/scripts/local/cluster/prefetch-images.sh
@@ -34,7 +34,7 @@ IMAGES=(
   "apache/superset:dockerize"
   "apache/superset:6.1.0"
   "docker.io/bitnamilegacy/redis:7.0.10-debian-11-r4"
-  "ghcr.io/malon64/floe:0.6.6"
+  "ghcr.io/malon64/floe:0.6.3"
 )
 
 WORK_DIR="$(mktemp -d)"

--- a/scripts/local/cluster/prefetch-images.sh
+++ b/scripts/local/cluster/prefetch-images.sh
@@ -34,7 +34,7 @@ IMAGES=(
   "apache/superset:dockerize"
   "apache/superset:6.1.0"
   "docker.io/bitnamilegacy/redis:7.0.10-debian-11-r4"
-  "ghcr.io/malon64/floe:0.6.3"
+  "ghcr.io/malon64/floe:0.6.7"
 )
 
 WORK_DIR="$(mktemp -d)"

--- a/scripts/local/cluster/prefetch-images.sh
+++ b/scripts/local/cluster/prefetch-images.sh
@@ -34,7 +34,7 @@ IMAGES=(
   "apache/superset:dockerize"
   "apache/superset:6.1.0"
   "docker.io/bitnamilegacy/redis:7.0.10-debian-11-r4"
-  "ghcr.io/malon64/floe:0.6.7"
+  "ghcr.io/malon64/floe:0.6.8"
 )
 
 WORK_DIR="$(mktemp -d)"

--- a/scripts/local/stack/deploy-artifacts.sh
+++ b/scripts/local/stack/deploy-artifacts.sh
@@ -43,11 +43,6 @@ prepare_local_project_code_image() {
 require_cmd kubectl
 require_cmd uv
 
-if ! kubectl cluster-info --context "${KUBE_CONTEXT}" >/dev/null 2>&1; then
-  echo "ERROR: Kubernetes context '${KUBE_CONTEXT}' is not reachable." >&2
-  echo "Run 'make local-foundation-up' before deploying local artifacts." >&2
-  exit 1
-fi
 kubectl config use-context "${KUBE_CONTEXT}" >/dev/null
 
 # Load the provider contract environment for the olf artifact commands.

--- a/scripts/local/stack/infra-up.sh
+++ b/scripts/local/stack/infra-up.sh
@@ -94,6 +94,7 @@ terraform_apply_once() {
 refresh_trino_if_catalog_credentials_are_stale() {
   local deployment="trino-coordinator"
   local check_output
+  local bootstrap_generation_before
 
   if ! kubectl get deployment "${deployment}" -n "${NAMESPACE}" >/dev/null 2>&1; then
     return 0
@@ -119,7 +120,26 @@ refresh_trino_if_catalog_credentials_are_stale() {
   kubectl rollout restart "deployment/${deployment}" -n "${NAMESPACE}"
   kubectl rollout status "deployment/${deployment}" -n "${NAMESPACE}" --timeout=300s
 
-  run_with_retry "Trino Iceberg catalog credential check" \
+  if run_with_retry "Trino Iceberg catalog credential check" \
+    kubectl exec "deployment/${deployment}" -n "${NAMESPACE}" -- \
+      trino --server http://localhost:8080 --execute "SHOW SCHEMAS FROM iceberg"; then
+    return 0
+  fi
+
+  bootstrap_generation_before="${POLARIS_BOOTSTRAP_GENERATION}"
+  prepare_polaris_bootstrap_generation
+  if [[ "${POLARIS_BOOTSTRAP_GENERATION}" == "${bootstrap_generation_before}" ]]; then
+    echo "ERROR: Trino still cannot obtain Iceberg metadata after restart, and Polaris rebootstrap was not triggered." >&2
+    return 1
+  fi
+
+  echo "WARN: Trino still has stale Polaris credentials; reapplying local infrastructure with Polaris rebootstrap..." >&2
+  run_with_retry "Terraform apply" terraform_apply_once
+
+  kubectl rollout restart "deployment/${deployment}" -n "${NAMESPACE}"
+  kubectl rollout status "deployment/${deployment}" -n "${NAMESPACE}" --timeout=300s
+
+  run_with_retry "Trino Iceberg catalog credential check after Polaris rebootstrap" \
     kubectl exec "deployment/${deployment}" -n "${NAMESPACE}" -- \
       trino --server http://localhost:8080 --execute "SHOW SCHEMAS FROM iceberg"
 }

--- a/scripts/test/check-contracts.sh
+++ b/scripts/test/check-contracts.sh
@@ -484,7 +484,6 @@ for required in [
     '-v "${REPO_ROOT}:/work"',
     '"${FLOE_RUNTIME_ARTIFACT_DIR}/manifests"',
     'FLOE_RUNTIME="${FLOE_RUNTIME:-image}"',
-    "--manifest-path-mode resolved-uri",
     '--runtime "${FLOE_RUNTIME}"',
 ]:
     if required not in floe_manifest_body:

--- a/scripts/test/check-contracts.sh
+++ b/scripts/test/check-contracts.sh
@@ -483,7 +483,9 @@ for required in [
     'profiles/${domain}/${product}',
     '-v "${REPO_ROOT}:/work"',
     '"${FLOE_RUNTIME_ARTIFACT_DIR}/manifests"',
+    'FLOE_RUNTIME="${FLOE_RUNTIME:-image}"',
     "--manifest-path-mode resolved-uri",
+    '--runtime "${FLOE_RUNTIME}"',
 ]:
     if required not in floe_manifest_body:
         errors.append(f"{floe_manifest_script}: missing provider-aware Floe runtime profile handling {required}")

--- a/tools/olf/olf/floe.py
+++ b/tools/olf/olf/floe.py
@@ -39,6 +39,7 @@ def render_profile(environ: Mapping[str, str]) -> str:
         "OPENLAKEFORGE_OPS_BUCKET_NAME", env("OPENLAKEFORGE_ARTIFACT_BUCKET_NAME", "openlakeforge-ops")
     )
     storage_region = env("OPENLAKEFORGE_STORAGE_REGION", "us-east-1")
+    storage_provider = env("OPENLAKEFORGE_STORAGE_PROVIDER", "local")
     storage_implementation = env(
         "OPENLAKEFORGE_STORAGE_IMPLEMENTATION", "storage.s3_compatible.seaweedfs"
     )
@@ -80,7 +81,12 @@ def render_profile(environ: Mapping[str, str]) -> str:
         "OPENLAKEFORGE_CATALOG_GLUE_WAREHOUSE_PREFIX", "warehouse/iceberg"
     )
     catalog_scope = env("OPENLAKEFORGE_CATALOG_OAUTH_SCOPE", "PRINCIPAL_ROLE:ALL")
-    floe_image = env("FLOE_IMAGE", "ghcr.io/malon64/floe:0.6.6")
+    default_floe_image = (
+        "ghcr.io/malon64/floe:0.6.3"
+        if storage_provider == "local"
+        else "ghcr.io/malon64/floe:0.6.6"
+    )
+    floe_image = env("FLOE_IMAGE", default_floe_image)
     storage_secret = env(
         "OPENLAKEFORGE_STORAGE_CREDENTIALS_SECRET_NAME", "" if is_aws_s3 else "seaweedfs-s3-creds"
     )

--- a/tools/olf/olf/floe.py
+++ b/tools/olf/olf/floe.py
@@ -81,7 +81,7 @@ def render_profile(environ: Mapping[str, str]) -> str:
         "OPENLAKEFORGE_CATALOG_GLUE_WAREHOUSE_PREFIX", "warehouse/iceberg"
     )
     catalog_scope = env("OPENLAKEFORGE_CATALOG_OAUTH_SCOPE", "PRINCIPAL_ROLE:ALL")
-    default_floe_image = "ghcr.io/malon64/floe:0.6.7"
+    default_floe_image = "ghcr.io/malon64/floe:0.6.8"
     floe_image = env("FLOE_IMAGE", default_floe_image)
     storage_secret = env(
         "OPENLAKEFORGE_STORAGE_CREDENTIALS_SECRET_NAME", "" if is_aws_s3 else "seaweedfs-s3-creds"

--- a/tools/olf/olf/floe.py
+++ b/tools/olf/olf/floe.py
@@ -39,7 +39,6 @@ def render_profile(environ: Mapping[str, str]) -> str:
         "OPENLAKEFORGE_OPS_BUCKET_NAME", env("OPENLAKEFORGE_ARTIFACT_BUCKET_NAME", "openlakeforge-ops")
     )
     storage_region = env("OPENLAKEFORGE_STORAGE_REGION", "us-east-1")
-    storage_provider = env("OPENLAKEFORGE_STORAGE_PROVIDER", "local")
     storage_implementation = env(
         "OPENLAKEFORGE_STORAGE_IMPLEMENTATION", "storage.s3_compatible.seaweedfs"
     )

--- a/tools/olf/olf/floe.py
+++ b/tools/olf/olf/floe.py
@@ -81,11 +81,7 @@ def render_profile(environ: Mapping[str, str]) -> str:
         "OPENLAKEFORGE_CATALOG_GLUE_WAREHOUSE_PREFIX", "warehouse/iceberg"
     )
     catalog_scope = env("OPENLAKEFORGE_CATALOG_OAUTH_SCOPE", "PRINCIPAL_ROLE:ALL")
-    default_floe_image = (
-        "ghcr.io/malon64/floe:0.6.3"
-        if storage_provider == "local"
-        else "ghcr.io/malon64/floe:0.6.6"
-    )
+    default_floe_image = "ghcr.io/malon64/floe:0.6.7"
     floe_image = env("FLOE_IMAGE", default_floe_image)
     storage_secret = env(
         "OPENLAKEFORGE_STORAGE_CREDENTIALS_SECRET_NAME", "" if is_aws_s3 else "seaweedfs-s3-creds"
@@ -118,7 +114,15 @@ def render_profile(environ: Mapping[str, str]) -> str:
     if storage_endpoint:
         runner_env["AWS_ENDPOINT_URL"] = storage_endpoint
     if storage_virtual_endpoint:
-        runner_env["AWS_ENDPOINT_URL_S3"] = storage_virtual_endpoint
+        # Floe's runner reads manifests and source objects from the local
+        # S3-compatible store using the AWS SDK. In the local path-style setup,
+        # the service endpoint must remain the concrete SeaweedFS S3 service,
+        # not the bucket-virtual host base.
+        runner_env["AWS_ENDPOINT_URL_S3"] = (
+            storage_endpoint
+            if env("OPENLAKEFORGE_STORAGE_PATH_STYLE_ACCESS", "false" if is_aws_s3 else "true") == "true"
+            else storage_virtual_endpoint
+        )
 
     runner_env_yaml = "\n".join(
         f"      {key}: {_yaml_string(value)}" for key, value in runner_env.items()

--- a/tools/olf/tests/test_floe.py
+++ b/tools/olf/tests/test_floe.py
@@ -26,10 +26,13 @@ def test_local_profile_uses_polaris_rest_catalog_and_secrets() -> None:
     assert 'name: "local-k8s"' in profile
     assert 'type: "rest"' in profile
     assert 'default: "iceberg_catalog"' in profile
+    assert "image: ghcr.io/malon64/floe:0.6.7" in profile
     assert 'warehouse_prefix: "s3://lakehouse-silver"' in profile
     assert "secret_name: seaweedfs-s3-creds" in profile
     assert "secret_name: polaris-floe-creds" in profile
     assert 'AWS_ALLOW_HTTP: "true"' in profile
+    assert 'AWS_ENDPOINT_URL: "http://seaweedfs-s3:8333"' in profile
+    assert 'AWS_ENDPOINT_URL_S3: "http://seaweedfs-s3:8333"' in profile
     assert "\nstorages:" not in profile
 
 
@@ -37,6 +40,7 @@ def test_aws_profile_uses_glue_catalog_without_secrets() -> None:
     profile = render_profile(AWS_ENV)
     assert 'name: "aws-eks"' in profile
     assert 'type: "glue"' in profile
+    assert "image: ghcr.io/malon64/floe:0.6.7" in profile
     assert 'database: "sales_customer_health_silver"' in profile
     assert 'warehouse_prefix: "s3://openlakeforge-poc-silver/warehouse/iceberg"' in profile
     assert "secrets: []" in profile

--- a/tools/olf/tests/test_floe.py
+++ b/tools/olf/tests/test_floe.py
@@ -26,7 +26,7 @@ def test_local_profile_uses_polaris_rest_catalog_and_secrets() -> None:
     assert 'name: "local-k8s"' in profile
     assert 'type: "rest"' in profile
     assert 'default: "iceberg_catalog"' in profile
-    assert "image: ghcr.io/malon64/floe:0.6.7" in profile
+    assert "image: ghcr.io/malon64/floe:0.6.8" in profile
     assert 'warehouse_prefix: "s3://lakehouse-silver"' in profile
     assert "secret_name: seaweedfs-s3-creds" in profile
     assert "secret_name: polaris-floe-creds" in profile
@@ -40,7 +40,7 @@ def test_aws_profile_uses_glue_catalog_without_secrets() -> None:
     profile = render_profile(AWS_ENV)
     assert 'name: "aws-eks"' in profile
     assert 'type: "glue"' in profile
-    assert "image: ghcr.io/malon64/floe:0.6.7" in profile
+    assert "image: ghcr.io/malon64/floe:0.6.8" in profile
     assert 'database: "sales_customer_health_silver"' in profile
     assert 'warehouse_prefix: "s3://openlakeforge-poc-silver/warehouse/iceberg"' in profile
     assert "secrets: []" in profile


### PR DESCRIPTION
## Summary

This PR repairs local Floe ingestion for the OpenLakeForge demo path and updates the runtime to `ghcr.io/malon64/floe:0.6.8` now that the upstream S3-compatible storage issue is fixed.

It keeps OpenLakeForge on image-based Floe execution: manifests are generated by the host or Dockerized Floe helper, while Dagster launches separate Floe runner pods from the image declared in the profile/manifest.

## Issue

Local demo runs were failing or stalling around the Floe ingestion path after the refactor. Earlier Floe releases exposed runtime issues in the image path, including manifest path handling and S3-compatible object access against the local SeaweedFS deployment. This made Dagster materializations fail after dlt completed, even when the local platform was otherwise healthy.

## Root Cause

The local pipeline depends on the Floe Kubernetes runner image, not the host CLI. The generated manifests and profile defaults therefore need to point at a working Floe image runtime. Floe `0.6.8` fixes the upstream S3-compatible access issue, so OpenLakeForge no longer needs to force the old manifest path generation workaround.

## Changes

- Bumps Floe profile defaults, generated manifests, prefetch image list, docs, and helper tests to `ghcr.io/malon64/floe:0.6.8`.
- Regenerates committed product manifests with Floe `0.6.8` while preserving absolute `local:///work/...` config and profile URIs.
- Removes the forced `--manifest-path-mode resolved-uri` manifest generation patch and the contract assertion that required it.
- Keeps `--runtime image` as the OpenLakeForge default so generated manifests target Kubernetes runner image execution.
- Includes the existing local repair work on this branch for Dagster/Floe dependency alignment and local stack robustness.

## Validation

- `make floe-manifest`
- `uv run --project tools/olf pytest tools/olf/tests/test_floe.py`
- `make check-contracts`
- `docker run --rm ghcr.io/malon64/floe:0.6.8 --version`

