### PR TITLE
feat: publish immutable Floe artifact revisions

### DIFF
--- a/tools/olf/README.md
+++ b/tools/olf/README.md
@@ -14,6 +14,7 @@ parsing. See [ADR 0017](../../docs/adr/0017-shared-python-deploy-tooling.md).
 | `olf contracts env [--terraform-dir D]` | Resolve the provider-contract runtime environment to `export`/`unset` lines (sourced by `scripts/contracts/load-runtime-env.sh`). |
 | `olf floe render-profile` | Render the Floe EnvironmentProfile YAML for the active contract env. |
 | `olf artifacts upload-manifests --via port-forward\|direct` | Publish product Floe manifests to the ops bucket (in-cluster S3 or cloud S3). |
+| `olf revision compute\|publish\|verify --runtime-root D` | Compute, publish, or verify an immutable Floe runtime-artifact revision. Publication writes `floe/revisions/sha256/<digest>/...` and does not activate that revision. |
 | `olf superset deploy-reports` / `export-reports` | Build/import or export Superset report bundles. |
 | `olf openmetadata deploy-metadata` | Seed OpenMetadata domains, data products, and medallion containers over REST. |
 | `olf k8s set-project-code-image --image X` | Point every Dagster surface at a pushed project-code image, trigger one coordinated restart, and wait for its rollout. |

--- a/tools/olf/olf/cli.py
+++ b/tools/olf/olf/cli.py
@@ -1,14 +1,18 @@
 """The olf CLI: entrypoint for OpenLakeForge deployment tooling.
 
 Subcommand groups are registered here as they are implemented:
-contracts, floe, artifacts, superset, openmetadata, polaris, k8s, e2e.
+contracts, floe, artifacts, revision, superset, openmetadata, polaris, k8s, e2e.
 """
 
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
+import boto3
 import typer
 
 import olf
