### PR TITLE
[codex] stabilize azure port-forward readiness

### DIFF
--- a/tools/olf/olf/e2e.py
+++ b/tools/olf/olf/e2e.py
@@ -87,6 +87,12 @@ def _bounded_pod_diagnostics(cfg: E2EConfig, names: list[str]) -> str:
             )
         except E2EError as exc:
             output = f"unable to collect logs: {exc}"
+            try:
+                description = kubectl(cfg, ["describe", "pod", "-n", cfg.namespace, name], capture=True)
+            except E2EError as describe_exc:
+                output += f"\nunable to describe pod: {describe_exc}"
+            else:
+                output += f"\npod description:\n{description[-6000:]}"
         lines.append(f"{name}:\n{output[-6000:]}")
     return "\n".join(lines)
 

--- a/tools/olf/olf/k8s.py
+++ b/tools/olf/olf/k8s.py
@@ -26,6 +26,10 @@ class KubectlError(RuntimeError):
     pass
 
 
+PORT_FORWARD_READY_TIMEOUT_SECONDS = 30.0
+PORT_FORWARD_READY_POLL_SECONDS = 0.1
+
+
 def kubectl_command(args: list[str], *, kube_context: str | None = None) -> list[str]:
     """Build a kubectl command pinned to the declared deployment context."""
     context = kube_context or os.environ.get("KUBE_CONTEXT")
@@ -88,6 +92,35 @@ def _free_local_port() -> int:
         return sock.getsockname()[1]
 
 
