### PR TITLE
feat: add slim local profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ site/
 # and stays out of git. Copy the tracked *.tfvars.example templates to your own
 # sandbox.tfvars — see docs/setup/cloud-poc-setup.md.
 !*.tfvars.example
+# The checked-in local slim profile contains no environment-specific values.
+!infra/terraform/environments/local/slim.tfvars
 crash.log
 crash.*.log
 override.tf

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
-.PHONY: help tree check-structure check-components check-contracts check-infra check-project-code check-dbt check-lockfiles release-check release-bundle floe-manifest floe-manifest-upload dbt-parse project-code-image project-code-load superset-image superset-load superset-reports-deploy superset-reports-export openmetadata-metadata-deploy local-foundation-up local-foundation-down local-platform-up local-platform-down local-artifacts-deploy local-up local-down local-status local-forward local-prefetch local-e2e azure-foundation-up azure-platform-up azure-platform-down azure-artifacts-deploy azure-up azure-forward azure-e2e azure-down azure-foundation-down aws-foundation-up aws-platform-up aws-platform-down aws-artifacts-deploy aws-up aws-forward aws-e2e aws-down aws-foundation-down
+.PHONY: help tree check-structure check-components check-contracts check-infra check-project-code check-dbt check-lockfiles release-check release-bundle floe-manifest floe-manifest-upload dbt-parse project-code-image project-code-load superset-image superset-load superset-reports-deploy superset-reports-export openmetadata-metadata-deploy local-foundation-up local-foundation-down local-platform-up local-platform-down local-artifacts-deploy local-up local-down local-status local-forward local-prefetch local-e2e local-slim-platform-up local-slim-artifacts-deploy local-slim-up local-slim-e2e local-slim-down azure-foundation-up azure-platform-up azure-platform-down azure-artifacts-deploy azure-up azure-forward azure-e2e azure-down azure-foundation-down aws-foundation-up aws-platform-up aws-platform-down aws-artifacts-deploy aws-up aws-forward aws-e2e aws-down aws-foundation-down
 
 NAMESPACE ?= lakehouse
 CLUSTER_NAME ?= openlakeforge-local
 KUBE_CONTEXT ?= kind-$(CLUSTER_NAME)
 LOCAL_KUBECONFIG_PATH ?= $(CURDIR)/.tmp/kubeconfigs/local.yaml
+LOCAL_TFVARS_FILE ?=
 PROJECT_CODE_IMAGE_REPOSITORY ?= ghcr.io/openlakeforge/project-code
 PROJECT_CODE_IMAGE_TAG ?= local
 PROJECT_CODE_IMAGE_PULL_POLICY ?= Never
+ENABLE_GOVERNANCE ?= true
+ENABLE_ANALYTICS ?= true
 SUPERSET_IMAGE_REPOSITORY ?= ghcr.io/openlakeforge/superset
 SUPERSET_IMAGE_TAG ?= local
 SUPERSET_IMAGE_PULL_POLICY ?= Never
@@ -67,6 +70,8 @@ help:
 	@printf '%s\n' '  make local-platform-down  Terraform-destroy local lakehouse platform services'
 	@printf '%s\n' '  make local-artifacts-deploy  Deploy dynamic local/CD artifacts'
 	@printf '%s\n' '  make local-up         Full wrapper: foundation, prefetch, platform, artifacts'
+	@printf '%s\n' '  make local-slim-up    Slim wrapper: full data path without OpenMetadata or Superset'
+	@printf '%s\n' '  make local-slim-e2e   Validate the slim profile (reports disabled assertions)'
 	@printf '%s\n' '  make local-down       Full teardown wrapper: platform, foundation'
 	@printf '%s\n' '  make local-status     Show pod and service status in the configured namespace'
 	@printf '%s\n' '  make local-forward    Port-forward all services to localhost (Dagster :3000, Superset :8088, OpenMetadata :8585, Trino :8080, Polaris :8181, S3 :9000, SeaweedFS Filer :8888, Master :9333)'
@@ -161,7 +166,7 @@ local-foundation-down:
 	@NAMESPACE=$(NAMESPACE) CLUSTER_NAME=$(CLUSTER_NAME) KUBE_CONTEXT=$(KUBE_CONTEXT) KUBECONFIG_PATH="$(LOCAL_KUBECONFIG_PATH)" bash scripts/local/foundation/down.sh
 
 local-platform-up:
-	@NAMESPACE=$(NAMESPACE) CLUSTER_NAME=$(CLUSTER_NAME) KUBE_CONTEXT=$(KUBE_CONTEXT) KUBECONFIG_PATH="$(LOCAL_KUBECONFIG_PATH)" DEPLOYMENT_SCOPE=local PROJECT_CODE_IMAGE_REPOSITORY=$(PROJECT_CODE_IMAGE_REPOSITORY) PROJECT_CODE_IMAGE_TAG=$(PROJECT_CODE_IMAGE_TAG) PROJECT_CODE_IMAGE_PULL_POLICY=$(PROJECT_CODE_IMAGE_PULL_POLICY) SUPERSET_IMAGE_REPOSITORY=$(SUPERSET_IMAGE_REPOSITORY) SUPERSET_IMAGE_TAG=$(SUPERSET_IMAGE_TAG) SUPERSET_IMAGE_PULL_POLICY=$(SUPERSET_IMAGE_PULL_POLICY) bash scripts/local/stack/platform-up.sh
+	@NAMESPACE=$(NAMESPACE) CLUSTER_NAME=$(CLUSTER_NAME) KUBE_CONTEXT=$(KUBE_CONTEXT) KUBECONFIG_PATH="$(LOCAL_KUBECONFIG_PATH)" LOCAL_TFVARS_FILE="$(LOCAL_TFVARS_FILE)" DEPLOYMENT_SCOPE=local PROJECT_CODE_IMAGE_REPOSITORY=$(PROJECT_CODE_IMAGE_REPOSITORY) PROJECT_CODE_IMAGE_TAG=$(PROJECT_CODE_IMAGE_TAG) PROJECT_CODE_IMAGE_PULL_POLICY=$(PROJECT_CODE_IMAGE_PULL_POLICY) ENABLE_GOVERNANCE=$(ENABLE_GOVERNANCE) ENABLE_ANALYTICS=$(ENABLE_ANALYTICS) SUPERSET_IMAGE_REPOSITORY=$(SUPERSET_IMAGE_REPOSITORY) SUPERSET_IMAGE_TAG=$(SUPERSET_IMAGE_TAG) SUPERSET_IMAGE_PULL_POLICY=$(SUPERSET_IMAGE_PULL_POLICY) bash scripts/local/stack/platform-up.sh
 
 local-artifacts-deploy:
 	@NAMESPACE=$(NAMESPACE) CLUSTER_NAME=$(CLUSTER_NAME) KUBE_CONTEXT=$(KUBE_CONTEXT) KUBECONFIG_PATH="$(LOCAL_KUBECONFIG_PATH)" DEPLOYMENT_SCOPE=local PROJECT_CODE_IMAGE_REPOSITORY=$(PROJECT_CODE_IMAGE_REPOSITORY) PROJECT_CODE_IMAGE_TAG=$(PROJECT_CODE_IMAGE_TAG) bash scripts/local/stack/deploy-artifacts.sh
@@ -172,12 +177,30 @@ local-up:
 	@$(MAKE) local-platform-up
 	@$(MAKE) local-artifacts-deploy
 
+local-slim-platform-up:
+	@$(MAKE) local-platform-up LOCAL_TFVARS_FILE=infra/terraform/environments/local/slim.tfvars ENABLE_GOVERNANCE=false ENABLE_ANALYTICS=false
+
+local-slim-artifacts-deploy:
+	@$(MAKE) local-artifacts-deploy ENABLE_GOVERNANCE=false ENABLE_ANALYTICS=false
+
+local-slim-up:
+	@$(MAKE) local-foundation-up
+	@$(MAKE) local-prefetch ENABLE_GOVERNANCE=false ENABLE_ANALYTICS=false
+	@$(MAKE) local-slim-platform-up
+	@$(MAKE) local-slim-artifacts-deploy
+
+local-slim-e2e:
+	@$(MAKE) local-e2e ENABLE_GOVERNANCE=false ENABLE_ANALYTICS=false
+
+local-slim-down:
+	@$(MAKE) local-down LOCAL_TFVARS_FILE=infra/terraform/environments/local/slim.tfvars
+
 local-down:
 	@$(MAKE) local-platform-down
 	@$(MAKE) local-foundation-down
 
 local-platform-down:
-	@NAMESPACE=$(NAMESPACE) CLUSTER_NAME=$(CLUSTER_NAME) KUBE_CONTEXT=$(KUBE_CONTEXT) KUBECONFIG_PATH="$(LOCAL_KUBECONFIG_PATH)" bash scripts/local/stack/teardown.sh
+	@NAMESPACE=$(NAMESPACE) CLUSTER_NAME=$(CLUSTER_NAME) KUBE_CONTEXT=$(KUBE_CONTEXT) KUBECONFIG_PATH="$(LOCAL_KUBECONFIG_PATH)" LOCAL_TFVARS_FILE="$(LOCAL_TFVARS_FILE)" bash scripts/local/stack/teardown.sh
 
 local-status:
 	@echo "=== Pods ===" && KUBECONFIG="$(LOCAL_KUBECONFIG_PATH)" kubectl --context $(KUBE_CONTEXT) get pods -n $(NAMESPACE)
@@ -186,7 +209,7 @@ local-status:
 
 local-prefetch:
 	@echo "Pre-pulling heavy images into kind to avoid Helm timeouts..."
-	@CLUSTER_NAME=$(CLUSTER_NAME) bash scripts/local/cluster/prefetch-images.sh
+	@CLUSTER_NAME=$(CLUSTER_NAME) ENABLE_GOVERNANCE=$(ENABLE_GOVERNANCE) ENABLE_ANALYTICS=$(ENABLE_ANALYTICS) bash scripts/local/cluster/prefetch-images.sh
 
 local-forward:
 	@echo "Starting port-forwards (Ctrl-C to stop all)..."
@@ -227,7 +250,7 @@ azure-foundation-up:
 	@AZURE_TFVARS_FILE="$(AZURE_TFVARS_FILE)" AZURE_CLUSTER_NAME=$(AZURE_CLUSTER_NAME) AZURE_NODE_COUNT=$(AZURE_NODE_COUNT) AZURE_ACR_NAME_PREFIX=$(AZURE_ACR_NAME_PREFIX) KUBECONFIG_PATH="$(AZURE_KUBECONFIG_PATH)" bash scripts/azure/foundation/up.sh
 
 azure-platform-up:
-	@NAMESPACE=$(NAMESPACE) AZURE_CLUSTER_NAME=$(AZURE_CLUSTER_NAME) KUBE_CONTEXT=$(AZURE_KUBE_CONTEXT) KUBECONFIG_PATH="$(AZURE_KUBECONFIG_PATH)" DEPLOYMENT_SCOPE=azure AZURE_IMAGE_TAG=$(AZURE_IMAGE_TAG) PROJECT_CODE_IMAGE_REPOSITORY="$(AZURE_PROJECT_CODE_IMAGE_REPOSITORY)" PROJECT_CODE_IMAGE_TAG="$(AZURE_PROJECT_CODE_IMAGE_TAG)" PROJECT_CODE_IMAGE_PULL_POLICY=Always SUPERSET_IMAGE_REPOSITORY="$(AZURE_SUPERSET_IMAGE_REPOSITORY)" SUPERSET_IMAGE_TAG="$(AZURE_SUPERSET_IMAGE_TAG)" SUPERSET_IMAGE_PULL_POLICY=Always bash scripts/azure/stack/platform-up.sh
+	@NAMESPACE=$(NAMESPACE) AZURE_CLUSTER_NAME=$(AZURE_CLUSTER_NAME) KUBE_CONTEXT=$(AZURE_KUBE_CONTEXT) KUBECONFIG_PATH="$(AZURE_KUBECONFIG_PATH)" DEPLOYMENT_SCOPE=azure AZURE_IMAGE_TAG=$(AZURE_IMAGE_TAG) PROJECT_CODE_IMAGE_REPOSITORY="$(AZURE_PROJECT_CODE_IMAGE_REPOSITORY)" PROJECT_CODE_IMAGE_TAG="$(AZURE_PROJECT_CODE_IMAGE_TAG)" PROJECT_CODE_IMAGE_PULL_POLICY=Always ENABLE_GOVERNANCE=$(ENABLE_GOVERNANCE) ENABLE_ANALYTICS=$(ENABLE_ANALYTICS) SUPERSET_IMAGE_REPOSITORY="$(AZURE_SUPERSET_IMAGE_REPOSITORY)" SUPERSET_IMAGE_TAG="$(AZURE_SUPERSET_IMAGE_TAG)" SUPERSET_IMAGE_PULL_POLICY=Always bash scripts/azure/stack/platform-up.sh
 
 azure-artifacts-deploy:
 	@NAMESPACE=$(NAMESPACE) AZURE_CLUSTER_NAME=$(AZURE_CLUSTER_NAME) KUBE_CONTEXT=$(AZURE_KUBE_CONTEXT) KUBECONFIG_PATH="$(AZURE_KUBECONFIG_PATH)" DEPLOYMENT_SCOPE=azure AZURE_IMAGE_TAG=$(AZURE_IMAGE_TAG) PROJECT_CODE_IMAGE_REPOSITORY="$(AZURE_PROJECT_CODE_IMAGE_REPOSITORY)" PROJECT_CODE_IMAGE_TAG="$(AZURE_PROJECT_CODE_IMAGE_TAG)" bash scripts/azure/stack/deploy-artifacts.sh
@@ -281,7 +304,7 @@ aws-foundation-up:
 	@AWS_REGION=$(AWS_REGION) AWS_CLUSTER_NAME=$(AWS_CLUSTER_NAME) AWS_NODE_DESIRED_SIZE=$(AWS_NODE_DESIRED_SIZE) AWS_NODE_MIN_SIZE=$(AWS_NODE_MIN_SIZE) AWS_NODE_MAX_SIZE=$(AWS_NODE_MAX_SIZE) AWS_NODE_INSTANCE_TYPES=$(AWS_NODE_INSTANCE_TYPES) KUBECONFIG_PATH="$(AWS_KUBECONFIG_PATH)" bash scripts/aws/foundation/up.sh
 
 aws-platform-up:
