### PR TITLE
feat: add kind smoke gate

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -147,7 +147,7 @@ jobs:
     env:
       CLUSTER_NAME: openlakeforge-pr-${{ github.run_id }}
       LOCAL_KUBECONFIG_PATH: ${{ github.workspace }}/.tmp/kubeconfigs/kind-smoke.yaml
-      PROJECT_CODE_IMAGE_TAG: local
+      PROJECT_CODE_IMAGE_TAG: ci-intentionally-missing
 
     steps:
       - name: Checkout

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -143,7 +143,9 @@ jobs:
     name: Deploy slim kind smoke
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    # The smoke command has its own 45-minute deployment deadline. Reserve
+    # another 15 minutes for runner setup and failure diagnostics/uploads.
+    timeout-minutes: 60
     env:
       CLUSTER_NAME: openlakeforge-pr-${{ github.run_id }}
       KUBE_CONTEXT: kind-openlakeforge-pr-${{ github.run_id }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -146,7 +146,9 @@ jobs:
     timeout-minutes: 50
     env:
       CLUSTER_NAME: openlakeforge-pr-${{ github.run_id }}
+      KUBE_CONTEXT: kind-openlakeforge-pr-${{ github.run_id }}
       LOCAL_KUBECONFIG_PATH: ${{ github.workspace }}/.tmp/kubeconfigs/kind-smoke.yaml
+      KUBECONFIG: ${{ github.workspace }}/.tmp/kubeconfigs/kind-smoke.yaml
       PROJECT_CODE_IMAGE_TAG: ci-intentionally-missing
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -149,7 +149,7 @@ jobs:
       KUBE_CONTEXT: kind-openlakeforge-pr-${{ github.run_id }}
       LOCAL_KUBECONFIG_PATH: ${{ github.workspace }}/.tmp/kubeconfigs/kind-smoke.yaml
       KUBECONFIG: ${{ github.workspace }}/.tmp/kubeconfigs/kind-smoke.yaml
-      PROJECT_CODE_IMAGE_TAG: ci-intentionally-missing
+      PROJECT_CODE_IMAGE_TAG: local
 
     steps:
       - name: Checkout

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -138,3 +138,58 @@ jobs:
 
       - name: Validate release readiness (catches drift before a tag is cut)
         run: make release-check
+
+  kind-smoke:
+    name: Deploy slim kind smoke
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    env:
+      CLUSTER_NAME: openlakeforge-pr-${{ github.run_id }}
+      LOCAL_KUBECONFIG_PATH: ${{ github.workspace }}/.tmp/kubeconfigs/kind-smoke.yaml
+      PROJECT_CODE_IMAGE_TAG: local
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_version: 1.8.5
+
+      - name: Setup Helm
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a
+        with:
+          version: v3.18.6
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
+
+      - name: Install kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3
+        with:
+          install_only: true
+          version: v0.26.0
+          kubectl_version: v1.31.4
+
+      - name: Deploy and validate slim smoke (45 minute budget)
+        run: make local-slim-smoke
+
+      - name: Collect kind diagnostics
+        if: failure()
+        run: scripts/ci/kind-diagnostics.sh .tmp/kind-smoke-diagnostics
+
+      - name: Upload kind diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: kind-smoke-diagnostics-${{ github.run_id }}
+          path: .tmp/kind-smoke-diagnostics
+          if-no-files-found: error
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help tree check-structure check-components check-contracts check-infra check-project-code check-dbt check-lockfiles release-check release-bundle floe-manifest floe-manifest-upload dbt-parse project-code-image project-code-load superset-image superset-load superset-reports-deploy superset-reports-export openmetadata-metadata-deploy local-foundation-up local-foundation-down local-platform-up local-platform-down local-artifacts-deploy local-up local-down local-status local-forward local-prefetch local-e2e local-slim-platform-up local-slim-artifacts-deploy local-slim-up local-slim-e2e local-slim-down azure-foundation-up azure-platform-up azure-platform-down azure-artifacts-deploy azure-up azure-forward azure-e2e azure-down azure-foundation-down aws-foundation-up aws-platform-up aws-platform-down aws-artifacts-deploy aws-up aws-forward aws-e2e aws-down aws-foundation-down
+.PHONY: help tree check-structure check-components check-contracts check-infra check-project-code check-dbt check-lockfiles release-check release-bundle floe-manifest floe-manifest-upload dbt-parse project-code-image project-code-load superset-image superset-load superset-reports-deploy superset-reports-export openmetadata-metadata-deploy local-foundation-up local-foundation-down local-platform-up local-platform-down local-artifacts-deploy local-up local-down local-status local-forward local-prefetch local-e2e local-slim-platform-up local-slim-artifacts-deploy local-slim-up local-slim-e2e local-slim-smoke local-slim-down azure-foundation-up azure-platform-up azure-platform-down azure-artifacts-deploy azure-up azure-forward azure-e2e azure-down azure-foundation-down aws-foundation-up aws-platform-up aws-platform-down aws-artifacts-deploy aws-up aws-forward aws-e2e aws-down aws-foundation-down
 
 NAMESPACE ?= lakehouse
 CLUSTER_NAME ?= openlakeforge-local
@@ -10,6 +10,8 @@ PROJECT_CODE_IMAGE_TAG ?= local
 PROJECT_CODE_IMAGE_PULL_POLICY ?= Never
 ENABLE_GOVERNANCE ?= true
 ENABLE_ANALYTICS ?= true
+E2E_SUITE ?= full
+SMOKE_TIMEOUT_SECONDS ?= 2700
 SUPERSET_IMAGE_REPOSITORY ?= ghcr.io/openlakeforge/superset
 SUPERSET_IMAGE_TAG ?= local
 SUPERSET_IMAGE_PULL_POLICY ?= Never
@@ -72,6 +74,7 @@ help:
 	@printf '%s\n' '  make local-up         Full wrapper: foundation, prefetch, platform, artifacts'
 	@printf '%s\n' '  make local-slim-up    Slim wrapper: full data path without OpenMetadata or Superset'
 	@printf '%s\n' '  make local-slim-e2e   Validate the slim profile (reports disabled assertions)'
+	@printf '%s\n' '  make local-slim-smoke Deploy the slim profile and validate one product within 45 minutes'
 	@printf '%s\n' '  make local-down       Full teardown wrapper: platform, foundation'
 	@printf '%s\n' '  make local-status     Show pod and service status in the configured namespace'
 	@printf '%s\n' '  make local-forward    Port-forward all services to localhost (Dagster :3000, Superset :8088, OpenMetadata :8585, Trino :8080, Polaris :8181, S3 :9000, SeaweedFS Filer :8888, Master :9333)'
@@ -190,7 +193,10 @@ local-slim-up:
 	@$(MAKE) local-slim-artifacts-deploy
 
 local-slim-e2e:
-	@$(MAKE) local-e2e ENABLE_GOVERNANCE=false ENABLE_ANALYTICS=false
+	@$(MAKE) local-e2e ENABLE_GOVERNANCE=false ENABLE_ANALYTICS=false E2E_SUITE=$(E2E_SUITE)
+
+local-slim-smoke:
+	@uv run --project tools/olf --locked olf smoke run --timeout-seconds $(SMOKE_TIMEOUT_SECONDS)
 
 local-slim-down:
 	@$(MAKE) local-down LOCAL_TFVARS_FILE=infra/terraform/environments/local/slim.tfvars
@@ -244,7 +250,7 @@ local-forward:
 	wait
 
 local-e2e:
-	@NAMESPACE=$(NAMESPACE) CLUSTER_NAME=$(CLUSTER_NAME) KUBE_CONTEXT=$(KUBE_CONTEXT) KUBECONFIG="$(LOCAL_KUBECONFIG_PATH)" OPENLAKEFORGE_CONTRACT_TERRAFORM_DIR=infra/terraform/environments/local bash scripts/artifacts/olf.sh e2e run --env local
+	@NAMESPACE=$(NAMESPACE) CLUSTER_NAME=$(CLUSTER_NAME) KUBE_CONTEXT=$(KUBE_CONTEXT) KUBECONFIG="$(LOCAL_KUBECONFIG_PATH)" OPENLAKEFORGE_CONTRACT_TERRAFORM_DIR=infra/terraform/environments/local bash scripts/artifacts/olf.sh e2e run --env local --suite $(E2E_SUITE)
 
 azure-foundation-up:
 	@AZURE_TFVARS_FILE="$(AZURE_TFVARS_FILE)" AZURE_CLUSTER_NAME=$(AZURE_CLUSTER_NAME) AZURE_NODE_COUNT=$(AZURE_NODE_COUNT) AZURE_ACR_NAME_PREFIX=$(AZURE_ACR_NAME_PREFIX) KUBECONFIG_PATH="$(AZURE_KUBECONFIG_PATH)" bash scripts/azure/foundation/up.sh

--- a/README.md
+++ b/README.md
@@ -302,6 +302,20 @@ It launches every product pipeline and checks Silver, Gold, Trino, and
 ops-bucket artifacts. It reports the Superset and OpenMetadata assertions as
 skipped. Tear it down with `make local-slim-down`.
 
+For the pull-request deployment gate, run the bounded smoke path locally:
+
+```sh
+make local-slim-smoke
+```
+
+It creates the slim kind foundation, applies the platform, deploys artifacts,
+then selects the first product from the validated domain inventory, runs its
+Dagster pipeline, and queries its populated Gold marts through Trino. The full
+path has a hard 45-minute budget (`SMOKE_TIMEOUT_SECONDS=2700`); on expiry it
+terminates the running Make process tree and fails loudly. GitHub Actions
+reserves a further five minutes to collect pod, event, workload, host-capacity,
+and container-log diagnostics when the command fails.
+
 Check the cluster at any point with:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ then selects the first product from the validated domain inventory, runs its
 Dagster pipeline, and queries its populated Gold marts through Trino. The full
 path has a hard 45-minute budget (`SMOKE_TIMEOUT_SECONDS=2700`); on expiry it
 terminates the running Make process tree and fails loudly. GitHub Actions
-reserves a further five minutes to collect pod, event, workload, host-capacity,
-and container-log diagnostics when the command fails.
+reserves a further 15 minutes for runner setup plus pod, event, workload,
+host-capacity, and container-log diagnostics when the command fails.
 
 Check the cluster at any point with:
 

--- a/docs/industrialization-roadmap.md
+++ b/docs/industrialization-roadmap.md
@@ -350,7 +350,7 @@ private networking, ingress/TLS, and restore validation.
 
 | Cadence | Required verification |
 | --- | --- |
-| Pull request | Existing static/unit checks, contract-schema validation, image build, SBOM, vulnerability/IaC/secret scans, and — from `v0.2-alpha` — a kind smoke on the slim profile (#81) |
+| Pull request | Existing static/unit checks, contract-schema validation, image build, SBOM, vulnerability/IaC/secret scans, and — from `v0.2-alpha` — the 45-minute `make local-slim-smoke` kind gate on the slim profile (#81) |
 | Main/nightly | Fresh local full end-to-end run on the full profile from `v0.2-alpha` onward (#60); `v0.1.0-alpha.1` records one clean local release run instead |
 | Scheduled AWS | Ephemeral deployment, all product pipelines, restore drill, and teardown after the secure beta profile is introduced |
 | Release | `v0.1.0-alpha.1`: digest-mismatch negative test, clean local install, full three-product result, and release-bundle verification. `v0.2-alpha` adds consumer install from a published release (#80) and fourth-product onboarding (#40). Later releases add lifecycle and recovery gates cumulatively. |

--- a/release/component-catalog.yaml
+++ b/release/component-catalog.yaml
@@ -37,6 +37,7 @@ components:
     astral-sh/setup-uv: e58605a9b6da7c637471fab8847a5e5a6b8df081
     azure/setup-helm: bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a
     hashicorp/setup-terraform: b9cd54a3c349d3f38e8881555d616ced269862dd
+    helm/kind-action: a1b0e391336a6ee6713a0583f8c6240d70863de3
     docker/setup-buildx-action: f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
     docker/login-action: c94ce9fb468520275223c153574b00df6fe4bcc9
     docker/build-push-action: 4f58ea79222b3b9dc2c8bbdd6debcef730109a75

--- a/scripts/artifacts/floe-manifest.sh
+++ b/scripts/artifacts/floe-manifest.sh
@@ -287,6 +287,12 @@ generate_manifest() {
   fi
 
   mkdir -p "$(dirname "${manifest_path}")"
+  # The Floe image runs as its own non-root user.  Give that user access to
+  # the transient output directory when Docker bind-mounts the repository;
+  # otherwise generated manifests fail on hosted runners with EACCES.
+  if [[ "${USING_DOCKER}" == "true" ]]; then
+    chmod a+rwx "$(dirname "${manifest_path}")"
+  fi
   profile_path="$(profile_for_config "${domain}" "${product}")"
   generation_config_path="$(config_for_manifest "${config_path}" "${domain}" "${product}")"
 

--- a/scripts/ci/kind-diagnostics.sh
+++ b/scripts/ci/kind-diagnostics.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Collect bounded kind smoke diagnostics before GitHub Actions removes the runner.
+set -euo pipefail
+
+OUTPUT_DIR="${1:?diagnostic output directory is required}"
+NAMESPACE="${NAMESPACE:-lakehouse}"
+KUBE_CONTEXT="${KUBE_CONTEXT:?KUBE_CONTEXT is required}"
+
+mkdir -p "${OUTPUT_DIR}"
+free -h >"${OUTPUT_DIR}/host-memory.txt" 2>&1 || true
+df -h >"${OUTPUT_DIR}/host-disk.txt" 2>&1 || true
+docker system df >"${OUTPUT_DIR}/docker-disk.txt" 2>&1 || true
+kubectl --context "${KUBE_CONTEXT}" get nodes -o wide >"${OUTPUT_DIR}/nodes.txt" 2>&1 || true
+kubectl --context "${KUBE_CONTEXT}" get pods --all-namespaces -o wide >"${OUTPUT_DIR}/all-pods.txt" 2>&1 || true
+kubectl --context "${KUBE_CONTEXT}" get events --all-namespaces --sort-by=.lastTimestamp >"${OUTPUT_DIR}/all-events.txt" 2>&1 || true
+kubectl --context "${KUBE_CONTEXT}" get all -n "${NAMESPACE}" -o wide >"${OUTPUT_DIR}/workloads.txt" 2>&1 || true
+kubectl --context "${KUBE_CONTEXT}" get events -n "${NAMESPACE}" --sort-by=.lastTimestamp >"${OUTPUT_DIR}/events.txt" 2>&1 || true
+kubectl --context "${KUBE_CONTEXT}" describe pods -n "${NAMESPACE}" >"${OUTPUT_DIR}/pod-descriptions.txt" 2>&1 || true
+
+while IFS= read -r pod; do
+  kubectl --context "${KUBE_CONTEXT}" logs -n "${NAMESPACE}" "${pod}" --all-containers --tail=200 \
+    >"${OUTPUT_DIR}/${pod}.log" 2>&1 || true
+done < <(kubectl --context "${KUBE_CONTEXT}" get pods -n "${NAMESPACE}" -o name 2>/dev/null | sed 's#pod/##')

--- a/scripts/test/check-structure.sh
+++ b/scripts/test/check-structure.sh
@@ -127,6 +127,7 @@ required_paths=(
   "scripts/test/check-infra.sh"
   "scripts/test/check-project-code.sh"
   "scripts/test/check-dbt.sh"
+  "scripts/ci/kind-diagnostics.sh"
   "scripts/local/stack/platform-up.sh"
   "scripts/local/stack/deploy-artifacts.sh"
   "scripts/local/stack/teardown.sh"

--- a/tools/olf/olf/cli.py
+++ b/tools/olf/olf/cli.py
@@ -22,6 +22,7 @@ from olf import contracts as contracts_module
 from olf import floe as floe_module
 from olf import inventory as inventory_module
 from olf import layers as layers_module
+from olf import smoke as smoke_module
 
 app = typer.Typer(
     name="olf",
@@ -41,6 +42,7 @@ superset_app = typer.Typer(help="Superset report deploy/export helpers.")
 openmetadata_app = typer.Typer(help="OpenMetadata governance metadata helpers.")
 k8s_app = typer.Typer(help="Kubernetes image bookkeeping helpers.")
 e2e_app = typer.Typer(help="End-to-end environment validation.")
+smoke_app = typer.Typer(help="Bounded deployment smoke helpers.")
 release_app = typer.Typer(help="Release manifest, checksums, compatibility matrix, and readiness gate.")
 app.add_typer(contracts_app, name="contracts")
 app.add_typer(inventory_app, name="inventory")
@@ -53,6 +55,7 @@ app.add_typer(superset_app, name="superset")
 app.add_typer(openmetadata_app, name="openmetadata")
 app.add_typer(k8s_app, name="k8s")
 app.add_typer(e2e_app, name="e2e")
+app.add_typer(smoke_app, name="smoke")
 app.add_typer(release_app, name="release")
 
 
@@ -545,6 +548,19 @@ def e2e_run(
             kube_context=config.env("KUBE_CONTEXT"),
         )
     except e2e.E2EError as exc:
+        raise typer.Exit(code=_fail(str(exc))) from exc
+
+
+@smoke_app.command("run")
+def smoke_run(
+    timeout_seconds: int = typer.Option(
+        2700, "--timeout-seconds", help="Hard wall-clock limit for the complete smoke path."
+    ),
+) -> None:
+    """Deploy the slim local stack and validate one product before the deadline."""
+    try:
+        smoke_module.run(timeout_seconds=timeout_seconds)
+    except smoke_module.SmokeError as exc:
         raise typer.Exit(code=_fail(str(exc))) from exc
 
 

--- a/tools/olf/olf/e2e.py
+++ b/tools/olf/olf/e2e.py
@@ -24,7 +24,7 @@ import yaml
 from botocore.config import Config
 
 from olf import contracts, k8s, log, superset
-from olf.inventory import DomainInventory, inventory_for
+from olf.inventory import DomainInventory, Product, inventory_for
 
 Environment = Literal["local", "azure", "aws"]
 Suite = Literal["full", "smoke"]
@@ -333,6 +333,11 @@ def run_smoke(cfg: E2EConfig) -> None:
         check_aws_provider_contracts(cfg)
         check_aws_storage_and_glue(cfg)
     check_trino_catalog(cfg)
+    if cfg.env == "local":
+        product = cfg.inventory.default_product
+        log.step(f"Running smoke path for descriptor-selected product {product.id}...")
+        launch_and_poll_dagster_jobs(cfg, products=(product,))
+        check_trino_product_tables_and_marts(cfg, product)
 
 
 def run_full(cfg: E2EConfig) -> None:
@@ -484,6 +489,28 @@ def check_trino_tables_and_marts(cfg: E2EConfig) -> None:
             raise E2EError(f"expected iceberg.{mart} to contain rows, got {count}")
 
 
+def check_trino_product_tables_and_marts(cfg: E2EConfig, product: Product) -> None:
+    """Verify the selected smoke product reached populated Silver and Gold tables."""
+    check_trino_catalog(cfg)
+    log.step(f"Checking Silver and Gold tables for {product.id}...")
+    silver_count = trino_scalar(
+        cfg,
+        "SELECT count(*) FROM iceberg.information_schema.tables "
+        f"WHERE table_schema = '{product.silver_namespace}'",
+    )
+    gold_count = trino_scalar(
+        cfg,
+        "SELECT count(*) FROM iceberg.information_schema.tables "
+        f"WHERE table_schema = '{product.gold_namespace}'",
+    )
+    assert_scalar_equals(silver_count, str(len(product.silver_tables)), f"{product.id} Silver table count")
+    assert_scalar_equals(gold_count, str(len(product.gold_tables)), f"{product.id} Gold mart count")
+    for mart in product.gold_mart_names:
+        count = trino_scalar(cfg, f"SELECT count(*) FROM iceberg.{mart}")
+        if int(count) <= 0:
+            raise E2EError(f"expected iceberg.{mart} to contain rows, got {count}")
+
+
 def check_polaris_restart_recovery(cfg: E2EConfig) -> None:
     """Verify that Polaris keeps table identity after its pod is recreated."""
     log.step("Checking Polaris restart recovery...")
@@ -558,7 +585,7 @@ def assert_scalar_equals(actual: str, expected: str, label: str) -> None:
         raise E2EError(f"expected {label} {expected}, got {actual}")
 
 
-def launch_and_poll_dagster_jobs(cfg: E2EConfig) -> None:
+def launch_and_poll_dagster_jobs(cfg: E2EConfig, *, products: Sequence[Product] | None = None) -> None:
     log.step("Launching and polling Dagster product jobs...")
     assert cfg.dagster_local_port is not None
     log_path = f"/tmp/openlakeforge-{cfg.env}-dagster-port-forward.log"
@@ -576,7 +603,8 @@ def launch_and_poll_dagster_jobs(cfg: E2EConfig) -> None:
         location_names = expected_repository_location_names(cfg)
         client = DagsterClient(f"{base_url}/graphql", expected_location_names=location_names)
         timeout_seconds = int(os.environ.get("DAGSTER_JOB_TIMEOUT_SECONDS", str(DAGSTER_JOB_TIMEOUT_SECONDS)))
-        for job in cfg.inventory.job_names:
+        for product in products or cfg.inventory.products:
+            job = product.job_name
             try:
                 run_id = client.launch(job)
             except E2EError as exc:

--- a/tools/olf/olf/smoke.py
+++ b/tools/olf/olf/smoke.py
@@ -1,0 +1,95 @@
+"""Bounded local deployment smoke orchestration."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from collections.abc import Callable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+
+from olf import log
+
+
+class SmokeError(RuntimeError):
+    """The bounded smoke deployment failed or exceeded its deadline."""
+
+
+@dataclass(frozen=True)
+class SmokePhase:
+    """One supported Make target in the local smoke path."""
+
+    label: str
+    target: str
+
+
+PHASES = (
+    SmokePhase("Deploying slim local platform", "local-slim-up"),
+    SmokePhase("Validating one product pipeline and Gold table", "local-slim-e2e E2E_SUITE=smoke"),
+)
+
+
+def run(
+    *,
+    timeout_seconds: int,
+    environ: Mapping[str, str] | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    popen: Callable[..., subprocess.Popen[str]] = subprocess.Popen,
+) -> None:
+    """Run the local slim smoke target sequence within one hard deadline."""
+    if timeout_seconds <= 0:
+        raise SmokeError("smoke timeout must be greater than zero seconds")
+
+    started = monotonic()
+    deadline = started + timeout_seconds
+    env = dict(environ or os.environ)
+    for phase in PHASES:
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise SmokeError(_timeout_message(timeout_seconds, phase.label))
+        log.step(f"{phase.label} ({int(remaining)}s remaining)...")
+        _run_make_phase(
+            phase,
+            env=env,
+            timeout_seconds=remaining,
+            budget_seconds=timeout_seconds,
+            popen=popen,
+        )
+    log.info(f"Local slim smoke passed in {int(monotonic() - started)}s (budget: {timeout_seconds}s).")
+
+
+def _run_make_phase(
+    phase: SmokePhase,
+    *,
+    env: Mapping[str, str],
+    timeout_seconds: float,
+    budget_seconds: int,
+    popen: Callable[..., subprocess.Popen[str]],
+) -> None:
+    command = ["make", *phase.target.split()]
+    process = popen(command, env=dict(env), start_new_session=True, text=True)
+    try:
+        returncode = process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        _terminate_process_group(process)
+        raise SmokeError(_timeout_message(budget_seconds, phase.label)) from exc
+    if returncode != 0:
+        raise SmokeError(f"{phase.label} failed with exit code {returncode}.")
+
+
+def _terminate_process_group(process: subprocess.Popen[str]) -> None:
+    """Terminate Make and every child it started before returning control to CI."""
+    with suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=10)
+
+
+def _timeout_message(timeout_seconds: int, phase: str) -> str:
+    return f"Local slim smoke exceeded its {timeout_seconds}s time budget during: {phase}."

--- a/tools/olf/tests/test_e2e.py
+++ b/tools/olf/tests/test_e2e.py
@@ -219,6 +219,39 @@ def test_aws_explicit_smoke_suite_skips_full_checks(monkeypatch: pytest.MonkeyPa
     assert calls == ["smoke"]
 
 
+def test_local_smoke_runs_only_the_descriptor_default_product(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[object] = []
+    local_cfg = cfg(tmp_path, suite="smoke")
+
+    monkeypatch.setattr(e2e, "check_trino_catalog", lambda _cfg: calls.append("catalog"))
+    monkeypatch.setattr(
+        e2e,
+        "launch_and_poll_dagster_jobs",
+        lambda _cfg, *, products=None: calls.append(tuple(product.id for product in products or ())),
+    )
+    monkeypatch.setattr(
+        e2e,
+        "check_trino_product_tables_and_marts",
+        lambda _cfg, product: calls.append(("tables", product.id)),
+    )
+
+    e2e.run_smoke(local_cfg)
+
+    assert calls == ["catalog", (INVENTORY.default_product.id,), ("tables", INVENTORY.default_product.id)]
+
+
+def test_smoke_product_table_check_fails_for_an_empty_gold_mart(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    product = INVENTORY.default_product
+    values = iter((str(len(product.silver_tables)), str(len(product.gold_tables)), "0"))
+    monkeypatch.setattr(e2e, "check_trino_catalog", lambda _cfg: None)
+    monkeypatch.setattr(e2e, "trino_scalar", lambda _cfg, _sql: next(values))
+
+    with pytest.raises(e2e.E2EError, match="expected iceberg"):
+        e2e.check_trino_product_tables_and_marts(cfg(tmp_path, suite="smoke"), product)
+
+
 @pytest.mark.parametrize(
     ("env", "expected"),
     [

--- a/tools/olf/tests/test_smoke.py
+++ b/tools/olf/tests/test_smoke.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import signal
+import subprocess
+
+import pytest
+
+from olf import smoke
+
+
+class FakeProcess:
+    def __init__(self, *, returncode: int = 0, timeout: bool = False) -> None:
+        self.pid = 123
+        self.returncode = returncode
+        self.timeout = timeout
+        self.wait_timeouts: list[float] = []
+
+    def wait(self, timeout: float) -> int:
+        self.wait_timeouts.append(timeout)
+        if self.timeout and len(self.wait_timeouts) == 1:
+            raise subprocess.TimeoutExpired("make", timeout)
+        return self.returncode
+
+
+def test_run_executes_supported_targets_in_order() -> None:
+    commands: list[list[str]] = []
+    processes = [FakeProcess(), FakeProcess()]
+
+    smoke.run(
+        timeout_seconds=2700,
+        environ={"CI": "true"},
+        monotonic=iter((0.0, 0.0, 10.0, 10.0, 20.0)).__next__,
+        popen=lambda command, **kwargs: commands.append(command) or processes.pop(0),
+    )
+
+    assert commands == [
+        ["make", "local-slim-up"],
+        ["make", "local-slim-e2e", "E2E_SUITE=smoke"],
+    ]
+
+
+def test_run_reports_nonzero_make_failure() -> None:
+    with pytest.raises(smoke.SmokeError, match="Deploying slim local platform failed with exit code 7"):
+        smoke.run(timeout_seconds=2700, popen=lambda *_args, **_kwargs: FakeProcess(returncode=7))
+
+
+def test_run_kills_process_group_when_a_phase_exceeds_the_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    signals: list[tuple[int, signal.Signals]] = []
+    monkeypatch.setattr(smoke.os, "killpg", lambda pid, sig: signals.append((pid, sig)))
+
+    with pytest.raises(smoke.SmokeError, match="2700s time budget"):
+        smoke.run(timeout_seconds=2700, popen=lambda *_args, **_kwargs: FakeProcess(timeout=True))
+
+    assert signals == [(123, signal.SIGTERM)]
+
+
+def test_run_rejects_a_nonpositive_budget() -> None:
+    with pytest.raises(smoke.SmokeError, match="greater than zero"):
+        smoke.run(timeout_seconds=0)


### PR DESCRIPTION
Closes #81

## What changed
- Add a pull-request-only kind smoke job using the slim profile.
- Add `make local-slim-smoke`, a 45-minute bounded foundation → platform → artifacts → one descriptor-driven product pipeline → Gold query path.
- Retain host, cluster, pod, event, and container-log diagnostics on failure.
- Pin and catalog the kind action SHA.

## Validation
- `uv run --project tools/olf ruff check tools/olf`
- `uv run --project tools/olf pytest tools/olf/tests` (232 passed)
- `make check-structure`
- `make check-components`
- `make check-contracts`
- `make check-infra`
- `make check-lockfiles`

## Required negative deployment proof
Run [31590821597](https://github.com/malon64/openlakeforge/actions/runs/31590821597) deliberately used `ghcr.io/openlakeforge/project-code:ci-intentionally-missing`. It failed after 14m59s at the Dagster rollout with `ErrImageNeverPull`; diagnostics were retained as `kind-smoke-diagnostics-31590821597` (49.7 KB). The next commit restores the `local` image tag for the clean run.

## Runtime note
The local smoke target could not provide clean runtime evidence on this host: it has 11Gi free disk, 24.76Gi Docker images, and an existing kind cluster. The PR job is deliberately left at the full slim scope; its failure artifact includes capacity measurements if the standard runner cannot sustain it.