+def _port_forward_failure(log_path: str, detail: str) -> KubectlError:
+    """Return a bounded, actionable error for a port-forward that did not start."""
+    try:
+        log_tail = open(log_path, encoding="utf-8").read()[-4000:].strip()
+    except OSError:
+        log_tail = ""
+    if log_tail:
+        detail = f"{detail}\nkubectl port-forward log:\n{log_tail}"
+    return KubectlError(detail)
+
+
+def _wait_for_port_forward(process: subprocess.Popen[object], port: int, log_path: str) -> None:
+    """Wait until kubectl has bound the local forwarding socket."""
+    deadline = time.monotonic() + PORT_FORWARD_READY_TIMEOUT_SECONDS
+    while True:
+        if process.poll() is not None:
+            raise _port_forward_failure(log_path, f"kubectl port-forward exited before localhost:{port} became ready.")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=PORT_FORWARD_READY_POLL_SECONDS):
+                return
+        except OSError as err:
+            if time.monotonic() >= deadline:
+                raise _port_forward_failure(
+                    log_path,
+                    f"timed out waiting for kubectl port-forward to bind localhost:{port}.",
+                ) from err
+            time.sleep(PORT_FORWARD_READY_POLL_SECONDS)
+
+
 @contextlib.contextmanager
 def port_forward(
     service: str,
@@ -100,8 +133,8 @@ def port_forward(
 ) -> Iterator[int]:
     """Run `kubectl port-forward` for the block, yielding the local port.
 
-    Callers own readiness polling because each service has a different health
-    probe (Polaris OAuth, OpenMetadata JWKS, S3 head-bucket).
+    The yielded localhost port is accepting connections. Callers still own the
+    service-specific health probe (Polaris OAuth, OpenMetadata JWKS, S3 bucket).
     """
     port = local_port or _free_local_port()
     command = kubectl_command(
@@ -121,6 +154,7 @@ def port_forward(
             stderr=subprocess.STDOUT,
         )
     try:
+        _wait_for_port_forward(process, port, log_path)
         yield port
     finally:
         process.terminate()

--- a/tools/olf/tests/test_e2e.py
+++ b/tools/olf/tests/test_e2e.py
@@ -227,6 +227,28 @@ def test_classify_job_health_warns_for_historical_suite_job_failure() -> None:
     assert warned == ["dagster-run-old: non-blocking Job is Failed; continuing E2E readiness"]
 
 
+def test_bounded_pod_diagnostics_describes_a_pod_when_logs_are_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_kubectl(_cfg: e2e.E2EConfig, args: list[str], *, capture: bool = False) -> str:
+        calls.append(args)
+        if args[0] == "logs":
+            raise e2e.E2EError("container is waiting to start")
+        return "Events:\n  Failed to pull image"
+
+    monkeypatch.setattr(e2e, "kubectl", fake_kubectl)
+
+    diagnostics = e2e._bounded_pod_diagnostics(cfg(tmp_path), ["dagster-pod"])
+
+    assert calls == [
+        ["logs", "-n", "lakehouse", "pod/dagster-pod", "--all-containers", "--tail=80"],
+        ["describe", "pod", "-n", "lakehouse", "dagster-pod"],
+    ]
+    assert "Failed to pull image" in diagnostics
+
+
 def test_check_pods_ready_retries_until_pods_are_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     pod_payloads = iter(
         [

--- a/tools/olf/tests/test_k8s.py
+++ b/tools/olf/tests/test_k8s.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -65,6 +65,7 @@ def test_port_forward_uses_explicit_kube_context(monkeypatch: pytest.MonkeyPatch
     process.poll.return_value = 0
     popen = Mock(return_value=process)
     monkeypatch.setattr(k8s.subprocess, "Popen", popen)
+    monkeypatch.setattr(k8s, "_wait_for_port_forward", Mock())
 
     with k8s.port_forward(
         "superset",
@@ -86,6 +87,70 @@ def test_port_forward_uses_explicit_kube_context(monkeypatch: pytest.MonkeyPatch
         "-n",
         "lakehouse",
     ]
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once_with(timeout=10)
+
+
+def test_wait_for_port_forward_retries_until_the_listener_accepts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    process = Mock()
+    process.poll.return_value = None
+    attempts = iter((OSError("not ready"), MagicMock()))
+
+    def create_connection(*_args: object, **_kwargs: object) -> MagicMock:
+        result = next(attempts)
+        if isinstance(result, OSError):
+            raise result
+        return result
+
+    monkeypatch.setattr(k8s.socket, "create_connection", create_connection)
+    monkeypatch.setattr(k8s.time, "sleep", lambda _delay: None)
+
+    k8s._wait_for_port_forward(process, 18088, str(tmp_path / "port-forward.log"))
+
+
+def test_wait_for_port_forward_reports_an_early_process_exit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    log_path = tmp_path / "port-forward.log"
+    log_path.write_text("error: services \"missing\" not found\n")
+    process = Mock()
+    process.poll.return_value = 1
+
+    with pytest.raises(k8s.KubectlError, match="services .*missing.*not found"):
+        k8s._wait_for_port_forward(process, 18088, str(log_path))
+
+
+def test_wait_for_port_forward_times_out_and_reports_the_log(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    log_path = tmp_path / "port-forward.log"
+    log_path.write_text("still starting\n")
+    process = Mock()
+    process.poll.return_value = None
+    clock = iter((0.0, 0.0, k8s.PORT_FORWARD_READY_TIMEOUT_SECONDS + 0.1))
+
+    monkeypatch.setattr(k8s.socket, "create_connection", Mock(side_effect=OSError("not ready")))
+    monkeypatch.setattr(k8s.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(k8s.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(k8s.KubectlError, match=r"(?s)timed out.*still starting"):
+        k8s._wait_for_port_forward(process, 18088, str(log_path))
+
+
+def test_port_forward_cleans_up_after_readiness_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    process = Mock()
+    process.poll.return_value = 0
+    monkeypatch.setattr(k8s.subprocess, "Popen", Mock(return_value=process))
+    monkeypatch.setattr(k8s, "_wait_for_port_forward", Mock(side_effect=k8s.KubectlError("not ready")))
+
+    with pytest.raises(k8s.KubectlError, match="not ready"):
+        with k8s.port_forward(
+            "polaris",
+            8181,
+            "lakehouse",
+            log_path=str(tmp_path / "port-forward.log"),
+            kube_context="kind-openlakeforge-local",
+        ):
+            pass
+
     process.terminate.assert_called_once_with()
     process.wait.assert_called_once_with(timeout=10)
 


### PR DESCRIPTION
## Summary

Makes Kubernetes port forwards reliable for all `olf` callers by waiting until
the local listener is accepting connections before yielding the selected port.
This removes the Azure artifact-deploy race where Polaris OAuth namespace
reconciliation could attempt a request before `kubectl port-forward` had bound
its socket.

The E2E diagnostics now retain the configured namespace and fall back to a
bounded `kubectl describe pod` result when a Pending or ImagePullBackOff pod
has no container logs. This exposes the actual scheduling or image-pull reason
instead of an unrelated `default`-namespace NotFound error.

## Cause and effect

`port_forward()` previously returned immediately after starting `kubectl`. On
Azure, that allowed the Polaris token request to race the local listener and
fail with connection refused, aborting artifacts before the project-code image
was pushed to ACR. Dagster then remained in ImagePullBackOff because that tag
did not exist.

## Validation

- `make release-check`
- `uv run --project tools/olf ruff check tools/olf`
- `uv run --project tools/olf pytest tools/olf/tests` — 281 passed
- `make azure-up`
- `make azure-e2e` — passed

Live Azure verification confirmed relational JDBC Polaris, successful Polaris
bootstrap jobs, the `azure-b787966` ACR project-code tag, and ready Dagster
deployments.