-	@NAMESPACE=$(NAMESPACE) AWS_REGION=$(AWS_REGION) AWS_CLUSTER_NAME=$(AWS_CLUSTER_NAME) KUBE_CONTEXT=$(AWS_KUBE_CONTEXT) KUBECONFIG_PATH="$(AWS_KUBECONFIG_PATH)" DEPLOYMENT_SCOPE=aws AWS_IMAGE_TAG=$(AWS_IMAGE_TAG) PROJECT_CODE_IMAGE_REPOSITORY="$(AWS_PROJECT_CODE_IMAGE_REPOSITORY)" PROJECT_CODE_IMAGE_TAG="$(AWS_PROJECT_CODE_IMAGE_TAG)" PROJECT_CODE_IMAGE_PULL_POLICY=Always SUPERSET_IMAGE_REPOSITORY="$(AWS_SUPERSET_IMAGE_REPOSITORY)" SUPERSET_IMAGE_TAG="$(AWS_SUPERSET_IMAGE_TAG)" SUPERSET_IMAGE_PULL_POLICY=Always bash scripts/aws/stack/platform-up.sh
+	@NAMESPACE=$(NAMESPACE) AWS_REGION=$(AWS_REGION) AWS_CLUSTER_NAME=$(AWS_CLUSTER_NAME) KUBE_CONTEXT=$(AWS_KUBE_CONTEXT) KUBECONFIG_PATH="$(AWS_KUBECONFIG_PATH)" DEPLOYMENT_SCOPE=aws AWS_IMAGE_TAG=$(AWS_IMAGE_TAG) PROJECT_CODE_IMAGE_REPOSITORY="$(AWS_PROJECT_CODE_IMAGE_REPOSITORY)" PROJECT_CODE_IMAGE_TAG="$(AWS_PROJECT_CODE_IMAGE_TAG)" PROJECT_CODE_IMAGE_PULL_POLICY=Always ENABLE_GOVERNANCE=$(ENABLE_GOVERNANCE) ENABLE_ANALYTICS=$(ENABLE_ANALYTICS) SUPERSET_IMAGE_REPOSITORY="$(AWS_SUPERSET_IMAGE_REPOSITORY)" SUPERSET_IMAGE_TAG="$(AWS_SUPERSET_IMAGE_TAG)" SUPERSET_IMAGE_PULL_POLICY=Always bash scripts/aws/stack/platform-up.sh
 
 aws-artifacts-deploy:
 	@NAMESPACE=$(NAMESPACE) AWS_REGION=$(AWS_REGION) AWS_CLUSTER_NAME=$(AWS_CLUSTER_NAME) KUBE_CONTEXT=$(AWS_KUBE_CONTEXT) KUBECONFIG_PATH="$(AWS_KUBECONFIG_PATH)" DEPLOYMENT_SCOPE=aws AWS_IMAGE_TAG=$(AWS_IMAGE_TAG) PROJECT_CODE_IMAGE_REPOSITORY="$(AWS_PROJECT_CODE_IMAGE_REPOSITORY)" PROJECT_CODE_IMAGE_TAG="$(AWS_PROJECT_CODE_IMAGE_TAG)" bash scripts/aws/stack/deploy-artifacts.sh

--- a/README.md
+++ b/README.md
@@ -286,11 +286,11 @@ The slim profile is defined by
 [`infra/terraform/environments/local/slim.tfvars`](infra/terraform/environments/local/slim.tfvars).
 It sets `enable_governance = false` and `enable_analytics = false`; both
 variables default to `true` in every environment, so `make local-up` is
-unchanged. It also disables the otherwise idle Dagster background daemon. The
-profile has no schedules or sensors, and its E2E suite launches product runs
-directly through Dagster. Its wrapper skips Superset image prefetch/build and
-its dynamic Superset/OpenMetadata artifact imports while preserving the
-foundation, platform, and artifact phases.
+unchanged. Dagster's background daemon remains enabled so its queued run
+coordinator can launch the product runs submitted by the E2E suite. Its wrapper
+skips Superset image prefetch/build and its dynamic Superset/OpenMetadata
+artifact imports while preserving the foundation, platform, and artifact
+phases.
 
 Validate the slim profile with:
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,46 @@ make local-up
 Use `make local-platform-up` or `make local-artifacts-deploy` directly when you
 only need to refresh one phase.
 
