### PR TITLE
fix: harden alpha release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,14 @@ permissions:
 env:
   IMAGE_NAMESPACE: ghcr.io/${{ github.repository }}
 
+# A tag push and a non-dry manual dispatch can target the same immutable
+# release tag. They must not concurrently build and retag the versioned images:
+# the generated inputs can differ, leaving the mutable image tag and bundle
+# manifest from separate runs.
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   prepare:
     name: Resolve release version and validate readiness

--- a/tools/olf/olf/release.py
+++ b/tools/olf/olf/release.py
@@ -598,6 +598,58 @@ def _check_dockerfiles_pinned(repo_root: Path) -> CheckResult:
     return CheckResult("Dockerfile base images are digest-pinned", True)
 
 
+def _terraform_lock_provider_versions(lock_path: Path) -> dict[str, str]:
+    """Read provider versions from a Terraform dependency lockfile.
+
+    Terraform lockfiles are HCL rather than TOML. The small, deliberately
+    strict parser below only extracts provider blocks and their exact selected
+    versions, which are the release inputs represented in the component
+    catalog.
+    """
+    provider_blocks = re.finditer(
+        r'^provider\s+"registry\.terraform\.io/(?P<provider>[^"]+)"\s*\{(?P<body>.*?)^\}',
+        lock_path.read_text(),
+        re.MULTILINE | re.DOTALL,
+    )
+    versions: dict[str, str] = {}
+    for block in provider_blocks:
+        version = re.search(r'^\s*version\s*=\s*"(?P<version>[^"]+)"\s*$', block.group("body"), re.MULTILINE)
+        if version is not None:
+            versions[block.group("provider")] = version.group("version")
+    return versions
+
+
+def _check_terraform_lockfiles_synced_with_catalog(
+    repo_root: Path, catalog: dict[str, Any]
+) -> CheckResult:
+    """Ensure cataloged per-root provider versions match Terraform locks.
+
+    Rendering the compatibility matrix from the catalog alone cannot catch a
+    lockfile update that was not copied into the catalog. That would publish a
+    stale value as the target's exact provider version.
+    """
+    terraform = ((catalog.get("components") or {}).get("terraform") or {})
+    catalog_lockfiles = terraform.get("lockfiles") or {}
+    problems: list[str] = []
+    for relative_path, cataloged_versions in sorted(catalog_lockfiles.items()):
+        lock_path = repo_root / relative_path
+        if not lock_path.is_file():
+            problems.append(f"{relative_path} does not exist")
+            continue
+        actual_versions = _terraform_lock_provider_versions(lock_path)
+        expected_versions = cataloged_versions if isinstance(cataloged_versions, dict) else {}
+        for provider in sorted(set(expected_versions) | set(actual_versions)):
+            expected = expected_versions.get(provider)
+            actual = actual_versions.get(provider)
+            if expected != actual:
+                problems.append(
+                    f"{relative_path}: {provider} catalog={expected!r}, lockfile={actual!r}"
+                )
+    if problems:
+        return CheckResult("Terraform lockfiles match the component catalog", False, "; ".join(problems))
+    return CheckResult("Terraform lockfiles match the component catalog", True)
+
+
 def run_release_check(
     repo_root: str | Path = ".",
     *,
@@ -609,8 +661,9 @@ def run_release_check(
     Validates: catalog version matches the tag (when a tag is given), every
     catalog image is digest-pinned, every workflow action is SHA-pinned and
     recorded in the catalog, both lockfiles exist and are non-empty and stay
-    synchronized with their pyproject.toml, and no Dockerfile FROM/ARG is
-    unpinned outside of build-arg indirection.
+    synchronized with their pyproject.toml, cataloged Terraform providers
+    match per-root lockfiles, and no Dockerfile FROM/ARG is unpinned outside
+    of build-arg indirection.
     """
     root = Path(repo_root).resolve()
     catalog = load_catalog(root / catalog_path)
@@ -622,5 +675,6 @@ def run_release_check(
     report.results.append(_check_lockfiles(root, catalog))
     report.results.append(_check_lockfiles_synced_with_pyproject(root, catalog))
     report.results.append(_check_dockerfiles_pinned(root))
+    report.results.append(_check_terraform_lockfiles_synced_with_catalog(root, catalog))
     report.results.append(_check_compatibility_matrix_up_to_date(root, catalog))
     return report

--- a/tools/olf/olf/release.py
+++ b/tools/olf/olf/release.py
@@ -607,7 +607,7 @@ def _terraform_lock_provider_versions(lock_path: Path) -> dict[str, str]:
     catalog.
     """
     provider_blocks = re.finditer(
-        r'^provider\s+"registry\.terraform\.io/(?P<provider>[^"]+)"\s*\{(?P<body>.*?)^\}',
+        r'^provider\s+"(?P<provider>[^"]+)"\s*\{(?P<body>.*?)^\}',
         lock_path.read_text(),
         re.MULTILINE | re.DOTALL,
     )
@@ -615,7 +615,8 @@ def _terraform_lock_provider_versions(lock_path: Path) -> dict[str, str]:
     for block in provider_blocks:
         version = re.search(r'^\s*version\s*=\s*"(?P<version>[^"]+)"\s*$', block.group("body"), re.MULTILINE)
         if version is not None:
-            versions[block.group("provider")] = version.group("version")
+            provider = block.group("provider").removeprefix("registry.terraform.io/")
+            versions[provider] = version.group("version")
     return versions
 
 

--- a/tools/olf/olf/release.py
+++ b/tools/olf/olf/release.py
@@ -631,6 +631,15 @@ def _check_terraform_lockfiles_synced_with_catalog(
     terraform = ((catalog.get("components") or {}).get("terraform") or {})
     catalog_lockfiles = terraform.get("lockfiles") or {}
     problems: list[str] = []
+    lockfile_root = repo_root / "infra" / "terraform"
+    discovered_lockfiles = (
+        {path.relative_to(repo_root).as_posix() for path in lockfile_root.rglob(".terraform.lock.hcl")}
+        if lockfile_root.is_dir()
+        else set()
+    )
+    cataloged_paths = set(catalog_lockfiles)
+    for relative_path in sorted(discovered_lockfiles - cataloged_paths):
+        problems.append(f"{relative_path} is not recorded in components.terraform.lockfiles")
     for relative_path, cataloged_versions in sorted(catalog_lockfiles.items()):
         lock_path = repo_root / relative_path
         if not lock_path.is_file():

--- a/tools/olf/tests/test_release.py
+++ b/tools/olf/tests/test_release.py
@@ -165,6 +165,34 @@ def test_run_release_check_without_tag_only_validates_catalog_shape() -> None:
     assert version_result.ok
 
 
+def test_check_terraform_lockfiles_match_real_catalog() -> None:
+    catalog = release.load_catalog(ROOT / "release/component-catalog.yaml")
+    result = release._check_terraform_lockfiles_synced_with_catalog(ROOT, catalog)
+    assert result.ok, result.detail
+
+
+def test_check_terraform_lockfiles_flags_catalog_drift(tmp_path: Path) -> None:
+    lock_path = tmp_path / "infra/terraform/demo/.terraform.lock.hcl"
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text(
+        'provider "registry.terraform.io/hashicorp/example" {\n'
+        '  version = "1.2.3"\n'
+        '}\n'
+    )
+    catalog = {
+        "components": {
+            "terraform": {
+                "lockfiles": {
+                    "infra/terraform/demo/.terraform.lock.hcl": {"hashicorp/example": "9.9.9"}
+                }
+            }
+        }
+    }
+    result = release._check_terraform_lockfiles_synced_with_catalog(tmp_path, catalog)
+    assert not result.ok
+    assert "catalog='9.9.9', lockfile='1.2.3'" in result.detail
+
+
 def test_check_images_digest_pinned_flags_missing_digest() -> None:
     catalog = {"components": {"images": {"bad": "python:3.12-slim"}}}
     result = release._check_images_digest_pinned(catalog)

--- a/tools/olf/tests/test_release.py
+++ b/tools/olf/tests/test_release.py
@@ -208,6 +208,28 @@ def test_check_terraform_lockfiles_flags_uncataloged_lockfile(tmp_path: Path) ->
     assert "new-root/.terraform.lock.hcl is not recorded" in result.detail
 
 
+def test_check_terraform_lockfiles_detects_uncataloged_nondefault_registry_provider(
+    tmp_path: Path,
+) -> None:
+    lock_path = tmp_path / "infra/terraform/demo/.terraform.lock.hcl"
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text(
+        'provider "registry.example.com/acme/example" {\n'
+        '  version = "1.2.3"\n'
+        '}\n'
+    )
+    catalog = {
+        "components": {
+            "terraform": {
+                "lockfiles": {"infra/terraform/demo/.terraform.lock.hcl": {}}
+            }
+        }
+    }
+    result = release._check_terraform_lockfiles_synced_with_catalog(tmp_path, catalog)
+    assert not result.ok
+    assert "registry.example.com/acme/example catalog=None, lockfile='1.2.3'" in result.detail
+
+
 def test_check_images_digest_pinned_flags_missing_digest() -> None:
     catalog = {"components": {"images": {"bad": "python:3.12-slim"}}}
     result = release._check_images_digest_pinned(catalog)

--- a/tools/olf/tests/test_release.py
+++ b/tools/olf/tests/test_release.py
@@ -193,6 +193,21 @@ def test_check_terraform_lockfiles_flags_catalog_drift(tmp_path: Path) -> None:
     assert "catalog='9.9.9', lockfile='1.2.3'" in result.detail
 
 
+def test_check_terraform_lockfiles_flags_uncataloged_lockfile(tmp_path: Path) -> None:
+    lock_path = tmp_path / "infra/terraform/new-root/.terraform.lock.hcl"
+    lock_path.parent.mkdir(parents=True)
+    lock_path.write_text(
+        'provider "registry.terraform.io/hashicorp/example" {\n'
+        '  version = "1.2.3"\n'
+        '}\n'
+    )
+    result = release._check_terraform_lockfiles_synced_with_catalog(
+        tmp_path, {"components": {"terraform": {"lockfiles": {}}}}
+    )
+    assert not result.ok
+    assert "new-root/.terraform.lock.hcl is not recorded" in result.detail
+
+
 def test_check_images_digest_pinned_flags_missing_digest() -> None:
     catalog = {"components": {"images": {"bad": "python:3.12-slim"}}}
     result = release._check_images_digest_pinned(catalog)


### PR DESCRIPTION
Follow-up to #69, addressing its two remaining release-gate findings.

- serializes release workflows by selected ref/tag, preventing concurrent runs from producing mixed image tags and bundle metadata;
- makes `olf release check` parse each cataloged `.terraform.lock.hcl` and reject missing, extra, or version-drifted provider rows before a compatibility matrix is rendered.

Verification:

- `uv run --project tools/olf ruff check tools/olf`
- `uv run --project tools/olf pytest tools/olf/tests/test_release.py` (37 passed)
- `uv run --project tools/olf olf release check --tag v0.1.0-alpha.1`