@@ -26,6 +30,7 @@ app = typer.Typer(
 contracts_app = typer.Typer(help="Provider-contract runtime environment helpers.")
 floe_app = typer.Typer(help="Floe profile and manifest helpers.")
 artifacts_app = typer.Typer(help="Object-storage artifact helpers.")
+revision_app = typer.Typer(help="Immutable Floe runtime-artifact revision helpers.")
 superset_app = typer.Typer(help="Superset report deploy/export helpers.")
 openmetadata_app = typer.Typer(help="OpenMetadata governance metadata helpers.")
 k8s_app = typer.Typer(help="Kubernetes image bookkeeping helpers.")
@@ -34,6 +39,7 @@ e2e_app = typer.Typer(help="End-to-end environment validation.")
 app.add_typer(contracts_app, name="contracts")
 app.add_typer(floe_app, name="floe")
 app.add_typer(artifacts_app, name="artifacts")
+app.add_typer(revision_app, name="revision")
 app.add_typer(superset_app, name="superset")
 app.add_typer(openmetadata_app, name="openmetadata")
 app.add_typer(k8s_app, name="k8s")
@@ -149,6 +155,103 @@ def artifacts_upload_manifests(
         )
     else:
         raise typer.Exit(code=_fail(f"unknown --via mode: {via!r} (expected 'port-forward' or 'direct')."))
+
+
+@revision_app.command("compute")
+def revision_compute(
+    runtime_root: str = typer.Option(..., "--runtime-root", help="Rendered Floe runtime artifact root."),
+) -> None:
+    """Print the deterministic content revision for a rendered artifact set."""
+    from olf import revision
+
+    try:
+        typer.echo(revision.compute_revision(Path(runtime_root)).revision)
+    except revision.RevisionError as exc:
+        raise typer.Exit(code=_fail(str(exc))) from exc
+
+
+@revision_app.command("publish")
+def revision_publish(
+    runtime_root: str = typer.Option(..., "--runtime-root", help="Rendered Floe runtime artifact root."),
+    via: str = typer.Option(
+        "port-forward",
+        "--via",
+        help="'port-forward' for in-cluster S3-compatible storage, 'direct' for cloud S3.",
+    ),
+) -> None:
+    """Publish a revision-qualified artifact set without activating it."""
+    from olf import revision, s3
+
+    uploads = s3.discover_runtime_artifacts(Path(runtime_root))
+    if not uploads:
+        raise typer.Exit(code=_fail(f"no rendered Floe runtime artifacts found under {runtime_root}."))
+    bucket = _artifact_bucket()
+    try:
+        with _artifact_storage_client(via, bucket) as client:
+            manifest = revision.publish(client, bucket, uploads)
+    except revision.RevisionError as exc:
+        raise typer.Exit(code=_fail(str(exc))) from exc
+    typer.echo(f"Published {manifest.revision} to s3://{bucket}/{revision.revision_prefix(manifest.revision)}")
+
+
+@revision_app.command("verify")
+def revision_verify(
+    revision_id: str = typer.Option(..., "--revision", help="Revision to verify, e.g. sha256:<digest>."),
+    via: str = typer.Option(
+        "port-forward",
+        "--via",
+        help="'port-forward' for in-cluster S3-compatible storage, 'direct' for cloud S3.",
+    ),
+) -> None:
+    """Verify an immutable revision sidecar and every object it declares."""
+    from olf import revision
+
+    bucket = _artifact_bucket()
+    try:
+        with _artifact_storage_client(via, bucket) as client:
+            manifest = revision.verify(client, bucket, revision_id)
+    except revision.RevisionError as exc:
+        raise typer.Exit(code=_fail(str(exc))) from exc
+    typer.echo(f"Verified {manifest.revision} ({len(manifest.entries)} artifacts).")
+
+
+def _artifact_bucket() -> str:
+    bucket = config.env("OPENLAKEFORGE_OPS_BUCKET_NAME") or config.env("OPENLAKEFORGE_ARTIFACT_BUCKET_NAME")
+    if not bucket:
+        raise typer.Exit(code=_fail("no ops/artifact bucket resolved from the contract environment."))
+    return bucket
+
+
+@contextmanager
+def _artifact_storage_client(via: str, bucket: str) -> Iterator[Any]:
+    from olf import k8s, s3
+
+    if via == "direct":
+        yield boto3.client("s3", region_name=config.env("OPENLAKEFORGE_STORAGE_REGION") or None)
+        return
+    if via != "port-forward":
+        raise typer.Exit(code=_fail(f"unknown --via mode: {via!r} (expected 'port-forward' or 'direct')."))
+
+    namespace = config.namespace()
+    secret_name = config.env("OPENLAKEFORGE_STORAGE_CREDENTIALS_SECRET_NAME")
+    service = config.env("OPENLAKEFORGE_STORAGE_S3_SERVICE_NAME", "seaweedfs-s3")
+    remote_port = int(config.env("OPENLAKEFORGE_STORAGE_S3_SERVICE_PORT", "8333"))
+    with s3.port_forward_client(
+        bucket,
+        service=service,
+        remote_port=remote_port,
+        namespace=namespace,
+        access_key_id=k8s.secret_value(
+            secret_name, config.env("OPENLAKEFORGE_STORAGE_ACCESS_KEY_ID_KEY", "AWS_ACCESS_KEY_ID"), namespace
+        ),
+        secret_access_key=k8s.secret_value(
+            secret_name,
+            config.env("OPENLAKEFORGE_STORAGE_SECRET_ACCESS_KEY_KEY", "AWS_SECRET_ACCESS_KEY"),
+            namespace,
+        ),
+        region=config.env("OPENLAKEFORGE_STORAGE_REGION", "us-east-1"),
+    ) as client:
+        yield client
 
 
 @superset_app.command("deploy-reports")

--- a/tools/olf/olf/revision.py
+++ b/tools/olf/olf/revision.py
@@ -1,0 +1,196 @@
+"""Immutable Floe runtime-artifact revision publishing.
+
+A revision is a deterministic hash of the rendered Floe config, profile, and
+manifest set. Revisions are written beneath an immutable, revision-qualified
+prefix and are not an activation mechanism: consumers continue using their
+current paths until the runtime-activation change selects a revision.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from botocore.exceptions import BotoCoreError, ClientError
+
+from olf import s3
+
+REVISION_PREFIX = "floe/revisions"
+SIDECAR_NAME = "REVISION.json"
+_REVISION_PATTERN = re.compile(r"^sha256:([0-9a-f]{64})$")
+
+
+class RevisionError(RuntimeError):
+    """A rendered artifact set cannot be published or verified safely."""
+
+
+@dataclass(frozen=True)
+class RevisionManifest:
+    """Aggregate revision and the content hash of each legacy artifact key."""
+
+    revision: str
+    entries: dict[str, str]
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {"revision": self.revision, "entries": dict(sorted(self.entries.items()))},
+            indent=2,
+            sort_keys=True,
+        ) + "\n"
+
+    @classmethod
+    def from_json(cls, value: str) -> RevisionManifest:
+        try:
+            payload = json.loads(value)
+            revision = payload["revision"]
+            entries = payload["entries"]
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise RevisionError(f"malformed {SIDECAR_NAME}: {exc}") from exc
+        if not isinstance(revision, str) or not isinstance(entries, dict) or not all(
+            isinstance(key, str) and isinstance(digest, str) for key, digest in entries.items()
+        ):
+            raise RevisionError(f"malformed {SIDECAR_NAME}: revision and entries must be strings.")
+        manifest = cls(revision=revision, entries=dict(entries))
+        manifest.validate()
+        return manifest
+
+    def validate(self) -> None:
+        _revision_digest(self.revision)
+        actual = aggregate_revision(self.entries)
+        if self.revision != actual:
+            raise RevisionError(
+                f"revision sidecar declares {self.revision}, but its entries aggregate to {actual}."
+            )
+
+
+def _content_hash(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def aggregate_revision(entries: dict[str, str]) -> str:
+    """Return a stable content address for a set of artifact-key digests."""
+    if not entries:
+        raise RevisionError("cannot compute a revision for an empty artifact set.")
+    hasher = hashlib.sha256()
+    for key in sorted(entries):
+        hasher.update(f"{key}\0{entries[key]}\n".encode())
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def manifest_from_uploads(uploads: list[s3.ManifestUpload]) -> RevisionManifest:
+    entries = {upload.key: _content_hash(upload.path.read_bytes()) for upload in uploads}
+    if len(entries) != len(uploads):
+        raise RevisionError("runtime artifact discovery produced duplicate object keys.")
+    return RevisionManifest(revision=aggregate_revision(entries), entries=entries)
+
+
+def compute_revision(runtime_root: Path) -> RevisionManifest:
+    uploads = s3.discover_runtime_artifacts(runtime_root)
+    if not uploads:
+        raise RevisionError(f"no rendered Floe runtime artifacts found under {runtime_root}.")
+    return manifest_from_uploads(uploads)
+
+
+def revision_prefix(revision: str) -> str:
+    return f"{REVISION_PREFIX}/sha256/{_revision_digest(revision)}"
+
+
+def revision_key(revision: str, artifact_key: str) -> str:
+    return f"{revision_prefix(revision)}/{artifact_key}"
+
+
+def sidecar_key(revision: str) -> str:
+    return f"{revision_prefix(revision)}/{SIDECAR_NAME}"
+
+
+def publish(client: Any, bucket: str, uploads: list[s3.ManifestUpload]) -> RevisionManifest:
+    """Publish a content-addressed set without overwriting a different revision.
+
+    A failed or partial publish leaves at most an unreferenced revision prefix;
+    it cannot change the mutable runtime paths used by existing code servers.
+    """
+    manifest = manifest_from_uploads(uploads)
+    for upload in uploads:
+        _publish_immutable(
+            client,
+            bucket,
+            revision_key(manifest.revision, upload.key),
+            upload.path.read_bytes(),
+            content_type=_content_type(upload.path),
+        )
+    _publish_immutable(
+        client,
+        bucket,
+        sidecar_key(manifest.revision),
+        manifest.to_json().encode("utf-8"),
+        content_type="application/json",
+    )
+    return manifest
+
+
+def verify(client: Any, bucket: str, revision: str) -> RevisionManifest:
+    """Verify the immutable sidecar and every object it declares."""
+    key = sidecar_key(revision)
+    manifest = RevisionManifest.from_json(_read_object(client, bucket, key).decode("utf-8"))
+    if manifest.revision != revision:
+        raise RevisionError(f"sidecar at {key} declares {manifest.revision}, not requested {revision}.")
+    for artifact_key, expected_digest in manifest.entries.items():
+        actual_digest = _content_hash(_read_object(client, bucket, revision_key(revision, artifact_key)))
+        if actual_digest != expected_digest:
+            raise RevisionError(
+                f"artifact {artifact_key} in revision {revision} hashes to {actual_digest}, "
+                f"expected {expected_digest}."
+            )
+    return manifest
+
+
+def _revision_digest(revision: str) -> str:
+    match = _REVISION_PATTERN.fullmatch(revision)
+    if not match:
+        raise RevisionError(f"invalid revision {revision!r}; expected sha256:<64 lowercase hex characters>.")
+    return match.group(1)
+
+
+def _read_object(client: Any, bucket: str, key: str) -> bytes:
+    content = _maybe_read_object(client, bucket, key)
+    if content is None:
+        raise RevisionError(f"missing immutable artifact s3://{bucket}/{key}.")
+    return content
+
+
+def _maybe_read_object(client: Any, bucket: str, key: str) -> bytes | None:
+    try:
+        response = client.get_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = str((exc.response.get("Error") or {}).get("Code", ""))
+        if code in {"404", "NoSuchKey", "NotFound"}:
+            return None
+        raise RevisionError(f"failed to read immutable artifact s3://{bucket}/{key}.") from exc
+    except BotoCoreError as exc:
+        raise RevisionError(f"failed to read immutable artifact s3://{bucket}/{key}.") from exc
+    content = response["Body"].read()
+    return content if isinstance(content, bytes) else content.encode("utf-8")
+
+
+def _publish_immutable(client: Any, bucket: str, key: str, content: bytes, *, content_type: str) -> None:
+    existing = _maybe_read_object(client, bucket, key)
+    if existing is None:
+        try:
+            client.put_object(Bucket=bucket, Key=key, Body=content, ContentType=content_type)
+        except (BotoCoreError, ClientError) as exc:
+            raise RevisionError(f"failed to publish immutable artifact s3://{bucket}/{key}.") from exc
+        return
+    if existing != content:
+        raise RevisionError(
+            f"immutable artifact collision at s3://{bucket}/{key}; existing content differs."
+        )
+
+
+def _content_type(path: Path) -> str:
+    if path.suffix == ".json":
+        return "application/json"
+    return "application/x-yaml"

--- a/tools/olf/olf/revision.py
+++ b/tools/olf/olf/revision.py
@@ -29,6 +29,12 @@ class RevisionError(RuntimeError):
 
 
 @dataclass(frozen=True)
+class _ArtifactSnapshot:
+    upload: s3.ManifestUpload
+    content: bytes
+
+
+@dataclass(frozen=True)
 class RevisionManifest:
     """Aggregate revision and the content hash of each legacy artifact key."""
 
@@ -82,8 +88,16 @@ def aggregate_revision(entries: dict[str, str]) -> str:
 
 
 def manifest_from_uploads(uploads: list[s3.ManifestUpload]) -> RevisionManifest:
-    entries = {upload.key: _content_hash(upload.path.read_bytes()) for upload in uploads}
-    if len(entries) != len(uploads):
+    return _manifest_from_snapshots(_snapshot_uploads(uploads))
+
+
+def _snapshot_uploads(uploads: list[s3.ManifestUpload]) -> list[_ArtifactSnapshot]:
+    return [_ArtifactSnapshot(upload=upload, content=upload.path.read_bytes()) for upload in uploads]
+
+
+def _manifest_from_snapshots(snapshots: list[_ArtifactSnapshot]) -> RevisionManifest:
+    entries = {snapshot.upload.key: _content_hash(snapshot.content) for snapshot in snapshots}
+    if len(entries) != len(snapshots):
         raise RevisionError("runtime artifact discovery produced duplicate object keys.")
     return RevisionManifest(revision=aggregate_revision(entries), entries=entries)
 
@@ -113,14 +127,15 @@ def publish(client: Any, bucket: str, uploads: list[s3.ManifestUpload]) -> Revis
     A failed or partial publish leaves at most an unreferenced revision prefix;
     it cannot change the mutable runtime paths used by existing code servers.
     """
-    manifest = manifest_from_uploads(uploads)
-    for upload in uploads:
+    snapshots = _snapshot_uploads(uploads)
+    manifest = _manifest_from_snapshots(snapshots)
+    for snapshot in snapshots:
         _publish_immutable(
             client,
             bucket,
-            revision_key(manifest.revision, upload.key),
-            upload.path.read_bytes(),
-            content_type=_content_type(upload.path),
+            revision_key(manifest.revision, snapshot.upload.key),
+            snapshot.content,
+            content_type=_content_type(snapshot.upload.path),
         )
     _publish_immutable(
         client,

--- a/tools/olf/olf/s3.py
+++ b/tools/olf/olf/s3.py
@@ -8,10 +8,13 @@ the derivation lives here once.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import boto3
 from botocore.config import Config
@@ -122,6 +125,30 @@ def upload_via_port_forward(
     region: str,
 ) -> None:
     """Upload to an in-cluster S3-compatible store through kubectl port-forward."""
+    with port_forward_client(
+        bucket,
+        service=service,
+        remote_port=remote_port,
+        namespace=namespace,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        region=region,
+    ) as client:
+        _put_objects(client, bucket, uploads)
+
+
+@contextlib.contextmanager
+def port_forward_client(
+    bucket: str,
+    *,
+    service: str,
+    remote_port: int,
+    namespace: str,
+    access_key_id: str,
+    secret_access_key: str,
+    region: str,
+) -> Iterator[Any]:
+    """Yield an S3 client connected to in-cluster object storage."""
     log_prefix = os.environ.get("OPENLAKEFORGE_PORT_FORWARD_LOG_PREFIX", "/tmp/openlakeforge")
     log_path = f"{log_prefix}-seaweedfs-port-forward.log"
     with k8s.port_forward(service, remote_port, namespace, log_path=log_path) as local_port:
@@ -135,7 +162,7 @@ def upload_via_port_forward(
             config=Config(s3={"addressing_style": "path"}),
         )
         _wait_for_bucket(client, bucket, endpoint)
-        _put_objects(client, bucket, uploads)
+        yield client
 
 
 def _wait_for_bucket(client, bucket: str, endpoint: str, *, attempts: int = 60, delay: float = 2.0) -> None:

--- a/tools/olf/tests/test_cli.py
+++ b/tools/olf/tests/test_cli.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from typer.testing import CliRunner
 
 import olf
@@ -10,3 +12,14 @@ def test_version_command_prints_package_version() -> None:
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert result.output.strip() == olf.__version__
+
+
+def test_revision_compute_command_prints_runtime_artifact_revision(tmp_path: Path) -> None:
+    path = tmp_path / "manifests/sales/order_revenue/order_revenue.manifest.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{}")
+
+    result = runner.invoke(app, ["revision", "compute", "--runtime-root", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert result.output.startswith("sha256:")

--- a/tools/olf/tests/test_revision.py
+++ b/tools/olf/tests/test_revision.py
@@ -1,0 +1,92 @@
+import io
+import json
+from pathlib import Path
+
+import pytest
+from botocore.exceptions import ClientError
+
+from olf import revision, s3
+
+
+class FakeS3:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+        self.puts: list[tuple[str, str]] = []
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, io.BytesIO]:
+        try:
+            value = self.objects[(Bucket, Key)]
+        except KeyError as exc:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject") from exc
+        return {"Body": io.BytesIO(value)}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes, ContentType: str) -> None:
+        self.objects[(Bucket, Key)] = Body
+        self.puts.append((Bucket, Key))
+
+
+def _uploads(tmp_path: Path) -> list[s3.ManifestUpload]:
+    config = tmp_path / "configs/sales/order_revenue/order_revenue.yml"
+    profile = tmp_path / "profiles/sales/order_revenue/local-k8s.yml"
+    manifest = tmp_path / "manifests/sales/order_revenue/order_revenue.manifest.json"
+    for path, content in [(config, "config"), (profile, "profile"), (manifest, "{}")]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return s3.discover_runtime_artifacts(tmp_path)
+
+
+def test_revision_is_stable_across_upload_order(tmp_path: Path) -> None:
+    uploads = _uploads(tmp_path)
+    original = revision.manifest_from_uploads(uploads).revision
+    reversed_order = revision.manifest_from_uploads(list(reversed(uploads))).revision
+    assert original == reversed_order
+
+
+def test_publish_uses_revision_qualified_keys_and_is_idempotent(tmp_path: Path) -> None:
+    uploads = _uploads(tmp_path)
+    client = FakeS3()
+
+    manifest = revision.publish(client, "ops", uploads)
+    expected_prefix = f"floe/revisions/sha256/{manifest.revision.removeprefix('sha256:')}"
+    assert {key for bucket, key in client.objects if bucket == "ops"} == {
+        f"{expected_prefix}/{upload.key}" for upload in uploads
+    } | {f"{expected_prefix}/REVISION.json"}
+
+    first_put_count = len(client.puts)
+    assert revision.publish(client, "ops", uploads) == manifest
+    assert len(client.puts) == first_put_count
+
+
+def test_publish_refuses_different_existing_content(tmp_path: Path) -> None:
+    uploads = _uploads(tmp_path)
+    client = FakeS3()
+    manifest = revision.manifest_from_uploads(uploads)
+    key = revision.revision_key(manifest.revision, uploads[0].key)
+    client.objects[("ops", key)] = b"tampered"
+
+    with pytest.raises(revision.RevisionError, match="collision"):
+        revision.publish(client, "ops", uploads)
+
+
+def test_verify_detects_tampered_artifact(tmp_path: Path) -> None:
+    uploads = _uploads(tmp_path)
+    client = FakeS3()
+    manifest = revision.publish(client, "ops", uploads)
+    key = revision.revision_key(manifest.revision, uploads[0].key)
+    client.objects[("ops", key)] = b"tampered"
+
+    with pytest.raises(revision.RevisionError, match="hashes to"):
+        revision.verify(client, "ops", manifest.revision)
+
+
+def test_verify_rejects_sidecar_with_inconsistent_aggregate(tmp_path: Path) -> None:
+    uploads = _uploads(tmp_path)
+    client = FakeS3()
+    manifest = revision.publish(client, "ops", uploads)
+    sidecar = revision.sidecar_key(manifest.revision)
+    payload = json.loads(client.objects[("ops", sidecar)])
+    payload["entries"][uploads[0].key] = "0" * 64
+    client.objects[("ops", sidecar)] = json.dumps(payload).encode()
+
+    with pytest.raises(revision.RevisionError, match="aggregate"):
+        revision.verify(client, "ops", manifest.revision)

--- a/tools/olf/tests/test_revision.py
+++ b/tools/olf/tests/test_revision.py
@@ -68,6 +68,28 @@ def test_publish_refuses_different_existing_content(tmp_path: Path) -> None:
         revision.publish(client, "ops", uploads)
 
 
+def test_publish_uses_one_byte_snapshot_per_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    uploads = _uploads(tmp_path)
+    client = FakeS3()
+    target = uploads[0].path
+    original_read_bytes = Path.read_bytes
+    reads = 0
+
+    def changing_read_bytes(path: Path) -> bytes:
+        nonlocal reads
+        if path == target:
+            reads += 1
+            return b"before" if reads == 1 else b"after"
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", changing_read_bytes)
+    manifest = revision.publish(client, "ops", uploads)
+
+    assert reads == 1
+    assert client.objects[("ops", revision.revision_key(manifest.revision, uploads[0].key))] == b"before"
+    assert revision.verify(client, "ops", manifest.revision) == manifest
+
+
 def test_verify_detects_tampered_artifact(tmp_path: Path) -> None:
     uploads = _uploads(tmp_path)
     client = FakeS3()


### PR DESCRIPTION
Part of #19. This is the immutable-publisher phase; runtime activation follows in a separate bounded PR.

## Summary

- adds deterministic content-addressed revisions for rendered Floe configs, profiles, and manifests
- publishes under `floe/revisions/sha256/<digest>/...` with an aggregate sidecar
- refuses conflicting content, verifies the sidecar aggregate and every object, and never activates a published revision
- exposes `olf revision compute|publish|verify` and reuses the port-forward S3 client

## Verification

- `uv run --project tools/olf ruff check tools/olf`
- `uv run --project tools/olf pytest tools/olf/tests` — 121 passed
- `make check-contracts` started after the test suite but was interrupted when a synchronized-workspace file read stalled; CI should rerun this repository check.