+### Choose a Local Profile
+
+The default full profile keeps the complete evaluation experience: governance
+in OpenMetadata and dashboards in Superset. The slim profile retains the same
+ingestion-to-Gold data path, but omits both optional layers. It is intended for
+teams that want to evaluate a Gold table and query it before adding catalog and
+dashboard services.
+
+| Profile | Command | Enabled layers | Steady-state pods | Requested memory |
+| --- | --- | --- | ---: | ---: |
+| Full (default) | `make local-up` | OpenMetadata and Superset | 15 | 8,320Mi (8.13Gi) |
+| Slim | `make local-slim-up` | Neither | 9 | 4,096Mi (4.00Gi) |
+
+The figures above are steady-state Kubernetes **container memory requests**,
+not host RAM or transient bootstrap Jobs. The full value was measured from a
+running local cluster; the slim value is the sum of the rendered slim pod
+requests. Both were recorded on 2026-08-12. The full profile still benefits
+from the 6 CPU / 12Gi Colima allocation shown above because kind, Kubernetes,
+images, and workload limits add host overhead.
+
+The slim profile is defined by
+[`infra/terraform/environments/local/slim.tfvars`](infra/terraform/environments/local/slim.tfvars).
+It sets `enable_governance = false` and `enable_analytics = false`; both
+variables default to `true` in every environment, so `make local-up` is
+unchanged. It also disables the otherwise idle Dagster background daemon. The
+profile has no schedules or sensors, and its E2E suite launches product runs
+directly through Dagster. Its wrapper skips Superset image prefetch/build and
+its dynamic Superset/OpenMetadata artifact imports while preserving the
+foundation, platform, and artifact phases.
+
+Validate the slim profile with:
+
+```sh
+make local-slim-e2e
+```
+
+It launches every product pipeline and checks Silver, Gold, Trino, and
+ops-bucket artifacts. It reports the Superset and OpenMetadata assertions as
+skipped. Tear it down with `make local-slim-down`.
+
 Check the cluster at any point with:
 
 ```sh

--- a/infra/terraform/environments/aws-poc/contracts.tf
+++ b/infra/terraform/environments/aws-poc/contracts.tf
@@ -105,25 +105,27 @@ locals {
     }
   })
 
-  governance_contract = merge(module.openmetadata.contract, {
+  governance_contract = merge(var.enable_governance ? module.openmetadata[0].contract : {}, {
+    enabled        = var.enable_governance
     provider       = local.aws_provider_name
     implementation = "governance.openmetadata_on_eks"
     adapter        = "governance.openmetadata_on_eks"
     logical_name   = "governance_catalog"
     auth_mode      = "local-development"
-    endpoint       = "http://${module.openmetadata.contract.service_name}:${module.openmetadata.contract.http_port}"
+    endpoint       = var.enable_governance ? "http://${module.openmetadata[0].contract.service_name}:${module.openmetadata[0].contract.http_port}" : null
     ingress_mode   = "cluster-internal"
     local_only     = false
     poc_only       = true
   })
 
-  reporting_contract = merge(module.superset.contract, {
+  reporting_contract = merge(var.enable_analytics ? module.superset[0].contract : {}, {
+    enabled        = var.enable_analytics
     provider       = local.aws_provider_name
     implementation = "reporting.superset_on_eks"
     adapter        = "reporting.superset_on_eks"
     logical_name   = "bi_reporting"
     auth_mode      = "local-development"
-    endpoint       = "http://${module.superset.contract.service_name}:${module.superset.contract.http_port}"
+    endpoint       = var.enable_analytics ? "http://${module.superset[0].contract.service_name}:${module.superset[0].contract.http_port}" : null
     ingress_mode   = "cluster-internal"
     local_only     = false
     poc_only       = true

--- a/infra/terraform/environments/aws-poc/main.tf
+++ b/infra/terraform/environments/aws-poc/main.tf
@@ -160,6 +160,8 @@ module "rds_postgresql" {
   subnet_ids          = local.foundation_contract.subnet_ids
   allowed_cidr_blocks = [local.foundation_contract.vpc_cidr_block]
   instance_class      = var.rds_instance_class
+  enable_openmetadata = var.enable_governance
+  enable_superset     = var.enable_analytics
 
   depends_on = [
     kubernetes_namespace_v1.lakehouse,
@@ -282,6 +284,7 @@ module "trino" {
 
 module "openmetadata" {
   source = "../../modules/governance/openmetadata"
+  count  = var.enable_governance ? 1 : 0
 
   namespace                   = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file            = "${path.root}/../../../helm/values/local/openmetadata.yaml"
@@ -304,6 +307,7 @@ module "openmetadata" {
 
 module "superset" {
   source = "../../modules/analytics/superset"
+  count  = var.enable_analytics ? 1 : 0
 
   namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file    = "${path.root}/../../../helm/values/local/superset.yaml"
@@ -316,6 +320,16 @@ module "superset" {
     module.rds_postgresql,
     module.trino,
   ]
+}
+
+moved {
+  from = module.openmetadata
+  to   = module.openmetadata[0]
+}
+
+moved {
+  from = module.superset
+  to   = module.superset[0]
 }
 
 module "dagster" {

--- a/infra/terraform/environments/aws-poc/variables.tf
+++ b/infra/terraform/environments/aws-poc/variables.tf
@@ -94,6 +94,18 @@ variable "project_code_image_revision" {
   default     = "manual"
 }
 
+variable "enable_governance" {
+  description = "Whether to deploy the OpenMetadata governance layer and its supporting credentials."
+  type        = bool
+  default     = true
+}
+
+variable "enable_analytics" {
+  description = "Whether to deploy the Superset analytics layer and its supporting credentials."
+  type        = bool
+  default     = true
+}
+
 variable "superset_image_repository" {
   description = "Superset image repository used by the AWS POC Superset Helm release."
   type        = string

--- a/infra/terraform/environments/azure-poc/contracts.tf
+++ b/infra/terraform/environments/azure-poc/contracts.tf
@@ -109,25 +109,27 @@ locals {
     }
   })
 
-  governance_contract = merge(module.openmetadata.contract, {
+  governance_contract = merge(var.enable_governance ? module.openmetadata[0].contract : {}, {
+    enabled        = var.enable_governance
     provider       = local.azure_provider_name
     implementation = "governance.openmetadata_on_aks"
     adapter        = "governance.openmetadata_on_aks"
     logical_name   = "governance_catalog"
     auth_mode      = "local-development"
-    endpoint       = "http://${module.openmetadata.contract.service_name}:${module.openmetadata.contract.http_port}"
+    endpoint       = var.enable_governance ? "http://${module.openmetadata[0].contract.service_name}:${module.openmetadata[0].contract.http_port}" : null
     ingress_mode   = "cluster-internal"
     local_only     = false
     poc_only       = true
   })
 
-  reporting_contract = merge(module.superset.contract, {
+  reporting_contract = merge(var.enable_analytics ? module.superset[0].contract : {}, {
+    enabled        = var.enable_analytics
     provider       = local.azure_provider_name
     implementation = "reporting.superset_on_aks"
     adapter        = "reporting.superset_on_aks"
     logical_name   = "bi_reporting"
     auth_mode      = "local-development"
-    endpoint       = "http://${module.superset.contract.service_name}:${module.superset.contract.http_port}"
+    endpoint       = var.enable_analytics ? "http://${module.superset[0].contract.service_name}:${module.superset[0].contract.http_port}" : null
     ingress_mode   = "cluster-internal"
     local_only     = false
     poc_only       = true

--- a/infra/terraform/environments/azure-poc/main.tf
+++ b/infra/terraform/environments/azure-poc/main.tf
@@ -91,7 +91,9 @@ resource "kubernetes_namespace_v1" "lakehouse" {
 module "postgresql" {
   source = "../../modules/storage/postgresql"
 
-  namespace = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  enable_openmetadata = var.enable_governance
+  enable_superset     = var.enable_analytics
 }
 
 module "seaweedfs" {
@@ -144,6 +146,7 @@ module "trino" {
 
 module "openmetadata" {
   source = "../../modules/governance/openmetadata"
+  count  = var.enable_governance ? 1 : 0
 
   namespace            = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file     = "${path.root}/../../../helm/values/local/openmetadata.yaml"
@@ -162,6 +165,7 @@ module "openmetadata" {
 
 module "superset" {
   source = "../../modules/analytics/superset"
+  count  = var.enable_analytics ? 1 : 0
 
   namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file    = "${path.root}/../../../helm/values/local/superset.yaml"
@@ -174,6 +178,16 @@ module "superset" {
     module.postgresql,
     module.trino,
   ]
+}
+
+moved {
+  from = module.openmetadata
+  to   = module.openmetadata[0]
+}
+
+moved {
+  from = module.superset
+  to   = module.superset[0]
 }
 
 module "dagster" {

--- a/infra/terraform/environments/azure-poc/variables.tf
+++ b/infra/terraform/environments/azure-poc/variables.tf
@@ -82,6 +82,18 @@ variable "project_code_image_revision" {
   default     = "manual"
 }
 
+variable "enable_governance" {
+  description = "Whether to deploy the OpenMetadata governance layer and its supporting credentials."
+  type        = bool
+  default     = true
+}
+
+variable "enable_analytics" {
+  description = "Whether to deploy the Superset analytics layer and its supporting credentials."
+  type        = bool
+  default     = true
+}
+
 variable "superset_image_repository" {
   description = "Superset image repository used by the Azure POC Superset Helm release."
   type        = string

--- a/infra/terraform/environments/local/contracts.tf
+++ b/infra/terraform/environments/local/contracts.tf
@@ -104,24 +104,26 @@ locals {
     }
   })
 
-  governance_contract = merge(module.openmetadata.contract, {
+  governance_contract = merge(var.enable_governance ? module.openmetadata[0].contract : {}, {
+    enabled        = var.enable_governance
     provider       = local.local_provider_name
     implementation = "governance.openmetadata"
     adapter        = "governance.openmetadata"
     logical_name   = "governance_catalog"
     auth_mode      = "local-development"
-    endpoint       = "http://${module.openmetadata.contract.service_name}:${module.openmetadata.contract.http_port}"
+    endpoint       = var.enable_governance ? "http://${module.openmetadata[0].contract.service_name}:${module.openmetadata[0].contract.http_port}" : null
     ingress_mode   = "cluster-internal"
     local_only     = true
   })
 
-  reporting_contract = merge(module.superset.contract, {
+  reporting_contract = merge(var.enable_analytics ? module.superset[0].contract : {}, {
+    enabled        = var.enable_analytics
     provider       = local.local_provider_name
     implementation = "reporting.superset"
     adapter        = "reporting.superset"
     logical_name   = "bi_reporting"
     auth_mode      = "local-development"
-    endpoint       = "http://${module.superset.contract.service_name}:${module.superset.contract.http_port}"
+    endpoint       = var.enable_analytics ? "http://${module.superset[0].contract.service_name}:${module.superset[0].contract.http_port}" : null
     ingress_mode   = "cluster-internal"
     local_only     = true
   })

--- a/infra/terraform/environments/local/main.tf
+++ b/infra/terraform/environments/local/main.tf
@@ -202,7 +202,6 @@ module "dagster" {
   catalog_contract               = local.catalog_contract
   governance_contract            = local.governance_contract
   postgresql_contract            = local.metadata_database_contract
-  enable_daemon                  = var.enable_dagster_daemon
   code_locations                 = local.orchestration_contract.code_locations
   floe_manifest_base_uri         = local.artifact_bucket_contract.base_uri
   floe_manifest_access_mode      = local.artifact_bucket_contract.access_mode

--- a/infra/terraform/environments/local/main.tf
+++ b/infra/terraform/environments/local/main.tf
@@ -91,7 +91,9 @@ resource "kubernetes_namespace_v1" "lakehouse" {
 module "postgresql" {
   source = "../../modules/storage/postgresql"
 
-  namespace = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  enable_openmetadata = var.enable_governance
+  enable_superset     = var.enable_analytics
 }
 
 module "seaweedfs" {
@@ -144,6 +146,7 @@ module "trino" {
 
 module "openmetadata" {
   source = "../../modules/governance/openmetadata"
+  count  = var.enable_governance ? 1 : 0
 
   namespace            = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file     = "${path.root}/../../../helm/values/local/openmetadata.yaml"
@@ -162,6 +165,7 @@ module "openmetadata" {
 
 module "superset" {
   source = "../../modules/analytics/superset"
+  count  = var.enable_analytics ? 1 : 0
 
   namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file    = "${path.root}/../../../helm/values/local/superset.yaml"
@@ -173,6 +177,16 @@ module "superset" {
     module.postgresql,
     module.trino,
   ]
+}
+
+moved {
+  from = module.openmetadata
+  to   = module.openmetadata[0]
+}
+
+moved {
+  from = module.superset
+  to   = module.superset[0]
 }
 
 module "dagster" {
@@ -188,6 +202,7 @@ module "dagster" {
   catalog_contract               = local.catalog_contract
   governance_contract            = local.governance_contract
   postgresql_contract            = local.metadata_database_contract
+  enable_daemon                  = var.enable_dagster_daemon
   code_locations                 = local.orchestration_contract.code_locations
   floe_manifest_base_uri         = local.artifact_bucket_contract.base_uri
   floe_manifest_access_mode      = local.artifact_bucket_contract.access_mode

--- a/infra/terraform/environments/local/slim.tfvars
+++ b/infra/terraform/environments/local/slim.tfvars
@@ -2,6 +2,3 @@
 # while omitting optional governance and dashboard layers.
 enable_governance = false
 enable_analytics  = false
-# Product pipelines are launched directly by e2e; this stack has no schedules
-# or sensors that require the background Dagster scheduler/run-queue daemon.
-enable_dagster_daemon = false

--- a/infra/terraform/environments/local/slim.tfvars
+++ b/infra/terraform/environments/local/slim.tfvars
@@ -1,0 +1,7 @@
+# Fastest local evaluation path: retain the full ingestion-to-Gold data path
+# while omitting optional governance and dashboard layers.
+enable_governance = false
+enable_analytics  = false
+# Product pipelines are launched directly by e2e; this stack has no schedules
+# or sensors that require the background Dagster scheduler/run-queue daemon.
+enable_dagster_daemon = false

--- a/infra/terraform/environments/local/variables.tf
+++ b/infra/terraform/environments/local/variables.tf
@@ -94,12 +94,6 @@ variable "enable_analytics" {
   default     = true
 }
 
-variable "enable_dagster_daemon" {
-  description = "Whether to deploy Dagster's background scheduler and run-queue daemon."
-  type        = bool
-  default     = true
-}
-
 variable "superset_image_repository" {
   description = "Superset image repository used by the local Superset Helm release."
   type        = string

--- a/infra/terraform/environments/local/variables.tf
+++ b/infra/terraform/environments/local/variables.tf
@@ -82,6 +82,24 @@ variable "project_code_image_revision" {
   default     = "manual"
 }
 
+variable "enable_governance" {
+  description = "Whether to deploy the OpenMetadata governance layer and its supporting credentials."
+  type        = bool
+  default     = true
+}
+
+variable "enable_analytics" {
+  description = "Whether to deploy the Superset analytics layer and its supporting credentials."
+  type        = bool
+  default     = true
+}
+
+variable "enable_dagster_daemon" {
+  description = "Whether to deploy Dagster's background scheduler and run-queue daemon."
+  type        = bool
+  default     = true
+}
+
 variable "superset_image_repository" {
   description = "Superset image repository used by the local Superset Helm release."
   type        = string

--- a/infra/terraform/modules/orchestration/dagster/main.tf
+++ b/infra/terraform/modules/orchestration/dagster/main.tf
@@ -364,7 +364,6 @@ resource "helm_release" "dagster" {
       }
 
       dagsterDaemon = {
-        enabled = var.enable_daemon
         image = {
           repository = var.project_code_image_repository
           tag        = var.project_code_image_tag

--- a/infra/terraform/modules/orchestration/dagster/main.tf
+++ b/infra/terraform/modules/orchestration/dagster/main.tf
@@ -1,9 +1,10 @@
 locals {
-  catalog_type     = coalesce(try(var.catalog_contract.catalog_type, null), "rest")
-  catalog_provider = coalesce(try(var.catalog_contract.catalog_provider, null), "polaris")
-  catalog_name     = coalesce(try(var.catalog_contract.catalog_name, null), try(var.catalog_contract.warehouse, null), "lakehouse_dev")
-  runtime_profile  = coalesce(try(var.catalog_contract.runtime_profile, null), "polaris-rest")
-  dbt_profile_env  = local.catalog_type == "glue" && local.catalog_provider == "aws-glue" ? "aws" : (try(var.storage_contract.provider, null) == "azure" ? "azure" : "local")
+  catalog_type       = coalesce(try(var.catalog_contract.catalog_type, null), "rest")
+  catalog_provider   = coalesce(try(var.catalog_contract.catalog_provider, null), "polaris")
+  catalog_name       = coalesce(try(var.catalog_contract.catalog_name, null), try(var.catalog_contract.warehouse, null), "lakehouse_dev")
+  runtime_profile    = coalesce(try(var.catalog_contract.runtime_profile, null), "polaris-rest")
+  dbt_profile_env    = local.catalog_type == "glue" && local.catalog_provider == "aws-glue" ? "aws" : (try(var.storage_contract.provider, null) == "azure" ? "azure" : "local")
+  governance_enabled = try(var.governance_contract.enabled, true)
 
   storage_env = concat(
     [
@@ -195,7 +196,7 @@ locals {
     },
   ] : []
 
-  dbt_env = [
+  dbt_env = concat([
     {
       name  = "OPENLAKEFORGE_DBT_PROFILE_ENV"
       value = local.dbt_profile_env
@@ -213,6 +214,11 @@ locals {
       value = "openlakeforge-dbt"
     },
     {
+      name  = "OPENLAKEFORGE_POSTGRES_SSL_MODE"
+      value = var.postgresql_ssl_mode
+    },
+    ], local.governance_enabled ? [
+    {
       name  = "OPENLINEAGE_URL"
       value = "http://openmetadata:${try(var.governance_contract.http_port, 8585)}"
     },
@@ -224,13 +230,9 @@ locals {
       name  = "OPENLINEAGE_NAMESPACE"
       value = "dagster"
     },
-    {
-      name  = "OPENLAKEFORGE_POSTGRES_SSL_MODE"
-      value = var.postgresql_ssl_mode
-    },
-  ]
+  ] : [])
 
-  dbt_secret_env = [
+  dbt_secret_env = local.governance_enabled ? [
     {
       name = "OPENLINEAGE_API_KEY"
       valueFrom = {
@@ -240,7 +242,7 @@ locals {
         }
       }
     },
-  ]
+  ] : []
 
   runtime_env = concat(local.storage_env, local.artifact_env, local.generic_catalog_env, local.glue_catalog_env, local.polaris_catalog_env, local.dbt_env, local.dbt_secret_env)
 
@@ -299,7 +301,7 @@ locals {
         name = var.catalog_contract.floe_credentials_secret_name
       },
     ],
-    var.governance_contract.ingestion_bot_secret_name == null ? [] : [
+    !local.governance_enabled || try(var.governance_contract.ingestion_bot_secret_name, null) == null ? [] : [
       {
         name = var.governance_contract.ingestion_bot_secret_name
       },
@@ -362,6 +364,7 @@ resource "helm_release" "dagster" {
       }
 
       dagsterDaemon = {
+        enabled = var.enable_daemon
         image = {
           repository = var.project_code_image_repository
           tag        = var.project_code_image_tag

--- a/infra/terraform/modules/orchestration/dagster/variables.tf
+++ b/infra/terraform/modules/orchestration/dagster/variables.tf
@@ -199,18 +199,25 @@ variable "postgresql_ssl_mode" {
 }
 
 variable "governance_contract" {
-  description = "OpenMetadata governance contract passed from the governance module."
+  description = "Optional OpenMetadata governance contract passed from the environment contract."
   type = object({
+    enabled                   = optional(bool, true)
     service_name              = optional(string)
     http_port                 = optional(number)
-    ingestion_bot_secret_name = string
-    ingestion_bot_jwt_key     = string
+    ingestion_bot_secret_name = optional(string)
+    ingestion_bot_jwt_key     = optional(string)
     provider                  = optional(string)
     implementation            = optional(string)
     auth_mode                 = optional(string)
     endpoint                  = optional(string)
     ingress_mode              = optional(string)
   })
+}
+
+variable "enable_daemon" {
+  description = "Whether to run Dagster's background scheduler and run-queue daemon."
+  type        = bool
+  default     = true
 }
 
 variable "service_account_annotations" {

--- a/infra/terraform/modules/orchestration/dagster/variables.tf
+++ b/infra/terraform/modules/orchestration/dagster/variables.tf
@@ -214,12 +214,6 @@ variable "governance_contract" {
   })
 }
 
-variable "enable_daemon" {
-  description = "Whether to run Dagster's background scheduler and run-queue daemon."
-  type        = bool
-  default     = true
-}
-
 variable "service_account_annotations" {
   description = "Optional annotations for Dagster service accounts, used by AWS workload identity integrations."
   type        = map(string)

--- a/infra/terraform/modules/storage/postgresql/main.tf
+++ b/infra/terraform/modules/storage/postgresql/main.tf
@@ -58,27 +58,35 @@ locals {
     create_or_update_role "$DAGSTER_DB_USER" "$DAGSTER_DB_PASSWORD"
     create_database_if_missing "$DAGSTER_DB_NAME" "$DAGSTER_DB_USER"
 
+    ${var.enable_openmetadata ? <<-SCRIPT
     create_or_update_role "$OM_DB_USER" "$OM_DB_PASSWORD"
     create_database_if_missing "$OM_DB_NAME" "$OM_DB_USER"
+    SCRIPT
+  : ""}
 
+    ${var.enable_superset ? <<-SCRIPT
     create_or_update_role "$SUPERSET_DB_USER" "$SUPERSET_DB_PASSWORD"
     create_database_if_missing "$SUPERSET_DB_NAME" "$SUPERSET_DB_USER"
+    SCRIPT
+: ""}
 
     create_or_update_role "$POLARIS_DB_USER" "$POLARIS_DB_PASSWORD"
     create_database_if_missing "$POLARIS_DB_NAME" "$POLARIS_DB_USER"
   SCRIPT
 
-  bootstrap_hash = substr(sha256(jsonencode({
-    script               = local.bootstrap_script
-    dagster_db_name      = var.dagster_db_name
-    dagster_db_user      = var.dagster_db_user
-    openmetadata_db_name = var.openmetadata_db_name
-    openmetadata_db_user = var.openmetadata_db_user
-    superset_db_name     = var.superset_db_name
-    superset_db_user     = var.superset_db_user
-    polaris_db_name      = var.polaris_db_name
-    polaris_db_user      = var.polaris_db_user
-  })), 0, 12)
+bootstrap_hash = substr(sha256(jsonencode({
+  script               = local.bootstrap_script
+  dagster_db_name      = var.dagster_db_name
+  dagster_db_user      = var.dagster_db_user
+  openmetadata_db_name = var.openmetadata_db_name
+  openmetadata_db_user = var.openmetadata_db_user
+  enable_openmetadata  = var.enable_openmetadata
+  superset_db_name     = var.superset_db_name
+  superset_db_user     = var.superset_db_user
+  enable_superset      = var.enable_superset
+  polaris_db_name      = var.polaris_db_name
+  polaris_db_user      = var.polaris_db_user
+})), 0, 12)
 }
 
 resource "random_password" "postgres_admin" {
@@ -92,11 +100,15 @@ resource "random_password" "dagster" {
 }
 
 resource "random_password" "openmetadata" {
+  count = var.enable_openmetadata ? 1 : 0
+
   length  = 32
   special = false
 }
 
 resource "random_password" "superset" {
+  count = var.enable_superset ? 1 : 0
+
   length  = 32
   special = false
 }
@@ -132,25 +144,29 @@ resource "kubernetes_secret_v1" "dagster_credentials" {
 }
 
 resource "kubernetes_secret_v1" "openmetadata_credentials" {
+  count = var.enable_openmetadata ? 1 : 0
+
   metadata {
     name      = var.openmetadata_credentials_secret_name
     namespace = var.namespace
     labels    = local.labels
   }
   data = {
-    "postgresql-password" = random_password.openmetadata.result
+    "postgresql-password" = random_password.openmetadata[0].result
   }
   type = "Opaque"
 }
 
 resource "kubernetes_secret_v1" "superset_credentials" {
+  count = var.enable_superset ? 1 : 0
+
   metadata {
     name      = var.superset_credentials_secret_name
     namespace = var.namespace
     labels    = local.labels
   }
   data = {
-    "postgresql-password" = random_password.superset.result
+    "postgresql-password" = random_password.superset[0].result
   }
   type = "Opaque"
 }
@@ -249,39 +265,57 @@ resource "kubernetes_stateful_set_v1" "postgresql" {
             name  = "DAGSTER_DB_NAME"
             value = var.dagster_db_name
           }
-          env {
-            name  = "OM_DB_USER"
-            value = var.openmetadata_db_user
+          dynamic "env" {
+            for_each = var.enable_openmetadata ? [true] : []
+            content {
+              name  = "OM_DB_USER"
+              value = var.openmetadata_db_user
+            }
           }
-          env {
-            name = "OM_DB_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret_v1.openmetadata_credentials.metadata[0].name
-                key  = "postgresql-password"
+          dynamic "env" {
+            for_each = var.enable_openmetadata ? [true] : []
+            content {
+              name = "OM_DB_PASSWORD"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret_v1.openmetadata_credentials[0].metadata[0].name
+                  key  = "postgresql-password"
+                }
               }
             }
           }
-          env {
-            name  = "OM_DB_NAME"
-            value = var.openmetadata_db_name
+          dynamic "env" {
+            for_each = var.enable_openmetadata ? [true] : []
+            content {
+              name  = "OM_DB_NAME"
+              value = var.openmetadata_db_name
+            }
           }
-          env {
-            name  = "SUPERSET_DB_USER"
-            value = var.superset_db_user
+          dynamic "env" {
+            for_each = var.enable_superset ? [true] : []
+            content {
+              name  = "SUPERSET_DB_USER"
+              value = var.superset_db_user
+            }
           }
-          env {
-            name = "SUPERSET_DB_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret_v1.superset_credentials.metadata[0].name
-                key  = "postgresql-password"
+          dynamic "env" {
+            for_each = var.enable_superset ? [true] : []
+            content {
+              name = "SUPERSET_DB_PASSWORD"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret_v1.superset_credentials[0].metadata[0].name
+                  key  = "postgresql-password"
+                }
               }
             }
           }
-          env {
-            name  = "SUPERSET_DB_NAME"
-            value = var.superset_db_name
+          dynamic "env" {
+            for_each = var.enable_superset ? [true] : []
+            content {
+              name  = "SUPERSET_DB_NAME"
+              value = var.superset_db_name
+            }
           }
           env {
             name  = "POLARIS_DB_USER"
@@ -452,39 +486,57 @@ resource "kubernetes_job_v1" "bootstrap" {
             name  = "DAGSTER_DB_NAME"
             value = var.dagster_db_name
           }
-          env {
-            name  = "OM_DB_USER"
-            value = var.openmetadata_db_user
+          dynamic "env" {
+            for_each = var.enable_openmetadata ? [true] : []
+            content {
+              name  = "OM_DB_USER"
+              value = var.openmetadata_db_user
+            }
           }
-          env {
-            name = "OM_DB_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret_v1.openmetadata_credentials.metadata[0].name
-                key  = "postgresql-password"
+          dynamic "env" {
+            for_each = var.enable_openmetadata ? [true] : []
+            content {
+              name = "OM_DB_PASSWORD"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret_v1.openmetadata_credentials[0].metadata[0].name
+                  key  = "postgresql-password"
+                }
               }
             }
           }
-          env {
-            name  = "OM_DB_NAME"
-            value = var.openmetadata_db_name
+          dynamic "env" {
+            for_each = var.enable_openmetadata ? [true] : []
+            content {
+              name  = "OM_DB_NAME"
+              value = var.openmetadata_db_name
+            }
           }
-          env {
-            name  = "SUPERSET_DB_USER"
-            value = var.superset_db_user
+          dynamic "env" {
+            for_each = var.enable_superset ? [true] : []
+            content {
+              name  = "SUPERSET_DB_USER"
+              value = var.superset_db_user
+            }
           }
-          env {
-            name = "SUPERSET_DB_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret_v1.superset_credentials.metadata[0].name
-                key  = "postgresql-password"
+          dynamic "env" {
+            for_each = var.enable_superset ? [true] : []
+            content {
+              name = "SUPERSET_DB_PASSWORD"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret_v1.superset_credentials[0].metadata[0].name
+                  key  = "postgresql-password"
+                }
               }
             }
           }
-          env {
-            name  = "SUPERSET_DB_NAME"
-            value = var.superset_db_name
+          dynamic "env" {
+            for_each = var.enable_superset ? [true] : []
+            content {
+              name  = "SUPERSET_DB_NAME"
+              value = var.superset_db_name
+            }
           }
           env {
             name  = "POLARIS_DB_USER"
@@ -553,4 +605,24 @@ resource "kubernetes_service_v1" "postgresql" {
 
     type = "ClusterIP"
   }
+}
+
+moved {
+  from = random_password.openmetadata
+  to   = random_password.openmetadata[0]
+}
+
+moved {
+  from = random_password.superset
+  to   = random_password.superset[0]
+}
+
+moved {
+  from = kubernetes_secret_v1.openmetadata_credentials
+  to   = kubernetes_secret_v1.openmetadata_credentials[0]
+}
+
+moved {
+  from = kubernetes_secret_v1.superset_credentials
+  to   = kubernetes_secret_v1.superset_credentials[0]
 }

--- a/infra/terraform/modules/storage/postgresql/outputs.tf
+++ b/infra/terraform/modules/storage/postgresql/outputs.tf
@@ -8,13 +8,13 @@ output "contract" {
     dagster_db_user                 = var.dagster_db_user
     dagster_credentials_secret_name = var.dagster_credentials_secret_name
 
-    openmetadata_db_name                 = var.openmetadata_db_name
-    openmetadata_db_user                 = var.openmetadata_db_user
-    openmetadata_credentials_secret_name = var.openmetadata_credentials_secret_name
+    openmetadata_db_name                 = var.enable_openmetadata ? var.openmetadata_db_name : null
+    openmetadata_db_user                 = var.enable_openmetadata ? var.openmetadata_db_user : null
+    openmetadata_credentials_secret_name = var.enable_openmetadata ? var.openmetadata_credentials_secret_name : null
 
-    superset_db_name                 = var.superset_db_name
-    superset_db_user                 = var.superset_db_user
-    superset_credentials_secret_name = var.superset_credentials_secret_name
+    superset_db_name                 = var.enable_superset ? var.superset_db_name : null
+    superset_db_user                 = var.enable_superset ? var.superset_db_user : null
+    superset_credentials_secret_name = var.enable_superset ? var.superset_credentials_secret_name : null
 
     polaris_credentials_secret_name = var.polaris_credentials_secret_name
   }

--- a/infra/terraform/modules/storage/postgresql/variables.tf
+++ b/infra/terraform/modules/storage/postgresql/variables.tf
@@ -39,6 +39,18 @@ variable "dagster_credentials_secret_name" {
   default     = "postgresql-dagster-creds"
 }
 
+variable "enable_openmetadata" {
+  description = "Whether to create the OpenMetadata PostgreSQL database credentials."
+  type        = bool
+  default     = true
+}
+
+variable "enable_superset" {
+  description = "Whether to create the Superset PostgreSQL database credentials."
+  type        = bool
+  default     = true
+}
+
 variable "openmetadata_db_name" {
   description = "PostgreSQL database name for OpenMetadata."
   type        = string

--- a/infra/terraform/modules/storage/rds-postgresql/main.tf
+++ b/infra/terraform/modules/storage/rds-postgresql/main.tf
@@ -20,11 +20,15 @@ resource "random_password" "dagster" {
 }
 
 resource "random_password" "openmetadata" {
+  count = var.enable_openmetadata ? 1 : 0
+
   length  = 32
   special = false
 }
 
 resource "random_password" "superset" {
+  count = var.enable_superset ? 1 : 0
+
   length  = 32
   special = false
 }
@@ -101,6 +105,8 @@ resource "kubernetes_secret_v1" "dagster" {
 }
 
 resource "kubernetes_secret_v1" "openmetadata" {
+  count = var.enable_openmetadata ? 1 : 0
+
   metadata {
     name      = var.openmetadata_credentials_secret_name
     namespace = var.namespace
@@ -108,11 +114,13 @@ resource "kubernetes_secret_v1" "openmetadata" {
   }
 
   data = {
-    postgresql-password = random_password.openmetadata.result
+    postgresql-password = random_password.openmetadata[0].result
   }
 }
 
 resource "kubernetes_secret_v1" "superset" {
+  count = var.enable_superset ? 1 : 0
+
   metadata {
     name      = var.superset_credentials_secret_name
     namespace = var.namespace
@@ -120,7 +128,7 @@ resource "kubernetes_secret_v1" "superset" {
   }
 
   data = {
-    postgresql-password = random_password.superset.result
+    postgresql-password = random_password.superset[0].result
   }
 }
 
@@ -196,8 +204,8 @@ resource "kubernetes_job_v1" "bootstrap" {
             }
 
             create_role_and_db "${var.dagster_db_name}" "${var.dagster_db_user}" "$DAGSTER_PASSWORD"
-            create_role_and_db "${var.openmetadata_db_name}" "${var.openmetadata_db_user}" "$OPENMETADATA_PASSWORD"
-            create_role_and_db "${var.superset_db_name}" "${var.superset_db_user}" "$SUPERSET_PASSWORD"
+            ${var.enable_openmetadata ? "create_role_and_db \"${var.openmetadata_db_name}\" \"${var.openmetadata_db_user}\" \"$OPENMETADATA_PASSWORD\"" : ""}
+            ${var.enable_superset ? "create_role_and_db \"${var.superset_db_name}\" \"${var.superset_db_user}\" \"$SUPERSET_PASSWORD\"" : ""}
           SCRIPT
           ]
 
@@ -236,22 +244,28 @@ resource "kubernetes_job_v1" "bootstrap" {
             }
           }
 
-          env {
-            name = "OPENMETADATA_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret_v1.openmetadata.metadata[0].name
-                key  = "postgresql-password"
+          dynamic "env" {
+            for_each = var.enable_openmetadata ? [true] : []
+            content {
+              name = "OPENMETADATA_PASSWORD"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret_v1.openmetadata[0].metadata[0].name
+                  key  = "postgresql-password"
+                }
               }
             }
           }
 
-          env {
-            name = "SUPERSET_PASSWORD"
-            value_from {
-              secret_key_ref {
-                name = kubernetes_secret_v1.superset.metadata[0].name
-                key  = "postgresql-password"
+          dynamic "env" {
+            for_each = var.enable_superset ? [true] : []
+            content {
+              name = "SUPERSET_PASSWORD"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret_v1.superset[0].metadata[0].name
+                  key  = "postgresql-password"
+                }
               }
             }
           }
@@ -270,4 +284,24 @@ resource "kubernetes_job_v1" "bootstrap" {
   depends_on = [
     aws_db_instance.this,
   ]
+}
+
+moved {
+  from = random_password.openmetadata
+  to   = random_password.openmetadata[0]
+}
+
+moved {
+  from = random_password.superset
+  to   = random_password.superset[0]
+}
+
+moved {
+  from = kubernetes_secret_v1.openmetadata
+  to   = kubernetes_secret_v1.openmetadata[0]
+}
+
+moved {
+  from = kubernetes_secret_v1.superset
+  to   = kubernetes_secret_v1.superset[0]
 }

--- a/infra/terraform/modules/storage/rds-postgresql/outputs.tf
+++ b/infra/terraform/modules/storage/rds-postgresql/outputs.tf
@@ -8,13 +8,13 @@ output "contract" {
     dagster_db_user                 = var.dagster_db_user
     dagster_credentials_secret_name = var.dagster_credentials_secret_name
 
-    openmetadata_db_name                 = var.openmetadata_db_name
-    openmetadata_db_user                 = var.openmetadata_db_user
-    openmetadata_credentials_secret_name = var.openmetadata_credentials_secret_name
+    openmetadata_db_name                 = var.enable_openmetadata ? var.openmetadata_db_name : null
+    openmetadata_db_user                 = var.enable_openmetadata ? var.openmetadata_db_user : null
+    openmetadata_credentials_secret_name = var.enable_openmetadata ? var.openmetadata_credentials_secret_name : null
 
-    superset_db_name                 = var.superset_db_name
-    superset_db_user                 = var.superset_db_user
-    superset_credentials_secret_name = var.superset_credentials_secret_name
+    superset_db_name                 = var.enable_superset ? var.superset_db_name : null
+    superset_db_user                 = var.enable_superset ? var.superset_db_user : null
+    superset_credentials_secret_name = var.enable_superset ? var.superset_credentials_secret_name : null
   }
 
   depends_on = [

--- a/infra/terraform/modules/storage/rds-postgresql/variables.tf
+++ b/infra/terraform/modules/storage/rds-postgresql/variables.tf
@@ -66,6 +66,18 @@ variable "dagster_credentials_secret_name" {
   default     = "dagster-postgresql-secret"
 }
 
+variable "enable_openmetadata" {
+  description = "Whether to create the OpenMetadata PostgreSQL database credentials."
+  type        = bool
+  default     = true
+}
+
+variable "enable_superset" {
+  description = "Whether to create the Superset PostgreSQL database credentials."
+  type        = bool
+  default     = true
+}
+
 variable "openmetadata_db_name" {
   description = "PostgreSQL database name for OpenMetadata."
   type        = string

--- a/scripts/artifacts/floe-manifest.sh
+++ b/scripts/artifacts/floe-manifest.sh
@@ -127,8 +127,18 @@ if [[ "${PERSIST_RUNTIME_ARTIFACTS}" == "true" ]]; then
     "${FLOE_RUNTIME_ARTIFACT_DIR}/profiles"
 fi
 
-if [[ -z "${PROFILE_PATH}" && "${IS_AWS_FLOE_PROFILE}" == "false" && "${NAMESPACE}" == "lakehouse" ]]; then
+if [[ -z "${PROFILE_PATH}" && "${IS_AWS_FLOE_PROFILE}" == "false" && "${NAMESPACE}" == "lakehouse" &&
+  "${OPENLAKEFORGE_GOVERNANCE_ENABLED}" == "true" ]]; then
   GENERATED_PROFILE_PATH="libs/floe/profiles/local-k8s.yml"
+elif [[ -z "${PROFILE_PATH}" && "${IS_AWS_FLOE_PROFILE}" == "false" ]]; then
+  if [[ "${PERSIST_RUNTIME_ARTIFACTS}" == "true" ]]; then
+    GENERATED_PROFILE_PATH="${FLOE_RUNTIME_ARTIFACT_DIR}/profiles/$(basename "${FLOE_RUNTIME_PROFILE_URI}")"
+  else
+    mkdir -p .tmp
+    PROFILE_TMP_DIR="$(mktemp -d .tmp/floe-profile.XXXXXX)"
+    GENERATED_PROFILE_PATH="${PROFILE_TMP_DIR}/$(basename "${FLOE_RUNTIME_PROFILE_URI}")"
+  fi
+  olf_run floe render-profile > "${GENERATED_PROFILE_PATH}"
 elif [[ -z "${PROFILE_PATH}" && "${IS_AWS_FLOE_PROFILE}" == "true" ]]; then
   if [[ "${PERSIST_RUNTIME_ARTIFACTS}" != "true" ]]; then
     mkdir -p .tmp

--- a/scripts/aws/stack/deploy-artifacts.sh
+++ b/scripts/aws/stack/deploy-artifacts.sh
@@ -80,12 +80,20 @@ PROJECT_CODE_IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG}" \
 echo "==> Publishing product Floe runtime artifacts to the AWS S3 ops bucket..."
 olf_run artifacts upload-manifests --via direct --runtime-root "${FLOE_RUNTIME_ARTIFACT_DIR}"
 
-echo "==> Deploying product Superset report assets..."
-olf_run superset deploy-reports
+if [[ "${OPENLAKEFORGE_ANALYTICS_ENABLED}" == "true" ]]; then
+  echo "==> Deploying product Superset report assets..."
+  olf_run superset deploy-reports
+else
+  echo "==> Skipping Superset report assets: analytics layer is disabled."
+fi
 
-echo "==> Deploying OpenMetadata governance metadata..."
-OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
-  olf_run openmetadata deploy-metadata
+if [[ "${OPENLAKEFORGE_GOVERNANCE_ENABLED}" == "true" ]]; then
+  echo "==> Deploying OpenMetadata governance metadata..."
+  OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
+    olf_run openmetadata deploy-metadata
+else
+  echo "==> Skipping OpenMetadata governance metadata: governance layer is disabled."
+fi
 
 echo "==> Pointing Dagster at project-code image ${PROJECT_CODE_IMAGE}..."
 olf_run k8s set-project-code-image --image "${PROJECT_CODE_IMAGE}"

--- a/scripts/aws/stack/deploy-artifacts.sh
+++ b/scripts/aws/stack/deploy-artifacts.sh
@@ -80,20 +80,8 @@ PROJECT_CODE_IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG}" \
 echo "==> Publishing product Floe runtime artifacts to the AWS S3 ops bucket..."
 olf_run artifacts upload-manifests --via direct --runtime-root "${FLOE_RUNTIME_ARTIFACT_DIR}"
 
-if [[ "${OPENLAKEFORGE_ANALYTICS_ENABLED}" == "true" ]]; then
-  echo "==> Deploying product Superset report assets..."
-  olf_run superset deploy-reports
-else
-  echo "==> Skipping Superset report assets: analytics layer is disabled."
-fi
-
-if [[ "${OPENLAKEFORGE_GOVERNANCE_ENABLED}" == "true" ]]; then
-  echo "==> Deploying OpenMetadata governance metadata..."
-  OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
-    olf_run openmetadata deploy-metadata
-else
-  echo "==> Skipping OpenMetadata governance metadata: governance layer is disabled."
-fi
+OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
+  olf_run artifacts deploy-optional-layers
 
 echo "==> Pointing Dagster at project-code image ${PROJECT_CODE_IMAGE}..."
 olf_run k8s set-project-code-image --image "${PROJECT_CODE_IMAGE}"

--- a/scripts/aws/stack/platform-up.sh
+++ b/scripts/aws/stack/platform-up.sh
@@ -109,7 +109,7 @@ echo "==> Checking AWS platform prerequisites..."
 check_prereqs aws docker helm kubectl terraform
 prepare_eks_context
 prepare_image_variables
-if [[ "${ENABLE_ANALYTICS}" == "true" ]]; then
+if OPENLAKEFORGE_ANALYTICS_ENABLED="${ENABLE_ANALYTICS}" olf_run layers enabled --layer analytics; then
   prepare_superset_image
 else
   echo "==> Skipping Superset image build: analytics layer is disabled."

--- a/scripts/aws/stack/platform-up.sh
+++ b/scripts/aws/stack/platform-up.sh
@@ -37,6 +37,8 @@ source "${REPO_ROOT}/scripts/lib/common.sh"
 source "${REPO_ROOT}/scripts/lib/helm.sh"
 # shellcheck source=scripts/lib/kube.sh
 source "${REPO_ROOT}/scripts/lib/kube.sh"
+# shellcheck source=scripts/lib/python.sh
+source "${REPO_ROOT}/scripts/lib/python.sh"
 
 TRINO_CHART_PACKAGE_PATH="${TRINO_CHART_PACKAGE_PATH:-${HELM_CHART_CACHE_DIR}/trino-${TRINO_CHART_VERSION}.tgz}"
 DAGSTER_CHART_PACKAGE_PATH="${DAGSTER_CHART_PACKAGE_PATH:-${HELM_CHART_CACHE_DIR}/dagster-${DAGSTER_CHART_VERSION}-no-schema.tgz}"
@@ -106,7 +108,7 @@ terraform_apply_once() {
 }
 
 echo "==> Checking AWS platform prerequisites..."
-check_prereqs aws docker helm kubectl terraform
+check_prereqs aws docker helm kubectl terraform uv
 prepare_eks_context
 prepare_image_variables
 if OPENLAKEFORGE_ANALYTICS_ENABLED="${ENABLE_ANALYTICS}" olf_run layers enabled --layer analytics; then

--- a/scripts/aws/stack/platform-up.sh
+++ b/scripts/aws/stack/platform-up.sh
@@ -20,6 +20,8 @@ TFVARS_ARGS=()
 [[ -f "${TFVARS_FILE}" ]] && TFVARS_ARGS+=(-var-file="${TFVARS_FILE}")
 PROJECT_CODE_IMAGE_PULL_POLICY="${PROJECT_CODE_IMAGE_PULL_POLICY:-Always}"
 PROJECT_CODE_IMAGE_REVISION="${PROJECT_CODE_IMAGE_REVISION:-manual}"
+ENABLE_GOVERNANCE="${ENABLE_GOVERNANCE:-true}"
+ENABLE_ANALYTICS="${ENABLE_ANALYTICS:-true}"
 SUPERSET_IMAGE_PULL_POLICY="${SUPERSET_IMAGE_PULL_POLICY:-Always}"
 TRINO_CHART_REPOSITORY="${TRINO_CHART_REPOSITORY:-https://trinodb.github.io/charts}"
 TRINO_CHART_VERSION="${TRINO_CHART_VERSION:-1.42.2}"
@@ -94,6 +96,8 @@ terraform_apply_once() {
     -var="project_code_image_tag=${PROJECT_CODE_IMAGE_TAG}" \
     -var="project_code_image_pull_policy=${PROJECT_CODE_IMAGE_PULL_POLICY}" \
     -var="project_code_image_revision=${PROJECT_CODE_IMAGE_REVISION}" \
+    -var="enable_governance=${ENABLE_GOVERNANCE}" \
+    -var="enable_analytics=${ENABLE_ANALYTICS}" \
     -var="superset_image_repository=${SUPERSET_IMAGE_REPOSITORY}" \
     -var="superset_image_tag=${SUPERSET_IMAGE_TAG}" \
     -var="superset_image_pull_policy=${SUPERSET_IMAGE_PULL_POLICY}" \
@@ -105,7 +109,11 @@ echo "==> Checking AWS platform prerequisites..."
 check_prereqs aws docker helm kubectl terraform
 prepare_eks_context
 prepare_image_variables
-prepare_superset_image
+if [[ "${ENABLE_ANALYTICS}" == "true" ]]; then
+  prepare_superset_image
+else
+  echo "==> Skipping Superset image build: analytics layer is disabled."
+fi
 prepare_helm_cache_dirs
 prepare_cached_chart "Trino" trino "${TRINO_CHART_REPOSITORY}" trino/trino \
   "${TRINO_CHART_VERSION}" "${TRINO_CHART_PACKAGE_PATH}"
@@ -125,6 +133,8 @@ terraform_import_namespace_args=(
   -var="project_code_image_tag=${PROJECT_CODE_IMAGE_TAG}"
   -var="project_code_image_pull_policy=${PROJECT_CODE_IMAGE_PULL_POLICY}"
   -var="project_code_image_revision=${PROJECT_CODE_IMAGE_REVISION}"
+  -var="enable_governance=${ENABLE_GOVERNANCE}"
+  -var="enable_analytics=${ENABLE_ANALYTICS}"
   -var="superset_image_repository=${SUPERSET_IMAGE_REPOSITORY}"
   -var="superset_image_tag=${SUPERSET_IMAGE_TAG}"
   -var="superset_image_pull_policy=${SUPERSET_IMAGE_PULL_POLICY}"

--- a/scripts/azure/stack/deploy-artifacts.sh
+++ b/scripts/azure/stack/deploy-artifacts.sh
@@ -81,12 +81,20 @@ PROJECT_CODE_IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG}" \
 echo "==> Publishing product Floe manifests to the Azure POC SeaweedFS ops bucket..."
 olf_run artifacts upload-manifests --via port-forward --runtime-root "${FLOE_RUNTIME_ARTIFACT_DIR}"
 
-echo "==> Deploying product Superset report assets..."
-olf_run superset deploy-reports
+if [[ "${OPENLAKEFORGE_ANALYTICS_ENABLED}" == "true" ]]; then
+  echo "==> Deploying product Superset report assets..."
+  olf_run superset deploy-reports
+else
+  echo "==> Skipping Superset report assets: analytics layer is disabled."
+fi
 
-echo "==> Deploying OpenMetadata governance metadata..."
-OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
-  olf_run openmetadata deploy-metadata
+if [[ "${OPENLAKEFORGE_GOVERNANCE_ENABLED}" == "true" ]]; then
+  echo "==> Deploying OpenMetadata governance metadata..."
+  OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
+    olf_run openmetadata deploy-metadata
+else
+  echo "==> Skipping OpenMetadata governance metadata: governance layer is disabled."
+fi
 
 echo "==> Pointing Dagster at project-code image ${PROJECT_CODE_IMAGE}..."
 olf_run k8s set-project-code-image --image "${PROJECT_CODE_IMAGE}"

--- a/scripts/azure/stack/deploy-artifacts.sh
+++ b/scripts/azure/stack/deploy-artifacts.sh
@@ -81,20 +81,8 @@ PROJECT_CODE_IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG}" \
 echo "==> Publishing product Floe manifests to the Azure POC SeaweedFS ops bucket..."
 olf_run artifacts upload-manifests --via port-forward --runtime-root "${FLOE_RUNTIME_ARTIFACT_DIR}"
 
-if [[ "${OPENLAKEFORGE_ANALYTICS_ENABLED}" == "true" ]]; then
-  echo "==> Deploying product Superset report assets..."
-  olf_run superset deploy-reports
-else
-  echo "==> Skipping Superset report assets: analytics layer is disabled."
-fi
-
-if [[ "${OPENLAKEFORGE_GOVERNANCE_ENABLED}" == "true" ]]; then
-  echo "==> Deploying OpenMetadata governance metadata..."
-  OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
-    olf_run openmetadata deploy-metadata
-else
-  echo "==> Skipping OpenMetadata governance metadata: governance layer is disabled."
-fi
+OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
+  olf_run artifacts deploy-optional-layers
 
 echo "==> Pointing Dagster at project-code image ${PROJECT_CODE_IMAGE}..."
 olf_run k8s set-project-code-image --image "${PROJECT_CODE_IMAGE}"

--- a/scripts/azure/stack/platform-up.sh
+++ b/scripts/azure/stack/platform-up.sh
@@ -15,6 +15,8 @@ DEPLOYMENT_SCOPE="${DEPLOYMENT_SCOPE:-azure}"
 export HELM_CACHE_SCOPE="${HELM_CACHE_SCOPE:-${DEPLOYMENT_SCOPE}}"
 PROJECT_CODE_IMAGE_PULL_POLICY="${PROJECT_CODE_IMAGE_PULL_POLICY:-Always}"
 PROJECT_CODE_IMAGE_REVISION="${PROJECT_CODE_IMAGE_REVISION:-manual}"
+ENABLE_GOVERNANCE="${ENABLE_GOVERNANCE:-true}"
+ENABLE_ANALYTICS="${ENABLE_ANALYTICS:-true}"
 SUPERSET_IMAGE_PULL_POLICY="${SUPERSET_IMAGE_PULL_POLICY:-Always}"
 TRINO_CHART_REPOSITORY="${TRINO_CHART_REPOSITORY:-https://trinodb.github.io/charts}"
 TRINO_CHART_VERSION="${TRINO_CHART_VERSION:-1.42.2}"
@@ -98,6 +100,8 @@ terraform_apply_once() {
     -var="project_code_image_tag=${PROJECT_CODE_IMAGE_TAG}" \
     -var="project_code_image_pull_policy=${PROJECT_CODE_IMAGE_PULL_POLICY}" \
     -var="project_code_image_revision=${PROJECT_CODE_IMAGE_REVISION}" \
+    -var="enable_governance=${ENABLE_GOVERNANCE}" \
+    -var="enable_analytics=${ENABLE_ANALYTICS}" \
     -var="superset_image_repository=${SUPERSET_IMAGE_REPOSITORY}" \
     -var="superset_image_tag=${SUPERSET_IMAGE_TAG}" \
     -var="superset_image_pull_policy=${SUPERSET_IMAGE_PULL_POLICY}" \
@@ -109,7 +113,11 @@ echo "==> Checking Azure platform prerequisites..."
 check_prereqs az docker helm kubectl terraform uv base64
 prepare_aks_context
 prepare_image_variables
-prepare_superset_image
+if [[ "${ENABLE_ANALYTICS}" == "true" ]]; then
+  prepare_superset_image
+else
+  echo "==> Skipping Superset image build: analytics layer is disabled."
+fi
 prepare_helm_cache_dirs
 prepare_cached_chart "Trino" trino "${TRINO_CHART_REPOSITORY}" trino/trino \
   "${TRINO_CHART_VERSION}" "${TRINO_CHART_PACKAGE_PATH}"
@@ -127,6 +135,8 @@ terraform_import_namespace_args=(
   -var="project_code_image_tag=${PROJECT_CODE_IMAGE_TAG}"
   -var="project_code_image_pull_policy=${PROJECT_CODE_IMAGE_PULL_POLICY}"
   -var="project_code_image_revision=${PROJECT_CODE_IMAGE_REVISION}"
+  -var="enable_governance=${ENABLE_GOVERNANCE}"
+  -var="enable_analytics=${ENABLE_ANALYTICS}"
   -var="superset_image_repository=${SUPERSET_IMAGE_REPOSITORY}"
   -var="superset_image_tag=${SUPERSET_IMAGE_TAG}"
   -var="superset_image_pull_policy=${SUPERSET_IMAGE_PULL_POLICY}"

--- a/scripts/azure/stack/platform-up.sh
+++ b/scripts/azure/stack/platform-up.sh
@@ -113,7 +113,7 @@ echo "==> Checking Azure platform prerequisites..."
 check_prereqs az docker helm kubectl terraform uv base64
 prepare_aks_context
 prepare_image_variables
-if [[ "${ENABLE_ANALYTICS}" == "true" ]]; then
+if OPENLAKEFORGE_ANALYTICS_ENABLED="${ENABLE_ANALYTICS}" olf_run layers enabled --layer analytics; then
   prepare_superset_image
 else
   echo "==> Skipping Superset image build: analytics layer is disabled."

--- a/scripts/local/cluster/prefetch-images.sh
+++ b/scripts/local/cluster/prefetch-images.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 CLUSTER_NAME="${CLUSTER_NAME:-openlakeforge-local}"
+ENABLE_GOVERNANCE="${ENABLE_GOVERNANCE:-true}"
+ENABLE_ANALYTICS="${ENABLE_ANALYTICS:-true}"
 DOCKER_PULL_ATTEMPTS="${LOCAL_PREFETCH_PULL_ATTEMPTS:-${DOCKER_PULL_ATTEMPTS:-5}}"
 DOCKER_PULL_RETRY_DELAY_SECONDS="${LOCAL_PREFETCH_PULL_RETRY_DELAY_SECONDS:-${DOCKER_PULL_RETRY_DELAY_SECONDS:-20}}"
 
@@ -25,17 +27,28 @@ case "${DOCKER_SERVER_ARCH}" in
     ;;
 esac
 
-IMAGES=(
-  "opensearchproject/opensearch:2.11.0"
-  "${POLARIS_IMAGE}"
-  "docker.getcollate.io/openmetadata/server:1.12.10"
-  "docker.getcollate.io/openmetadata/ingestion-base:1.12.10"
-  "postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777"
-  "apache/superset:dockerize"
-  "apache/superset:6.1.0@sha256:fb3464528ec7076f91195f0ff7835755aa023e281f1bb78a84782ce7a36b3705"
-  "docker.io/bitnamilegacy/redis:7.0.10-debian-11-r4"
-  "ghcr.io/malon64/floe:0.6.11"
-)
+IMAGES=()
+if [[ "${ENABLE_GOVERNANCE}" == "true" ]]; then
+  IMAGES+=(
+    "opensearchproject/opensearch:2.11.0"
+  )
+fi
+IMAGES+=("${POLARIS_IMAGE}")
+if [[ "${ENABLE_GOVERNANCE}" == "true" ]]; then
+  IMAGES+=(
+    "docker.getcollate.io/openmetadata/server:1.12.10"
+    "docker.getcollate.io/openmetadata/ingestion-base:1.12.10"
+  )
+fi
+IMAGES+=("postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777")
+if [[ "${ENABLE_ANALYTICS}" == "true" ]]; then
+  IMAGES+=(
+    "apache/superset:dockerize"
+    "apache/superset:6.1.0@sha256:fb3464528ec7076f91195f0ff7835755aa023e281f1bb78a84782ce7a36b3705"
+    "docker.io/bitnamilegacy/redis:7.0.10-debian-11-r4"
+  )
+fi
+IMAGES+=("ghcr.io/malon64/floe:0.6.11")
 
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT

--- a/scripts/local/stack/deploy-artifacts.sh
+++ b/scripts/local/stack/deploy-artifacts.sh
@@ -76,11 +76,19 @@ fi
 echo "==> Pointing Dagster at project-code image ${PROJECT_CODE_IMAGE}..."
 olf_run k8s set-project-code-image --image "${PROJECT_CODE_IMAGE}"
 
-echo "==> Deploying product Superset report assets..."
-olf_run superset deploy-reports
+if [[ "${OPENLAKEFORGE_ANALYTICS_ENABLED}" == "true" ]]; then
+  echo "==> Deploying product Superset report assets..."
+  olf_run superset deploy-reports
+else
+  echo "==> Skipping Superset report assets: analytics layer is disabled."
+fi
 
-echo "==> Deploying OpenMetadata governance metadata..."
-OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
-  olf_run openmetadata deploy-metadata
+if [[ "${OPENLAKEFORGE_GOVERNANCE_ENABLED}" == "true" ]]; then
+  echo "==> Deploying OpenMetadata governance metadata..."
+  OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
+    olf_run openmetadata deploy-metadata
+else
+  echo "==> Skipping OpenMetadata governance metadata: governance layer is disabled."
+fi
 
 echo "Dynamic OpenLakeForge local artifacts are deployed."

--- a/scripts/local/stack/deploy-artifacts.sh
+++ b/scripts/local/stack/deploy-artifacts.sh
@@ -76,19 +76,7 @@ fi
 echo "==> Pointing Dagster at project-code image ${PROJECT_CODE_IMAGE}..."
 olf_run k8s set-project-code-image --image "${PROJECT_CODE_IMAGE}"
 
-if [[ "${OPENLAKEFORGE_ANALYTICS_ENABLED}" == "true" ]]; then
-  echo "==> Deploying product Superset report assets..."
-  olf_run superset deploy-reports
-else
-  echo "==> Skipping Superset report assets: analytics layer is disabled."
-fi
-
-if [[ "${OPENLAKEFORGE_GOVERNANCE_ENABLED}" == "true" ]]; then
-  echo "==> Deploying OpenMetadata governance metadata..."
-  OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
-    olf_run openmetadata deploy-metadata
-else
-  echo "==> Skipping OpenMetadata governance metadata: governance layer is disabled."
-fi
+OPENMETADATA_ALLOW_MISSING_ASSETS="${OPENMETADATA_ALLOW_MISSING_ASSETS:-true}" \
+  olf_run artifacts deploy-optional-layers
 
 echo "Dynamic OpenLakeForge local artifacts are deployed."

--- a/scripts/local/stack/platform-up.sh
+++ b/scripts/local/stack/platform-up.sh
@@ -137,7 +137,7 @@ check_prereqs terraform kubectl helm uv base64
 check_cluster
 require_kube_context
 
-if [[ "${ENABLE_ANALYTICS}" == "true" ]]; then
+if OPENLAKEFORGE_ANALYTICS_ENABLED="${ENABLE_ANALYTICS}" olf_run layers enabled --layer analytics; then
   prepare_local_superset_image
 else
   echo "==> Skipping Superset image build: analytics layer is disabled."

--- a/scripts/local/stack/platform-up.sh
+++ b/scripts/local/stack/platform-up.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 TERRAFORM_DIR="${REPO_ROOT}/infra/terraform/environments/local"
 FOUNDATION_TERRAFORM_DIR="${REPO_ROOT}/infra/terraform/foundations/local-kind"
 FOUNDATION_STATE_PATH="${FOUNDATION_STATE_PATH:-${FOUNDATION_TERRAFORM_DIR}/terraform.tfstate}"
+LOCAL_TFVARS_FILE="${LOCAL_TFVARS_FILE:-}"
 NAMESPACE="${NAMESPACE:-lakehouse}"
 export NAMESPACE
 CLUSTER_NAME="${CLUSTER_NAME:-openlakeforge-local}"
@@ -18,6 +19,8 @@ PROJECT_CODE_IMAGE_REPOSITORY="${PROJECT_CODE_IMAGE_REPOSITORY:-ghcr.io/openlake
 PROJECT_CODE_IMAGE_TAG="${PROJECT_CODE_IMAGE_TAG:-local}"
 PROJECT_CODE_IMAGE_PULL_POLICY="${PROJECT_CODE_IMAGE_PULL_POLICY:-Never}"
 PROJECT_CODE_IMAGE_REVISION="${PROJECT_CODE_IMAGE_REVISION:-manual}"
+ENABLE_GOVERNANCE="${ENABLE_GOVERNANCE:-true}"
+ENABLE_ANALYTICS="${ENABLE_ANALYTICS:-true}"
 SUPERSET_IMAGE_REPOSITORY="${SUPERSET_IMAGE_REPOSITORY:-ghcr.io/openlakeforge/superset}"
 SUPERSET_IMAGE_TAG="${SUPERSET_IMAGE_TAG:-local}"
 SUPERSET_IMAGE_PULL_POLICY="${SUPERSET_IMAGE_PULL_POLICY:-Never}"
@@ -38,6 +41,13 @@ source "${REPO_ROOT}/scripts/lib/kube.sh"
 source "${REPO_ROOT}/scripts/lib/python.sh"
 
 TRINO_CHART_PACKAGE_PATH="${TRINO_CHART_PACKAGE_PATH:-${HELM_CHART_CACHE_DIR}/trino-${TRINO_CHART_VERSION}.tgz}"
+TFVARS_ARGS=()
+if [[ -n "${LOCAL_TFVARS_FILE}" ]]; then
+  if [[ "${LOCAL_TFVARS_FILE}" != /* ]]; then
+    LOCAL_TFVARS_FILE="${REPO_ROOT}/${LOCAL_TFVARS_FILE}"
+  fi
+  TFVARS_ARGS+=("-var-file=${LOCAL_TFVARS_FILE}")
+fi
 
 check_cluster() {
   if [[ ! -f "${FOUNDATION_STATE_PATH}" ]]; then
@@ -79,6 +89,7 @@ terraform_apply_once() {
   cleanup_failed_jobs_by_prefix "polaris-bootstrap-"
 
   terraform -chdir="${TERRAFORM_DIR}" apply -auto-approve \
+    ${TFVARS_ARGS[@]+"${TFVARS_ARGS[@]}"} \
     -var="namespace=${NAMESPACE}" \
     -var="kube_context=${KUBE_CONTEXT}" \
     -var="kubeconfig_path=${KUBECONFIG_PATH}" \
@@ -87,6 +98,8 @@ terraform_apply_once() {
     -var="project_code_image_tag=${PROJECT_CODE_IMAGE_TAG}" \
     -var="project_code_image_pull_policy=${PROJECT_CODE_IMAGE_PULL_POLICY}" \
     -var="project_code_image_revision=${PROJECT_CODE_IMAGE_REVISION}" \
+    -var="enable_governance=${ENABLE_GOVERNANCE}" \
+    -var="enable_analytics=${ENABLE_ANALYTICS}" \
     -var="superset_image_repository=${SUPERSET_IMAGE_REPOSITORY}" \
     -var="superset_image_tag=${SUPERSET_IMAGE_TAG}" \
     -var="superset_image_pull_policy=${SUPERSET_IMAGE_PULL_POLICY}" \
@@ -124,7 +137,11 @@ check_prereqs terraform kubectl helm uv base64
 check_cluster
 require_kube_context
 
-prepare_local_superset_image
+if [[ "${ENABLE_ANALYTICS}" == "true" ]]; then
+  prepare_local_superset_image
+else
+  echo "==> Skipping Superset image build: analytics layer is disabled."
+fi
 prepare_helm_cache_dirs
 prepare_cached_chart "Trino" trino "${TRINO_CHART_REPOSITORY}" trino/trino \
   "${TRINO_CHART_VERSION}" "${TRINO_CHART_PACKAGE_PATH}"
@@ -133,6 +150,7 @@ echo "==> Initializing Terraform..."
 terraform -chdir="${TERRAFORM_DIR}" init
 reset_drifted_local_platform_if_needed
 terraform_import_namespace_args=(
+  ${TFVARS_ARGS[@]+"${TFVARS_ARGS[@]}"}
   -var="namespace=${NAMESPACE}"
   -var="kube_context=${KUBE_CONTEXT}"
   -var="kubeconfig_path=${KUBECONFIG_PATH}"
@@ -141,6 +159,8 @@ terraform_import_namespace_args=(
   -var="project_code_image_tag=${PROJECT_CODE_IMAGE_TAG}"
   -var="project_code_image_pull_policy=${PROJECT_CODE_IMAGE_PULL_POLICY}"
   -var="project_code_image_revision=${PROJECT_CODE_IMAGE_REVISION}"
+  -var="enable_governance=${ENABLE_GOVERNANCE}"
+  -var="enable_analytics=${ENABLE_ANALYTICS}"
   -var="superset_image_repository=${SUPERSET_IMAGE_REPOSITORY}"
   -var="superset_image_tag=${SUPERSET_IMAGE_TAG}"
   -var="superset_image_pull_policy=${SUPERSET_IMAGE_PULL_POLICY}"

--- a/scripts/local/stack/teardown.sh
+++ b/scripts/local/stack/teardown.sh
@@ -8,11 +8,19 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 TERRAFORM_DIR="${REPO_ROOT}/infra/terraform/environments/local"
 FOUNDATION_TERRAFORM_DIR="${REPO_ROOT}/infra/terraform/foundations/local-kind"
 FOUNDATION_STATE_PATH="${FOUNDATION_STATE_PATH:-${FOUNDATION_TERRAFORM_DIR}/terraform.tfstate}"
+LOCAL_TFVARS_FILE="${LOCAL_TFVARS_FILE:-}"
 NAMESPACE="${NAMESPACE:-lakehouse}"
 CLUSTER_NAME="${CLUSTER_NAME:-openlakeforge-local}"
 KUBE_CONTEXT="${KUBE_CONTEXT:-kind-${CLUSTER_NAME}}"
 KUBECONFIG_PATH="${KUBECONFIG_PATH:-${REPO_ROOT}/.tmp/kubeconfigs/local.yaml}"
 export KUBECONFIG="${KUBECONFIG_PATH}"
+TFVARS_ARGS=()
+if [[ -n "${LOCAL_TFVARS_FILE}" ]]; then
+  if [[ "${LOCAL_TFVARS_FILE}" != /* ]]; then
+    LOCAL_TFVARS_FILE="${REPO_ROOT}/${LOCAL_TFVARS_FILE}"
+  fi
+  TFVARS_ARGS+=("-var-file=${LOCAL_TFVARS_FILE}")
+fi
 
 check_prereqs() {
   local missing=0
@@ -47,6 +55,7 @@ echo "==> Destroying Terraform local stack..."
 terraform -chdir="${TERRAFORM_DIR}" init
 terraform -chdir="${TERRAFORM_DIR}" destroy \
   -auto-approve \
+  ${TFVARS_ARGS[@]+"${TFVARS_ARGS[@]}"} \
   -var="namespace=${NAMESPACE}" \
   -var="kube_context=${KUBE_CONTEXT}" \
   -var="kubeconfig_path=${KUBECONFIG_PATH}" \

--- a/scripts/test/check-structure.sh
+++ b/scripts/test/check-structure.sh
@@ -29,6 +29,7 @@ required_paths=(
   "infra/README.md"
   "infra/terraform/README.md"
   "infra/terraform/environments/local/contracts.tf"
+  "infra/terraform/environments/local/slim.tfvars"
   "infra/terraform/environments/azure-poc/main.tf"
   "infra/terraform/environments/azure-poc/variables.tf"
   "infra/terraform/environments/azure-poc/outputs.tf"

--- a/tools/olf/olf/cli.py
+++ b/tools/olf/olf/cli.py
@@ -20,6 +20,7 @@ from olf import config
 from olf import contracts as contracts_module
 from olf import floe as floe_module
 from olf import inventory as inventory_module
+from olf import layers as layers_module
 
 app = typer.Typer(
     name="olf",
@@ -32,6 +33,7 @@ contracts_app = typer.Typer(help="Provider-contract runtime environment helpers.
 inventory_app = typer.Typer(help="Typed domain inventory helpers.")
 floe_app = typer.Typer(help="Floe profile and manifest helpers.")
 artifacts_app = typer.Typer(help="Object-storage artifact helpers.")
+layers_app = typer.Typer(help="Optional platform-layer capability helpers.")
 revision_app = typer.Typer(help="Immutable Floe runtime-artifact revision helpers.")
 superset_app = typer.Typer(help="Superset report deploy/export helpers.")
 openmetadata_app = typer.Typer(help="OpenMetadata governance metadata helpers.")
@@ -42,6 +44,7 @@ app.add_typer(contracts_app, name="contracts")
 app.add_typer(inventory_app, name="inventory")
 app.add_typer(floe_app, name="floe")
 app.add_typer(artifacts_app, name="artifacts")
+app.add_typer(layers_app, name="layers")
 app.add_typer(revision_app, name="revision")
 app.add_typer(superset_app, name="superset")
 app.add_typer(openmetadata_app, name="openmetadata")
@@ -95,6 +98,30 @@ def inventory_terraform_external() -> None:
 def floe_render_profile() -> None:
     """Render the Floe EnvironmentProfile YAML for the active contract env."""
     typer.echo(floe_module.render_profile(os.environ), nl=False)
+
+
+@layers_app.command("enabled")
+def layers_enabled(
+    layer: str = typer.Option(..., "--layer", help="Optional layer: analytics or governance."),
+) -> None:
+    """Exit successfully only when an optional platform layer is enabled."""
+    try:
+        is_enabled = layers_module.enabled(os.environ, layer)
+    except ValueError as exc:
+        raise typer.Exit(code=_fail(str(exc))) from exc
+    if not is_enabled:
+        raise typer.Exit(code=1)
+
+
+@artifacts_app.command("deploy-optional-layers")
+def artifacts_deploy_optional_layers() -> None:
+    """Deploy artifacts for enabled optional platform layers."""
+    layers_module.deploy_enabled_artifacts(
+        os.environ,
+        deploy_reports=deploy_superset_reports,
+        deploy_metadata=deploy_openmetadata_metadata,
+        report=lambda message: typer.echo(f"==> {message}"),
+    )
 
 
 @artifacts_app.command("upload-manifests")
@@ -266,6 +293,11 @@ def _artifact_storage_client(via: str, bucket: str) -> Iterator[Any]:
 @superset_app.command("deploy-reports")
 def superset_deploy_reports() -> None:
     """Build and import source-controlled Superset report bundles."""
+    deploy_superset_reports()
+
+
+def deploy_superset_reports() -> None:
+    """Build and import source-controlled Superset report bundles."""
     from olf import superset
 
     superset.deploy_reports(
@@ -318,6 +350,11 @@ def superset_export_reports() -> None:
 
 @openmetadata_app.command("deploy-metadata")
 def openmetadata_deploy_metadata() -> None:
+    """Seed OpenMetadata domains, data products, and medallion containers."""
+    deploy_openmetadata_metadata()
+
+
+def deploy_openmetadata_metadata() -> None:
     """Seed OpenMetadata domains, data products, and medallion containers."""
     from olf import k8s
     from olf import openmetadata as om

--- a/tools/olf/olf/contracts.py
+++ b/tools/olf/olf/contracts.py
@@ -222,17 +222,29 @@ def _apply_default_contract_env(env: _Env, base: Mapping[str, str], repo_root: P
     env.default("POLARIS_OAUTH_SCOPE", env.get("OPENLAKEFORGE_CATALOG_OAUTH_SCOPE"))
     env.default("OPENLAKEFORGE_DBT_TRINO_USER", "openlakeforge-dbt")
     env.default("OPENLAKEFORGE_DBT_EXECUTABLE", "dbt-ol")
-    env.default("OPENLINEAGE_URL", "http://openmetadata:8585")
-    env.default("OPENLINEAGE_ENDPOINT", "api/v1/openlineage/lineage")
-    env.default("OPENLINEAGE_NAMESPACE", "dagster")
-    env.default(
-        "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
-        "openmetadata-ingestion-bot",
-    )
-    env.default(
-        "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
-        "OPENMETADATA_INGESTION_BOT_JWT",
-    )
+    env.default("OPENLAKEFORGE_GOVERNANCE_ENABLED", "true")
+    env.default("OPENLAKEFORGE_ANALYTICS_ENABLED", "true")
+    if env.get("OPENLAKEFORGE_GOVERNANCE_ENABLED") == "true":
+        env.default("OPENLINEAGE_URL", "http://openmetadata:8585")
+        env.default("OPENLINEAGE_ENDPOINT", "api/v1/openlineage/lineage")
+        env.default("OPENLINEAGE_NAMESPACE", "dagster")
+        env.default(
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
+            "openmetadata-ingestion-bot",
+        )
+        env.default(
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
+            "OPENMETADATA_INGESTION_BOT_JWT",
+        )
+    else:
+        for name in (
+            "OPENLINEAGE_URL",
+            "OPENLINEAGE_ENDPOINT",
+            "OPENLINEAGE_NAMESPACE",
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
+        ):
+            env.unset(name)
 
 
 def _apply_provider_contracts(env: _Env, contracts: dict[str, Any]) -> None:
@@ -242,6 +254,7 @@ def _apply_provider_contracts(env: _Env, contracts: dict[str, Any]) -> None:
     platform = contracts.get("kubernetes_platform", contracts.get("cluster")) or {}
     query = contracts.get("query") or {}
     governance = contracts.get("governance") or {}
+    reporting = contracts.get("reporting") or {}
     is_glue_catalog = catalog.get("catalog_type") == "glue" and catalog.get("catalog_provider") == "aws-glue"
     catalog_warehouse = (
         catalog.get("catalog_name") if is_glue_catalog else (catalog.get("warehouse") or catalog.get("catalog_name"))
@@ -332,15 +345,28 @@ def _apply_provider_contracts(env: _Env, contracts: dict[str, Any]) -> None:
     )
     emit("OPENLAKEFORGE_KUBE_NAMESPACE", platform.get("namespace"))
     emit("OPENLAKEFORGE_QUERY_TRINO_CATALOG", query.get("catalog_name"))
-    emit("OPENLINEAGE_URL", governance.get("endpoint"))
-    emit(
-        "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
-        governance.get("ingestion_bot_secret_name"),
-    )
-    emit(
-        "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
-        governance.get("ingestion_bot_jwt_key"),
-    )
+    governance_enabled = governance.get("enabled", True)
+    emit("OPENLAKEFORGE_GOVERNANCE_ENABLED", governance_enabled)
+    emit("OPENLAKEFORGE_ANALYTICS_ENABLED", reporting.get("enabled", True))
+    if governance_enabled:
+        emit("OPENLINEAGE_URL", governance.get("endpoint"))
+        emit(
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
+            governance.get("ingestion_bot_secret_name"),
+        )
+        emit(
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
+            governance.get("ingestion_bot_jwt_key"),
+        )
+    else:
+        for name in (
+            "OPENLINEAGE_URL",
+            "OPENLINEAGE_ENDPOINT",
+            "OPENLINEAGE_NAMESPACE",
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
+        ):
+            env.unset(name)
     endpoint = query.get("endpoint")
     if endpoint and endpoint.startswith("http://"):
         host_port = endpoint.removeprefix("http://").split("/", 1)[0]

--- a/tools/olf/olf/e2e.py
+++ b/tools/olf/olf/e2e.py
@@ -28,6 +28,7 @@ from olf.inventory import DomainInventory, inventory_for
 
 Environment = Literal["local", "azure", "aws"]
 Suite = Literal["full", "smoke"]
+Layer = Literal["governance", "analytics"]
 
 # The one artifact prefix that is genuinely platform-level, not per-product:
 # Dagster's own compute-log archive path. Per-product prefixes (Floe reports,
@@ -63,6 +64,15 @@ class DagsterTransientError(E2EError):
 
 class DagsterHTTPError(E2EError):
     """A non-transient Dagster HTTP response (normally a client error)."""
+
+
+@dataclass(frozen=True)
+class FullAssertion:
+    """One full-suite assertion and the optional platform layer it needs."""
+
+    label: str
+    check: Callable[[E2EConfig], None]
+    layer: Layer | None = None
 
 
 def workload_health_class(item: Mapping[str, Any], suite_jobs: tuple[str, ...]) -> str:
@@ -326,13 +336,50 @@ def run_smoke(cfg: E2EConfig) -> None:
 
 
 def run_full(cfg: E2EConfig) -> None:
-    launch_and_poll_dagster_jobs(cfg)
-    check_trino_tables_and_marts(cfg)
+    enabled_layers = configured_layers(cfg)
+    skipped: list[str] = []
+    for assertion in full_assertions(cfg):
+        if assertion.layer is not None and not enabled_layers[assertion.layer]:
+            skipped.append(assertion.label)
+            log.info(f"Skipping {assertion.label}: {assertion.layer} layer is disabled.")
+            continue
+        assertion.check(cfg)
+    if skipped:
+        log.info("Skipped e2e assertions: " + ", ".join(skipped))
+
+
+def full_assertions(cfg: E2EConfig) -> tuple[FullAssertion, ...]:
+    """Return the full-suite assertion inventory for the deployed profile."""
+    assertions = [
+        FullAssertion("Dagster product pipelines", launch_and_poll_dagster_jobs),
+        FullAssertion("Silver and Gold tables", check_trino_tables_and_marts),
+    ]
     if cfg.env == "local":
-        check_polaris_restart_recovery(cfg)
-    check_superset_dashboards(cfg)
-    check_openmetadata_assets(cfg)
-    check_ops_artifacts(cfg)
+        assertions.append(FullAssertion("Polaris restart recovery", check_polaris_restart_recovery))
+    assertions.extend(
+        [
+            FullAssertion("Superset dashboards", check_superset_dashboards, layer="analytics"),
+            FullAssertion("OpenMetadata governance assets", check_openmetadata_assets, layer="governance"),
+            FullAssertion("ops bucket artifacts", check_ops_artifacts),
+        ]
+    )
+    return tuple(assertions)
+
+
+def configured_layers(cfg: E2EConfig) -> dict[Layer, bool]:
+    """Read enabled platform layers once from the environment contract."""
+    provider_contracts = load_provider_contracts_or_raise(cfg)
+    layers = {
+        "governance": provider_contracts.get("governance") or {},
+        "analytics": provider_contracts.get("reporting") or {},
+    }
+    enabled: dict[Layer, bool] = {}
+    for layer, contract in layers.items():
+        value = contract.get("enabled", True)
+        if not isinstance(value, bool):
+            raise E2EError(f"provider_contracts.{layer}.enabled must be a boolean.")
+        enabled[layer] = value
+    return enabled
 
 
 def check_pods_ready(cfg: E2EConfig) -> None:

--- a/tools/olf/olf/floe.py
+++ b/tools/olf/olf/floe.py
@@ -74,21 +74,7 @@ def render_profile(environ: Mapping[str, str]) -> str:
     catalog_secret = env("OPENLAKEFORGE_CATALOG_FLOE_CREDENTIALS_SECRET_NAME", "polaris-floe-creds")
     catalog_client_id_key = env("OPENLAKEFORGE_CATALOG_FLOE_CLIENT_ID_KEY", "POLARIS_FLOE_CLIENT_ID")
     catalog_client_secret_key = env("OPENLAKEFORGE_CATALOG_FLOE_CLIENT_SECRET_KEY", "POLARIS_FLOE_CLIENT_SECRET")
-    lineage_url = env("OPENLINEAGE_URL", "http://openmetadata:8585")
-    lineage_endpoint = env("OPENLINEAGE_ENDPOINT", "api/v1/openlineage/lineage")
-    lineage_namespace = env("OPENLINEAGE_NAMESPACE", "dagster")
-    lineage_dataset_namespace = env(
-        "OPENLAKEFORGE_FLOE_LINEAGE_DATASET_NAMESPACE",
-        "aws_glue" if is_aws_glue else "polaris",
-    )
-    lineage_secret = env(
-        "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
-        "openmetadata-ingestion-bot",
-    )
-    lineage_secret_key = env(
-        "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
-        "OPENMETADATA_INGESTION_BOT_JWT",
-    )
+    governance_enabled = env("OPENLAKEFORGE_GOVERNANCE_ENABLED", "true") == "true"
 
     if storage_implementation.startswith("storage.") and "s3" in storage_implementation:
         catalog_warehouse_prefix = _absolute_s3_prefix(storage_silver_bucket, catalog_warehouse_prefix)
@@ -148,9 +134,34 @@ def render_profile(environ: Mapping[str, str]) -> str:
         key: {catalog_client_secret_key}
 """
 
-    lineage_secret_yaml = f"""      - name: OPENLINEAGE_API_KEY
+    lineage_secret_yaml = ""
+    lineage_block = ""
+    if governance_enabled:
+        lineage_url = env("OPENLINEAGE_URL", "http://openmetadata:8585")
+        lineage_endpoint = env("OPENLINEAGE_ENDPOINT", "api/v1/openlineage/lineage")
+        lineage_namespace = env("OPENLINEAGE_NAMESPACE", "dagster")
+        lineage_dataset_namespace = env(
+            "OPENLAKEFORGE_FLOE_LINEAGE_DATASET_NAMESPACE",
+            "aws_glue" if is_aws_glue else "polaris",
+        )
+        lineage_secret = env(
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
+            "openmetadata-ingestion-bot",
+        )
+        lineage_secret_key = env(
+            "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
+            "OPENMETADATA_INGESTION_BOT_JWT",
+        )
+        lineage_secret_yaml = f"""      - name: OPENLINEAGE_API_KEY
         secret_name: {lineage_secret}
         key: {lineage_secret_key}
+"""
+        lineage_block = f"""lineage:
+  url: {_yaml_string(lineage_url)}
+  endpoint: {_yaml_string(lineage_endpoint)}
+  namespace: {_yaml_string(lineage_namespace)}
+  dataset_namespace: {_yaml_string(lineage_dataset_namespace)}
+  timeout_secs: 5
 """
 
     secrets_entries = (storage_secret_yaml + catalog_secret_yaml + lineage_secret_yaml).rstrip("\n")
@@ -212,12 +223,6 @@ execution:
     env:
 {runner_env_yaml}
 {secrets_block}
-lineage:
-  url: {_yaml_string(lineage_url)}
-  endpoint: {_yaml_string(lineage_endpoint)}
-  namespace: {_yaml_string(lineage_namespace)}
-  dataset_namespace: {_yaml_string(lineage_dataset_namespace)}
-  timeout_secs: 5
-validation:
+{lineage_block}validation:
   strict: true
 """

--- a/tools/olf/olf/layers.py
+++ b/tools/olf/olf/layers.py
@@ -1,0 +1,39 @@
+"""Optional platform-layer decisions shared by environment deploy scripts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+
+def enabled(environ: Mapping[str, str], layer: str) -> bool:
+    """Return whether an optional platform layer is enabled by its contract."""
+    variables = {
+        "analytics": "OPENLAKEFORGE_ANALYTICS_ENABLED",
+        "governance": "OPENLAKEFORGE_GOVERNANCE_ENABLED",
+    }
+    try:
+        value = environ.get(variables[layer], "true")
+    except KeyError as exc:
+        raise ValueError(f"unknown optional layer {layer!r}") from exc
+    return value == "true"
+
+
+def deploy_enabled_artifacts(
+    environ: Mapping[str, str],
+    *,
+    deploy_reports: Callable[[], None],
+    deploy_metadata: Callable[[], None],
+    report: Callable[[str], None],
+) -> None:
+    """Deploy artifacts for enabled optional layers and report skipped layers."""
+    if enabled(environ, "analytics"):
+        report("Deploying product Superset report assets...")
+        deploy_reports()
+    else:
+        report("Skipping Superset report assets: analytics layer is disabled.")
+
+    if enabled(environ, "governance"):
+        report("Deploying OpenMetadata governance metadata...")
+        deploy_metadata()
+    else:
+        report("Skipping OpenMetadata governance metadata: governance layer is disabled.")

--- a/tools/olf/tests/test_cli.py
+++ b/tools/olf/tests/test_cli.py
@@ -16,6 +16,27 @@ def test_version_command_prints_package_version() -> None:
     assert result.output.strip() == olf.__version__
 
 
+def test_layers_enabled_exits_nonzero_for_a_disabled_layer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENLAKEFORGE_ANALYTICS_ENABLED", "false")
+
+    result = runner.invoke(app, ["layers", "enabled", "--layer", "analytics"])
+
+    assert result.exit_code == 1
+
+
+def test_artifacts_deploy_optional_layers_skips_disabled_layers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENLAKEFORGE_ANALYTICS_ENABLED", "false")
+    monkeypatch.setenv("OPENLAKEFORGE_GOVERNANCE_ENABLED", "false")
+    monkeypatch.setattr("olf.cli.deploy_superset_reports", lambda: pytest.fail("reports should be skipped"))
+    monkeypatch.setattr("olf.cli.deploy_openmetadata_metadata", lambda: pytest.fail("metadata should be skipped"))
+
+    result = runner.invoke(app, ["artifacts", "deploy-optional-layers"])
+
+    assert result.exit_code == 0
+    assert "Skipping Superset report assets" in result.output
+    assert "Skipping OpenMetadata governance metadata" in result.output
+
+
 def test_revision_compute_command_prints_runtime_artifact_revision(tmp_path: Path) -> None:
     path = tmp_path / "manifests/sales/order_revenue/order_revenue.manifest.json"
     path.parent.mkdir(parents=True)

--- a/tools/olf/tests/test_contracts.py
+++ b/tools/olf/tests/test_contracts.py
@@ -77,6 +77,26 @@ def test_local_contracts_apply_seaweedfs_values() -> None:
     assert unsets == []
 
 
+def test_disabled_governance_and_analytics_unset_their_runtime_dependencies() -> None:
+    contracts = load_fixture("local-provider-contracts.json")
+    contracts["governance"] = {"enabled": False}
+    contracts["reporting"] = {"enabled": False}
+
+    exports, unsets = build_contract_env({}, contracts, repo_root=REPO_ROOT)
+
+    assert exports["OPENLAKEFORGE_GOVERNANCE_ENABLED"] == "false"
+    assert exports["OPENLAKEFORGE_ANALYTICS_ENABLED"] == "false"
+    for name in (
+        "OPENLINEAGE_URL",
+        "OPENLINEAGE_ENDPOINT",
+        "OPENLINEAGE_NAMESPACE",
+        "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_SECRET_NAME",
+        "OPENLAKEFORGE_GOVERNANCE_INGESTION_BOT_JWT_KEY",
+    ):
+        assert name not in exports
+        assert name in unsets
+
+
 def test_aws_contracts_blank_local_only_fields_and_derive_glue_fqns() -> None:
     exports, unsets = build_contract_env({}, load_fixture("aws-provider-contracts.json"), repo_root=REPO_ROOT)
     # storage.aws_s3 blanks S3-compatible endpoint plumbing

--- a/tools/olf/tests/test_e2e.py
+++ b/tools/olf/tests/test_e2e.py
@@ -238,10 +238,42 @@ def test_run_full_only_restarts_polaris_for_local(
     monkeypatch.setattr(e2e, "check_superset_dashboards", lambda _cfg: calls.append("superset"))
     monkeypatch.setattr(e2e, "check_openmetadata_assets", lambda _cfg: calls.append("openmetadata"))
     monkeypatch.setattr(e2e, "check_ops_artifacts", lambda _cfg: calls.append("artifacts"))
+    monkeypatch.setattr(e2e, "configured_layers", lambda _cfg: {"governance": True, "analytics": True})
 
     e2e.run_full(cfg(tmp_path, env=env))
 
     assert calls == expected
+
+
+def test_run_full_skips_disabled_layer_assertions_and_reports_them(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+    messages: list[str] = []
+
+    monkeypatch.setattr(e2e, "launch_and_poll_dagster_jobs", lambda _cfg: calls.append("jobs"))
+    monkeypatch.setattr(e2e, "check_trino_tables_and_marts", lambda _cfg: calls.append("tables"))
+    monkeypatch.setattr(e2e, "check_polaris_restart_recovery", lambda _cfg: calls.append("recovery"))
+    monkeypatch.setattr(e2e, "check_superset_dashboards", lambda _cfg: calls.append("superset"))
+    monkeypatch.setattr(e2e, "check_openmetadata_assets", lambda _cfg: calls.append("openmetadata"))
+    monkeypatch.setattr(e2e, "check_ops_artifacts", lambda _cfg: calls.append("artifacts"))
+    monkeypatch.setattr(e2e, "configured_layers", lambda _cfg: {"governance": False, "analytics": False})
+    monkeypatch.setattr(e2e.log, "info", messages.append)
+
+    e2e.run_full(cfg(tmp_path))
+
+    assert calls == ["jobs", "tables", "recovery", "artifacts"]
+    assert "Skipped e2e assertions: Superset dashboards, OpenMetadata governance assets" in messages
+
+
+def test_configured_layers_reads_contract_flags(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        e2e,
+        "load_provider_contracts_or_raise",
+        lambda _cfg: {"governance": {"enabled": False}, "reporting": {"enabled": False}},
+    )
+
+    assert e2e.configured_layers(cfg(tmp_path)) == {"governance": False, "analytics": False}
 
 
 def test_prepare_kube_context_refreshes_existing_aws_context(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tools/olf/tests/test_floe.py
+++ b/tools/olf/tests/test_floe.py
@@ -62,3 +62,11 @@ def test_aws_glue_profile_requires_glue_database() -> None:
     del env["OPENLAKEFORGE_CATALOG_GLUE_DATABASE"]
     with pytest.raises(SystemExit):
         render_profile(env)
+
+
+def test_profile_omits_openlineage_when_governance_is_disabled() -> None:
+    profile = render_profile({"OPENLAKEFORGE_GOVERNANCE_ENABLED": "false"})
+
+    assert "lineage:" not in profile
+    assert "OPENLINEAGE_API_KEY" not in profile
+    assert "openmetadata-ingestion-bot" not in profile

--- a/tools/olf/tests/test_layers.py
+++ b/tools/olf/tests/test_layers.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from olf.layers import deploy_enabled_artifacts, enabled
+
+
+def test_deploy_enabled_artifacts_only_runs_enabled_layers() -> None:
+    deployed: list[str] = []
+    messages: list[str] = []
+
+    deploy_enabled_artifacts(
+        {"OPENLAKEFORGE_ANALYTICS_ENABLED": "false", "OPENLAKEFORGE_GOVERNANCE_ENABLED": "false"},
+        deploy_reports=lambda: deployed.append("reports"),
+        deploy_metadata=lambda: deployed.append("metadata"),
+        report=messages.append,
+    )
+
+    assert deployed == []
+    assert messages == [
+        "Skipping Superset report assets: analytics layer is disabled.",
+        "Skipping OpenMetadata governance metadata: governance layer is disabled.",
+    ]
+
+
+def test_deploy_enabled_artifacts_runs_both_layers_by_default() -> None:
+    deployed: list[str] = []
+
+    deploy_enabled_artifacts(
+        {},
+        deploy_reports=lambda: deployed.append("reports"),
+        deploy_metadata=lambda: deployed.append("metadata"),
+        report=lambda _message: None,
+    )
+
+    assert deployed == ["reports", "metadata"]
+
+
+def test_enabled_rejects_unknown_layer() -> None:
+    with pytest.raises(ValueError, match="unknown optional layer"):
+        enabled({}, "catalog")


### PR DESCRIPTION
Closes #78

## What changed
- Add default-enabled governance and analytics layer contracts across environments.
- Remove disabled-layer PostgreSQL credentials and Terraform resources, with moved blocks preserving existing full-profile state.
- Add `make local-slim-up` / `make local-slim-e2e` and a checked-in slim local profile.
- Make artifact deployment, Floe lineage configuration, and E2E assertions capability-aware.
- Document full and slim steady-state pod and requested-memory footprints.

## Validation
- `make release-check`
- `uv run --project tools/olf pytest tools/olf/tests` (221 passed)
- Slim Terraform plan confirms no OpenMetadata or Superset resources and no lineage Secret references.

## Runtime note
A live slim E2E could not run on this host: the existing full cluster owns SeaweedFS cluster-scoped Helm resources, and a fresh kind cluster fails during node startup because the host is nearly out of disk space. The temporary namespace/resources and Terraform state were removed; the existing full cluster was left unchanged.