### PR TITLE
feat: add Python process execution, tool wrappers, and deployment context to olf

### DIFF
--- a/tools/olf/olf/deployment/__init__.py
+++ b/tools/olf/olf/deployment/__init__.py
@@ -1,0 +1,8 @@
+"""Deployment state/context/orchestration primitives.
+
+`olf.deployment` holds typed errors, retry policy, and `DeploymentContext` —
+data/path/environment rules. It does not execute external processes; that is
+`olf.tooling`'s job.
+"""
+
+from __future__ import annotations

--- a/tools/olf/olf/deployment/context.py
+++ b/tools/olf/olf/deployment/context.py
@@ -1,0 +1,247 @@
+"""Typed deployment context: paths, provider identity, and scoped environment.
+
+This is deliberately separate from `olf.config` (the lightweight runtime
+contract/environment helper); `DeploymentContext` is the new-code home for
+provider/profile-scoped path and environment construction. It never executes
+subprocesses and never mutates `os.environ` — building it is pure data
+assembly, and command execution stays owned by `olf.tooling`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+DEFAULT_NAMESPACE = "lakehouse"
+DEFAULT_LOCAL_CLUSTER_NAME = "openlakeforge-local"
+
+
+class Provider(StrEnum):
+    LOCAL = "local"
+    AWS = "aws"
+    AZURE = "azure"
+
+
+class Profile(StrEnum):
+    SLIM = "slim"
+    FULL = "full"
+
+
+@dataclass(frozen=True)
+class DeploymentPaths:
+    repo_root: Path
+    distribution_root: Path
+    work_root: Path
+    cache_root: Path
+    kubeconfig_path: Path
+    foundation_terraform_dir: Path
+    platform_terraform_dir: Path
+    foundation_state_path: Path
+    docker_config_dir: Path
+    helm_cache_dir: Path
+    helm_repository_config: Path
+    helm_repository_cache: Path
+    superset_report_work_dir: Path
+    port_forward_log_prefix: Path
+
+
+@dataclass(frozen=True)
+class DeploymentFeatures:
+    governance_enabled: bool
+    analytics_enabled: bool
+
+    @classmethod
+    def for_profile(cls, profile: Profile) -> DeploymentFeatures:
+        enabled = profile == Profile.FULL
+        return cls(governance_enabled=enabled, analytics_enabled=enabled)
+
+
+@dataclass(frozen=True)
+class DeploymentContext:
+    provider: Provider
+    profile: Profile
+    namespace: str
+    kube_context: str
+    paths: DeploymentPaths
+    features: DeploymentFeatures
+
+    @classmethod
+    def for_provider(cls, provider: Provider | str, *, repo_root: Path, **kwargs: object) -> DeploymentContext:
+        resolved = Provider(provider)
+        factory = {
+            Provider.LOCAL: cls.local,
+            Provider.AWS: cls.aws,
+            Provider.AZURE: cls.azure,
+        }[resolved]
+        return factory(repo_root=repo_root, **kwargs)  # type: ignore[arg-type]
+
+    @classmethod
+    def local(
+        cls,
+        *,
+        repo_root: Path,
+        profile: Profile = Profile.FULL,
+        distribution_root: Path | None = None,
+        namespace: str = DEFAULT_NAMESPACE,
+        cluster_name: str = DEFAULT_LOCAL_CLUSTER_NAME,
+    ) -> DeploymentContext:
+        return cls._build(
+            provider=Provider.LOCAL,
+            scope="local",
+            repo_root=repo_root,
+            distribution_root=distribution_root,
+            profile=profile,
+            namespace=namespace,
+            kube_context=f"kind-{cluster_name}",
+            foundation_terraform_dir=Path("infra/terraform/foundations/local-kind"),
+            platform_terraform_dir=Path("infra/terraform/environments/local"),
+        )
+
+    @classmethod
+    def aws(
+        cls,
+        *,
+        repo_root: Path,
+        profile: Profile = Profile.FULL,
+        distribution_root: Path | None = None,
+        namespace: str = DEFAULT_NAMESPACE,
+        kube_context: str = "",
+    ) -> DeploymentContext:
+        return cls._build(
+            provider=Provider.AWS,
+            scope="aws",
+            repo_root=repo_root,
+            distribution_root=distribution_root,
+            profile=profile,
+            namespace=namespace,
+            kube_context=kube_context,
+            foundation_terraform_dir=Path("infra/terraform/foundations/aws-eks"),
+            platform_terraform_dir=Path("infra/terraform/environments/aws-poc"),
+        )
+
+    @classmethod
+    def azure(
+        cls,
+        *,
+        repo_root: Path,
+        profile: Profile = Profile.FULL,
+        distribution_root: Path | None = None,
+        namespace: str = DEFAULT_NAMESPACE,
+        kube_context: str = "",
+    ) -> DeploymentContext:
+        return cls._build(
+            provider=Provider.AZURE,
+            scope="azure",
+            repo_root=repo_root,
+            distribution_root=distribution_root,
+            profile=profile,
+            namespace=namespace,
+            kube_context=kube_context,
+            foundation_terraform_dir=Path("infra/terraform/foundations/azure-aks"),
+            platform_terraform_dir=Path("infra/terraform/environments/azure-poc"),
+        )
+
+    @classmethod
+    def _build(
+        cls,
+        *,
+        provider: Provider,
+        scope: str,
+        repo_root: Path,
+        distribution_root: Path | None,
+        profile: Profile,
+        namespace: str,
+        kube_context: str,
+        foundation_terraform_dir: Path,
+        platform_terraform_dir: Path,
+    ) -> DeploymentContext:
+        resolved_repo_root = Path(repo_root).resolve()
+        resolved_distribution_root = (
+            Path(distribution_root).resolve() if distribution_root is not None else resolved_repo_root
+        )
+        work_root = resolved_repo_root / ".tmp"
+        helm_root = work_root / "helm" / scope
+
+        paths = DeploymentPaths(
+            repo_root=resolved_repo_root,
+            distribution_root=resolved_distribution_root,
+            work_root=work_root,
+            cache_root=work_root,
+            kubeconfig_path=work_root / "kubeconfigs" / f"{scope}.yaml",
+            foundation_terraform_dir=resolved_repo_root / foundation_terraform_dir,
+            platform_terraform_dir=resolved_repo_root / platform_terraform_dir,
+            foundation_state_path=resolved_repo_root / foundation_terraform_dir / "terraform.tfstate",
+            docker_config_dir=work_root / "docker" / scope,
+            helm_cache_dir=helm_root / "charts",
+            helm_repository_config=helm_root / "repositories.yaml",
+            helm_repository_cache=helm_root / "repository-cache",
+            superset_report_work_dir=work_root / "superset-reports" / scope,
+            port_forward_log_prefix=Path(f"/tmp/openlakeforge-{scope}"),
+        )
+        return cls(
+            provider=provider,
+            profile=profile,
+            namespace=namespace,
+            kube_context=kube_context,
+            paths=paths,
+            features=DeploymentFeatures.for_profile(profile),
+        )
+
+    def command_env(
+        self,
+        *,
+        base: Mapping[str, str] | None = None,
+        docker_host: str | None = None,
+    ) -> dict[str, str]:
+        """Build a command-scoped environment overlay.
+
+        Does not mutate `os.environ` or any mapping passed in as `base`;
+        returns a fresh dict a caller can pass to `ProcessRunner`/tool
+        adapters as `env`.
+        """
+        env: dict[str, str] = dict(base) if base is not None else {}
+        env["KUBECONFIG"] = str(self.paths.kubeconfig_path)
+        env["KUBE_CONTEXT"] = self.kube_context
+        env["DOCKER_CONFIG"] = str(self.paths.docker_config_dir)
+        env.setdefault("DOCKER_BUILDKIT", "1")
+        env.setdefault("BUILDKIT_PROGRESS", "plain")
+        env["HELM_REPOSITORY_CONFIG"] = str(self.paths.helm_repository_config)
+        env["HELM_REPOSITORY_CACHE"] = str(self.paths.helm_repository_cache)
+        env["SUPERSET_REPORT_WORK_DIR"] = str(self.paths.superset_report_work_dir)
+        env["OPENLAKEFORGE_PORT_FORWARD_LOG_PREFIX"] = str(self.paths.port_forward_log_prefix)
+        if docker_host:
+            env["DOCKER_HOST"] = docker_host
+        return env
+
+    def prepare_directories(self, *, docker_cli_plugins_source: Path | None = None) -> None:
+        """Create OpenLakeForge-owned working paths.
+
+        Also links `~/.docker/cli-plugins` (or `$DOCKER_CONFIG/cli-plugins`)
+        into the scoped Docker config directory, if present, so `docker build`
+        keeps using BuildKit without an existing destination being overwritten.
+        """
+        for directory in (
+            self.paths.kubeconfig_path.parent,
+            self.paths.docker_config_dir,
+            self.paths.helm_repository_config.parent,
+            self.paths.helm_repository_cache,
+            self.paths.helm_cache_dir,
+            self.paths.superset_report_work_dir,
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        self._link_docker_cli_plugins(source=docker_cli_plugins_source)
+
+    def _link_docker_cli_plugins(self, *, source: Path | None) -> None:
+        if source is None:
+            docker_config_source = os.environ.get("DOCKER_CONFIG")
+            source = Path(docker_config_source) if docker_config_source else Path.home() / ".docker"
+        cli_plugins_source = source / "cli-plugins"
+        destination = self.paths.docker_config_dir / "cli-plugins"
+
+        if not cli_plugins_source.is_dir() or destination.exists():
+            return
+        destination.symlink_to(cli_plugins_source)

--- a/tools/olf/olf/deployment/errors.py
+++ b/tools/olf/olf/deployment/errors.py
@@ -1,0 +1,83 @@
+"""Typed error hierarchy for the deployment substrate.
+
+`str(error)` on every error here is diagnostic-safe: it only ever includes
+sanitized argv/environment representations (see `olf.tooling.redact`), never
+raw secret values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from olf.tooling.redact import redact_argv, redact_env
+
+
+class DeploymentError(Exception):
+    """Base class for all deployment-substrate errors."""
+
+
+class ToolingError(DeploymentError):
+    """Base class for external process/tool execution errors."""
+
+
+class ExecutableNotFoundError(ToolingError):
+    """Raised when an executable resolver cannot locate a required tool."""
+
+    def __init__(self, tool: str, *, searched: str | None = None) -> None:
+        self.tool = tool
+        self.searched = searched
+        message = f"executable '{tool}' was not found"
+        if searched:
+            message = f"{message} (searched: {searched})"
+        super().__init__(message)
+
+
+class CommandExecutionError(ToolingError):
+    """Raised when a command exits non-zero and the caller asked to `check`."""
+
+    def __init__(
+        self,
+        argv: Sequence[str],
+        returncode: int,
+        *,
+        stdout: str = "",
+        stderr: str = "",
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self.argv = tuple(str(a) for a in argv)
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.cwd = cwd
+        self.env = dict(env) if env is not None else None
+
+        sanitized_argv = " ".join(redact_argv(self.argv))
+        message = f"command failed ({returncode}): {sanitized_argv}"
+        if cwd is not None:
+            message += f" (cwd={cwd})"
+        if self.env:
+            sanitized_env = redact_env(self.env)
+            message += f" env={sanitized_env}"
+        sanitized_stderr = self._sanitized_output(stderr)
+        if sanitized_stderr:
+            message += f"\nstderr: {sanitized_stderr}"
+        super().__init__(message)
+
+    def _sanitized_output(self, text: str) -> str:
+        # Command output is not scanned for secret content, only truncated
+        # for readability; secrets are kept out of argv/env in the first
+        # place rather than pattern-matched out of free-form tool output.
+        stripped = text.strip()
+        return stripped[:2000]
+
+
+class CommandTimeoutError(ToolingError):
+    """Raised when a command exceeds its configured timeout."""
+
+    def __init__(self, argv: Sequence[str], timeout_seconds: float) -> None:
+        self.argv = tuple(str(a) for a in argv)
+        self.timeout_seconds = timeout_seconds
+        sanitized_argv = " ".join(redact_argv(self.argv))
+        super().__init__(f"command timed out after {timeout_seconds:g}s: {sanitized_argv}")

--- a/tools/olf/olf/deployment/retry.py
+++ b/tools/olf/olf/deployment/retry.py
@@ -1,0 +1,61 @@
+"""Bounded, explicit retry primitive for deployment tooling calls.
+
+This is deliberately separate from `olf.tooling.process.ProcessRunner`:
+retrying is a policy a caller opts into per-call, never automatic behavior
+baked into process execution.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from olf.deployment.errors import CommandExecutionError
+
+# Receives the failing error and the 1-indexed attempt number that just
+# failed; returns whether another attempt should be made.
+RetryPredicate = Callable[[CommandExecutionError, int], bool]
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int = 4
+    delay_seconds: float = 20.0
+    backoff_multiplier: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        if self.delay_seconds < 0:
+            raise ValueError("delay_seconds must be >= 0")
+
+    def delay_for_attempt(self, attempt: int) -> float:
+        """Delay to sleep after the given (1-indexed) attempt fails."""
+        return self.delay_seconds * (self.backoff_multiplier ** (attempt - 1))
+
+
+def run_with_retry[T](
+    fn: Callable[[], T],
+    *,
+    policy: RetryPolicy,
+    retry_if: RetryPredicate | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> T:
+    """Run `fn`, retrying on `CommandExecutionError` per `policy`.
+
+    Attempt 1 always runs immediately. No sleep happens after the final
+    attempt. `retry_if`, when given, can veto a retry (e.g. only retry on
+    specific return codes/messages); by default every `CommandExecutionError`
+    is retryable up to `policy.max_attempts`.
+    """
+    attempt = 1
+    while True:
+        try:
+            return fn()
+        except CommandExecutionError as exc:
+            should_retry = retry_if(exc, attempt) if retry_if is not None else True
+            if not should_retry or attempt >= policy.max_attempts:
+                raise
+            sleep_fn(policy.delay_for_attempt(attempt))
+            attempt += 1

--- a/tools/olf/olf/tooling/__init__.py
+++ b/tools/olf/olf/tooling/__init__.py
@@ -1,0 +1,8 @@
+"""Execution of external programs: the process runner and tool adapters.
+
+`olf.tooling` wraps external executables (Terraform, Helm, kubectl, Docker,
+kind, aws, az) behind typed argv-based commands. It never reimplements what
+those tools do.
+"""
+
+from __future__ import annotations

--- a/tools/olf/olf/tooling/aws.py
+++ b/tools/olf/olf/tooling/aws.py
@@ -1,0 +1,54 @@
+"""Thin AWS CLI adapter: no boto3 resource provisioning, no lifecycle sequencing."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from olf.tooling.process import CommandResult, ProcessRunner
+from olf.tooling.resolver import ExecutableResolver
+
+
+class AwsCli:
+    def __init__(self, runner: ProcessRunner, resolver: ExecutableResolver) -> None:
+        self._runner = runner
+        self._resolver = resolver
+
+    def _executable(self) -> Path:
+        return self._resolver.resolve("aws")
+
+    def _run(self, args: list[str], *, env: Mapping[str, str] | None = None, check: bool = True) -> CommandResult:
+        return self._runner.run([str(self._executable()), *args], env=env, check=check)
+
+    def sts_get_caller_identity(self, *, env: Mapping[str, str] | None = None) -> Any:
+        result = self._run(["sts", "get-caller-identity", "--output", "json"], env=env)
+        return json.loads(result.stdout)
+
+    def eks_update_kubeconfig(
+        self,
+        cluster_name: str,
+        *,
+        region: str,
+        kubeconfig_path: Path,
+        alias: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = [
+            "eks",
+            "update-kubeconfig",
+            "--region",
+            region,
+            "--name",
+            cluster_name,
+            "--kubeconfig",
+            str(kubeconfig_path),
+        ]
+        if alias is not None:
+            args += ["--alias", alias]
+        return self._run(args, env=env)
+
+    def ecr_get_login_password(self, *, region: str, env: Mapping[str, str] | None = None) -> str:
+        result = self._run(["ecr", "get-login-password", "--region", region], env=env)
+        return result.stdout.strip()

--- a/tools/olf/olf/tooling/azure.py
+++ b/tools/olf/olf/tooling/azure.py
@@ -1,0 +1,56 @@
+"""Thin Azure CLI adapter: no Azure SDK resource provisioning, no lifecycle sequencing."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from olf.tooling.process import CommandResult, ProcessRunner
+from olf.tooling.resolver import ExecutableResolver
+
+
+class AzureCli:
+    def __init__(self, runner: ProcessRunner, resolver: ExecutableResolver) -> None:
+        self._runner = runner
+        self._resolver = resolver
+
+    def _executable(self) -> Path:
+        return self._resolver.resolve("az")
+
+    def _run(self, args: list[str], *, env: Mapping[str, str] | None = None, check: bool = True) -> CommandResult:
+        return self._runner.run([str(self._executable()), *args], env=env, check=check)
+
+    def account_show(self, *, env: Mapping[str, str] | None = None) -> Any:
+        result = self._run(["account", "show", "--output", "json"], env=env)
+        return json.loads(result.stdout)
+
+    def account_set(self, subscription: str, *, env: Mapping[str, str] | None = None) -> CommandResult:
+        return self._run(["account", "set", "--subscription", subscription], env=env)
+
+    def aks_get_credentials(
+        self,
+        cluster_name: str,
+        *,
+        resource_group: str,
+        kubeconfig_path: Path,
+        overwrite: bool = True,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = [
+            "aks",
+            "get-credentials",
+            "--resource-group",
+            resource_group,
+            "--name",
+            cluster_name,
+            "--file",
+            str(kubeconfig_path),
+        ]
+        if overwrite:
+            args.append("--overwrite-existing")
+        return self._run(args, env=env)
+
+    def acr_login(self, registry_name: str, *, env: Mapping[str, str] | None = None) -> CommandResult:
+        return self._run(["acr", "login", "--name", registry_name], env=env)

--- a/tools/olf/olf/tooling/docker.py
+++ b/tools/olf/olf/tooling/docker.py
@@ -1,0 +1,143 @@
+"""Thin Docker adapter.
+
+Preserves the "resolve the selected engine endpoint before scoping
+DOCKER_CONFIG" behavior from `scripts/lib/common.sh::configure_deployment_scope`
+so an isolated DOCKER_CONFIG cannot silently fall back to
+`/var/run/docker.sock` on hosts using Colima or another non-default context.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from olf.deployment.errors import CommandExecutionError
+from olf.deployment.retry import RetryPolicy, RetryPredicate
+from olf.tooling.process import CommandResult, ProcessRunner
+from olf.tooling.resolver import ExecutableResolver
+
+
+class Docker:
+    def __init__(self, runner: ProcessRunner, resolver: ExecutableResolver) -> None:
+        self._runner = runner
+        self._resolver = resolver
+
+    def _executable(self) -> Path:
+        return self._resolver.resolve("docker")
+
+    def _run(
+        self,
+        args: Sequence[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+        input_text: str | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        argv = [str(self._executable()), *args]
+        return self._runner.run(
+            argv,
+            env=env,
+            check=check,
+            input_text=input_text,
+            retry_policy=retry_policy,
+            retry_if=retry_if,
+        )
+
+    def context_show(self, *, env: Mapping[str, str] | None = None) -> str:
+        return self._run(["context", "show"], env=env).stdout.strip()
+
+    def context_inspect(
+        self,
+        name: str,
+        *,
+        format_template: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> str:
+        args = ["context", "inspect", name]
+        if format_template is not None:
+            args += ["--format", format_template]
+        return self._run(args, env=env).stdout.strip()
+
+    def resolve_current_engine_endpoint(self, *, env: Mapping[str, str] | None = None) -> str | None:
+        """Resolve `.Endpoints.docker.Host` for the currently selected context.
+
+        Returns None (rather than raising) when Docker isn't usable, mirroring
+        the shell helper's `|| true` fallback — callers keep any explicit
+        DOCKER_HOST override in that case.
+        """
+        try:
+            current = self.context_show(env=env)
+            endpoint = self.context_inspect(current, format_template="{{.Endpoints.docker.Host}}", env=env)
+        except CommandExecutionError:
+            return None
+        return endpoint or None
+
+    def build(
+        self,
+        context_dir: Path,
+        *,
+        tag: str | None = None,
+        file: Path | None = None,
+        build_args: Mapping[str, str] | None = None,
+        extra_args: Sequence[str] = (),
+        env: Mapping[str, str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        args = ["build", str(context_dir)]
+        if tag is not None:
+            args += ["-t", tag]
+        if file is not None:
+            args += ["-f", str(file)]
+        for key, value in (build_args or {}).items():
+            args += ["--build-arg", f"{key}={value}"]
+        args.extend(extra_args)
+        return self._run(args, env=env, retry_policy=retry_policy, retry_if=retry_if)
+
+    def pull(
+        self,
+        image: str,
+        *,
+        env: Mapping[str, str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        return self._run(["pull", image], env=env, retry_policy=retry_policy, retry_if=retry_if)
+
+    def push(
+        self,
+        image: str,
+        *,
+        env: Mapping[str, str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        return self._run(["push", image], env=env, retry_policy=retry_policy, retry_if=retry_if)
+
+    def load(self, *, input_path: Path | None = None, env: Mapping[str, str] | None = None) -> CommandResult:
+        args = ["load"]
+        if input_path is not None:
+            args += ["-i", str(input_path)]
+        return self._run(args, env=env)
+
+    def tag(self, source: str, target: str, *, env: Mapping[str, str] | None = None) -> CommandResult:
+        return self._run(["tag", source, target], env=env)
+
+    def login(
+        self,
+        registry: str | None = None,
+        *,
+        username: str | None = None,
+        password: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = ["login"]
+        if username is not None:
+            args += ["--username", username]
+        if password is not None:
+            args.append("--password-stdin")
+        if registry is not None:
+            args.append(registry)
+        return self._run(args, env=env, input_text=password)

--- a/tools/olf/olf/tooling/helm.py
+++ b/tools/olf/olf/tooling/helm.py
@@ -1,0 +1,151 @@
+"""Thin Helm adapter: low-level chart/repo primitives only.
+
+Higher-level chart-cache policy (e.g. re-packing the Dagster chart without
+its values schema) belongs to a future deployment-lifecycle issue, not here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from olf.deployment.retry import RetryPolicy, RetryPredicate
+from olf.tooling.process import CommandResult, ProcessRunner
+from olf.tooling.resolver import ExecutableResolver
+
+
+class Helm:
+    def __init__(self, runner: ProcessRunner, resolver: ExecutableResolver) -> None:
+        self._runner = runner
+        self._resolver = resolver
+
+    def _executable(self) -> Path:
+        return self._resolver.resolve("helm")
+
+    def _run(
+        self,
+        args: Sequence[str],
+        *,
+        repository_config: Path | None = None,
+        repository_cache: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        argv = [str(self._executable()), *args]
+        merged_env: dict[str, str] = dict(env or {})
+        if repository_config is not None:
+            merged_env["HELM_REPOSITORY_CONFIG"] = str(repository_config)
+        if repository_cache is not None:
+            merged_env["HELM_REPOSITORY_CACHE"] = str(repository_cache)
+        return self._runner.run(
+            argv,
+            env=merged_env or None,
+            check=check,
+            retry_policy=retry_policy,
+            retry_if=retry_if,
+        )
+
+    def repo_add(
+        self,
+        name: str,
+        url: str,
+        *,
+        force_update: bool = True,
+        repository_config: Path | None = None,
+        repository_cache: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        args = ["repo", "add", name, url]
+        if force_update:
+            args.append("--force-update")
+        return self._run(
+            args,
+            repository_config=repository_config,
+            repository_cache=repository_cache,
+            env=env,
+            retry_policy=retry_policy,
+            retry_if=retry_if,
+        )
+
+    def repo_update(
+        self,
+        *,
+        repository_config: Path | None = None,
+        repository_cache: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        return self._run(
+            ["repo", "update"],
+            repository_config=repository_config,
+            repository_cache=repository_cache,
+            env=env,
+            retry_policy=retry_policy,
+            retry_if=retry_if,
+        )
+
+    def pull(
+        self,
+        chart_ref: str,
+        *,
+        version: str | None = None,
+        destination: Path | None = None,
+        untar: bool = False,
+        untar_dir: Path | None = None,
+        repository_config: Path | None = None,
+        repository_cache: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        args = ["pull", chart_ref]
+        if version is not None:
+            args += ["--version", version]
+        if destination is not None:
+            args += ["--destination", str(destination)]
+        if untar:
+            args.append("--untar")
+        if untar_dir is not None:
+            args += ["--untardir", str(untar_dir)]
+        return self._run(
+            args,
+            repository_config=repository_config,
+            repository_cache=repository_cache,
+            env=env,
+            retry_policy=retry_policy,
+            retry_if=retry_if,
+        )
+
+    def show_chart(
+        self,
+        chart_path: Path,
+        *,
+        repository_config: Path | None = None,
+        repository_cache: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        check: bool = False,
+    ) -> CommandResult:
+        return self._run(
+            ["show", "chart", str(chart_path)],
+            repository_config=repository_config,
+            repository_cache=repository_cache,
+            env=env,
+            check=check,
+        )
+
+    def package(
+        self,
+        chart_dir: Path,
+        *,
+        destination: Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = ["package", str(chart_dir)]
+        if destination is not None:
+            args += ["--destination", str(destination)]
+        return self._run(args, env=env)

--- a/tools/olf/olf/tooling/kind.py
+++ b/tools/olf/olf/tooling/kind.py
@@ -1,0 +1,76 @@
+"""Thin kind adapter. Cluster lifecycle stays owned by Terraform for now."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from olf.tooling.process import CommandResult, ProcessRunner
+from olf.tooling.resolver import ExecutableResolver
+
+
+class Kind:
+    def __init__(self, runner: ProcessRunner, resolver: ExecutableResolver) -> None:
+        self._runner = runner
+        self._resolver = resolver
+
+    def _executable(self) -> Path:
+        return self._resolver.resolve("kind")
+
+    def _run(self, args: list[str], *, env: Mapping[str, str] | None = None, check: bool = True) -> CommandResult:
+        return self._runner.run([str(self._executable()), *args], env=env, check=check)
+
+    def get_clusters(self, *, env: Mapping[str, str] | None = None) -> list[str]:
+        result = self._run(["get", "clusters"], env=env)
+        return [line for line in result.stdout.splitlines() if line]
+
+    def export_kubeconfig(
+        self,
+        cluster_name: str,
+        *,
+        kubeconfig_path: Path,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        return self._run(
+            ["export", "kubeconfig", "--name", cluster_name, "--kubeconfig", str(kubeconfig_path)],
+            env=env,
+        )
+
+    def load_docker_image(
+        self,
+        image: str,
+        *,
+        cluster_name: str,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        return self._run(["load", "docker-image", image, "--name", cluster_name], env=env)
+
+    def create_cluster(
+        self,
+        cluster_name: str,
+        *,
+        config_path: Path | None = None,
+        kubeconfig_path: Path | None = None,
+        wait: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = ["create", "cluster", "--name", cluster_name]
+        if config_path is not None:
+            args += ["--config", str(config_path)]
+        if kubeconfig_path is not None:
+            args += ["--kubeconfig", str(kubeconfig_path)]
+        if wait is not None:
+            args += ["--wait", wait]
+        return self._run(args, env=env)
+
+    def delete_cluster(
+        self,
+        cluster_name: str,
+        *,
+        kubeconfig_path: Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = ["delete", "cluster", "--name", cluster_name]
+        if kubeconfig_path is not None:
+            args += ["--kubeconfig", str(kubeconfig_path)]
+        return self._run(args, env=env)

--- a/tools/olf/olf/tooling/kubectl.py
+++ b/tools/olf/olf/tooling/kubectl.py
@@ -1,0 +1,196 @@
+"""Thin kubectl adapter: primitives only, no cleanup/import lifecycle logic.
+
+Every cluster-scoped call takes `context`/`kubeconfig`/`namespace` explicitly
+so behavior never depends on the caller's ambient kubectl context.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from olf.deployment.errors import CommandExecutionError, ToolingError
+from olf.deployment.retry import RetryPolicy, RetryPredicate
+from olf.tooling.process import CommandResult, ProcessRunner
+from olf.tooling.resolver import ExecutableResolver
+
+
+class KubeContextUnreachableError(ToolingError):
+    def __init__(self, context: str, *, reason: str) -> None:
+        self.context = context
+        self.reason = reason
+        super().__init__(f"Kubernetes context '{context}' is not reachable: {reason}")
+
+
+class Kubectl:
+    def __init__(self, runner: ProcessRunner, resolver: ExecutableResolver) -> None:
+        self._runner = runner
+        self._resolver = resolver
+
+    def _executable(self) -> Path:
+        return self._resolver.resolve("kubectl")
+
+    def _run(
+        self,
+        args: Sequence[str],
+        *,
+        context: str | None = None,
+        kubeconfig: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+        timeout_seconds: float | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        argv = [str(self._executable())]
+        if context is not None:
+            argv += ["--context", context]
+        argv.extend(args)
+
+        merged_env: dict[str, str] = dict(env or {})
+        if kubeconfig is not None:
+            merged_env["KUBECONFIG"] = str(kubeconfig)
+
+        return self._runner.run(
+            argv,
+            env=merged_env or None,
+            check=check,
+            timeout_seconds=timeout_seconds,
+            retry_policy=retry_policy,
+            retry_if=retry_if,
+        )
+
+    def config_get_contexts(
+        self,
+        *,
+        kubeconfig: Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> list[str]:
+        result = self._run(["config", "get-contexts", "-o", "name"], kubeconfig=kubeconfig, env=env)
+        return [line for line in result.stdout.splitlines() if line]
+
+    def cluster_info(
+        self,
+        *,
+        context: str | None = None,
+        kubeconfig: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+    ) -> CommandResult:
+        return self._run(["cluster-info"], context=context, kubeconfig=kubeconfig, env=env, check=check)
+
+    def get(
+        self,
+        resource: str,
+        *,
+        name: str | None = None,
+        namespace: str | None = None,
+        context: str | None = None,
+        kubeconfig: Path | None = None,
+        output: str | None = None,
+        extra_args: Sequence[str] = (),
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+    ) -> CommandResult:
+        args = ["get", resource]
+        if name is not None:
+            args.append(name)
+        if namespace is not None:
+            args += ["-n", namespace]
+        if output is not None:
+            args += ["-o", output]
+        args.extend(extra_args)
+        return self._run(args, context=context, kubeconfig=kubeconfig, env=env, check=check)
+
+    def delete(
+        self,
+        resource: str,
+        name: str,
+        *,
+        namespace: str | None = None,
+        context: str | None = None,
+        kubeconfig: Path | None = None,
+        ignore_not_found: bool = True,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = ["delete", resource, name]
+        if namespace is not None:
+            args += ["-n", namespace]
+        if ignore_not_found:
+            args.append("--ignore-not-found")
+        return self._run(args, context=context, kubeconfig=kubeconfig, env=env)
+
+    def rollout_status(
+        self,
+        resource: str,
+        *,
+        namespace: str | None = None,
+        context: str | None = None,
+        kubeconfig: Path | None = None,
+        timeout: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = ["rollout", "status", resource]
+        if namespace is not None:
+            args += ["-n", namespace]
+        if timeout is not None:
+            args += ["--timeout", timeout]
+        return self._run(args, context=context, kubeconfig=kubeconfig, env=env)
+
+    def wait(
+        self,
+        resource: str,
+        *,
+        for_condition: str,
+        namespace: str | None = None,
+        context: str | None = None,
+        kubeconfig: Path | None = None,
+        timeout: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = ["wait", resource, f"--for={for_condition}"]
+        if namespace is not None:
+            args += ["-n", namespace]
+        if timeout is not None:
+            args += ["--timeout", timeout]
+        return self._run(args, context=context, kubeconfig=kubeconfig, env=env)
+
+    def port_forward(
+        self,
+        resource: str,
+        ports: Sequence[str],
+        *,
+        namespace: str | None = None,
+        context: str | None = None,
+        kubeconfig: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+    ) -> CommandResult:
+        args = ["port-forward", resource, *ports]
+        if namespace is not None:
+            args += ["-n", namespace]
+        return self._run(
+            args,
+            context=context,
+            kubeconfig=kubeconfig,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def require_context_reachable(
+        self,
+        context: str,
+        *,
+        kubeconfig: Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        contexts = self.config_get_contexts(kubeconfig=kubeconfig, env=env)
+        if context not in contexts:
+            raise KubeContextUnreachableError(
+                context,
+                reason=f"absent from kubeconfig {kubeconfig if kubeconfig is not None else '(default)'}",
+            )
+        try:
+            self.cluster_info(context=context, kubeconfig=kubeconfig, env=env)
+        except CommandExecutionError as exc:
+            raise KubeContextUnreachableError(context, reason=str(exc)) from exc

--- a/tools/olf/olf/tooling/process.py
+++ b/tools/olf/olf/tooling/process.py
@@ -1,0 +1,154 @@
+"""The one process-execution API for new deployment code.
+
+Every command is executed as structured argv (`shell=False`); nothing here
+ever builds or interprets a shell command string.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from olf.deployment.errors import CommandExecutionError, CommandTimeoutError, ExecutableNotFoundError
+from olf.deployment.retry import RetryPolicy, RetryPredicate, run_with_retry
+from olf.tooling.redact import redact_argv
+
+
+@dataclass(frozen=True)
+class Command:
+    argv: tuple[str, ...]
+    cwd: Path | None = None
+    env: Mapping[str, str] | None = None
+    timeout_seconds: float | None = None
+    input_text: str | None = None
+
+    def __post_init__(self) -> None:
+        argv = tuple(str(part) for part in self.argv)
+        if not argv:
+            raise ValueError("Command.argv must not be empty")
+        object.__setattr__(self, "argv", argv)
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    argv: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+    duration_seconds: float
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+def _to_command(
+    command: Command | Sequence[str | Path],
+    *,
+    cwd: Path | None,
+    env: Mapping[str, str] | None,
+    timeout_seconds: float | None,
+    input_text: str | None,
+) -> Command:
+    if isinstance(command, Command):
+        return command
+    return Command(
+        argv=tuple(str(part) for part in command),
+        cwd=cwd,
+        env=env,
+        timeout_seconds=timeout_seconds,
+        input_text=input_text,
+    )
+
+
+class ProcessRunner:
+    """Executes `Command`s with `subprocess.run`, no shell involvement.
+
+    `env`, when given, is layered on top of a copy of the current process
+    environment (never `os.environ` itself) so callers only need to specify
+    the deployment-scoped overrides they care about, while the parent
+    process's environment is left untouched.
+    """
+
+    def __init__(self, *, log_commands: bool = False) -> None:
+        self._log_commands = log_commands
+
+    def run(
+        self,
+        command: Command | Sequence[str | Path],
+        *,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_seconds: float | None = None,
+        input_text: str | None = None,
+        check: bool = True,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        cmd = _to_command(
+            command,
+            cwd=cwd,
+            env=env,
+            timeout_seconds=timeout_seconds,
+            input_text=input_text,
+        )
+
+        def attempt() -> CommandResult:
+            return self._run_once(cmd, check=check)
+
+        if retry_policy is not None:
+            return run_with_retry(attempt, policy=retry_policy, retry_if=retry_if)
+        return attempt()
+
+    def _run_once(self, command: Command, *, check: bool) -> CommandResult:
+        argv = list(command.argv)
+        full_env = {**os.environ, **command.env} if command.env is not None else None
+
+        if self._log_commands:
+            from olf import log
+
+            sanitized = " ".join(redact_argv(argv))
+            log.step(f"run: {sanitized}")
+
+        started = time.perf_counter()
+        try:
+            completed = subprocess.run(  # noqa: S603 - argv is structured, shell=False
+                argv,
+                cwd=command.cwd,
+                env=full_env,
+                capture_output=True,
+                text=True,
+                timeout=command.timeout_seconds,
+                input=command.input_text,
+                stdin=None if command.input_text is not None else subprocess.DEVNULL,
+                check=False,
+                shell=False,
+            )
+        except FileNotFoundError as exc:
+            raise ExecutableNotFoundError(argv[0]) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise CommandTimeoutError(tuple(argv), command.timeout_seconds or 0.0) from exc
+
+        duration = time.perf_counter() - started
+        result = CommandResult(
+            argv=tuple(argv),
+            returncode=completed.returncode,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+            duration_seconds=duration,
+        )
+
+        if check and result.returncode != 0:
+            raise CommandExecutionError(
+                result.argv,
+                result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                cwd=command.cwd,
+                env=command.env,
+            )
+        return result

--- a/tools/olf/olf/tooling/redact.py
+++ b/tools/olf/olf/tooling/redact.py
@@ -1,0 +1,72 @@
+"""Centralized diagnostic sanitization for command/environment redaction.
+
+This module never touches the real argv or environment passed to
+`subprocess.run` — it only produces sanitized copies for logging, error
+messages, and other diagnostics so secret values never leak into them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+REDACTED = "<redacted>"
+
+# Names containing (or ending in) any of these markers are treated as
+# sensitive, e.g. AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+# AZURE_CLIENT_SECRET, OPENLINEAGE_API_KEY.
+_SENSITIVE_NAME_MARKERS = (
+    "PASSWORD",
+    "PASSWD",
+    "SECRET",
+    "TOKEN",
+    "API_KEY",
+    "APIKEY",
+    "ACCESS_KEY",
+    "PRIVATE_KEY",
+    "CLIENT_SECRET",
+    "CREDENTIAL",
+    "AUTH",
+)
+
+# Flags whose following argv token (or `=`-joined value) is a secret.
+_SECRET_VALUE_FLAGS = (
+    "--password",
+    "--token",
+    "--access-token",
+    "--client-secret",
+    "--secret",
+    "--api-key",
+    "-p",
+)
+
+
+def is_sensitive_env_name(name: str) -> bool:
+    upper = name.upper()
+    return any(marker in upper for marker in _SENSITIVE_NAME_MARKERS)
+
+
+def redact_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Return a copy of `env` with sensitive-looking values replaced."""
+    return {key: (REDACTED if is_sensitive_env_name(key) else value) for key, value in env.items()}
+
+
+def redact_argv(argv: Sequence[str]) -> list[str]:
+    """Return a copy of `argv` with values following secret flags replaced."""
+    redacted: list[str] = []
+    redact_next = False
+    for token in argv:
+        if redact_next:
+            redacted.append(REDACTED)
+            redact_next = False
+            continue
+
+        flag, sep, _value = token.partition("=")
+        if sep and flag.lower() in _SECRET_VALUE_FLAGS:
+            redacted.append(f"{flag}={REDACTED}")
+            continue
+
+        redacted.append(token)
+        if token.lower() in _SECRET_VALUE_FLAGS:
+            redact_next = True
+
+    return redacted

--- a/tools/olf/olf/tooling/resolver.py
+++ b/tools/olf/olf/tooling/resolver.py
@@ -1,0 +1,42 @@
+"""Injectable executable resolution.
+
+Tool adapters must resolve executables through an `ExecutableResolver`
+rather than calling `shutil.which` directly, so a future managed-toolchain
+resolver (#127) can be substituted without touching any adapter.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Protocol
+
+from olf.deployment.errors import ExecutableNotFoundError
+
+
+class ExecutableResolver(Protocol):
+    def resolve(self, tool: str) -> Path: ...
+
+
+class PathExecutableResolver:
+    """Resolves tools from PATH, with explicit overrides taking precedence."""
+
+    def __init__(
+        self,
+        overrides: Mapping[str, Path] | None = None,
+        *,
+        which: Callable[[str], str | None] = shutil.which,
+    ) -> None:
+        self._overrides = dict(overrides or {})
+        self._which = which
+
+    def resolve(self, tool: str) -> Path:
+        override = self._overrides.get(tool)
+        if override is not None:
+            return Path(override)
+
+        found = self._which(tool)
+        if found is None:
+            raise ExecutableNotFoundError(tool, searched="PATH")
+        return Path(found)

--- a/tools/olf/olf/tooling/terraform.py
+++ b/tools/olf/olf/tooling/terraform.py
@@ -1,0 +1,135 @@
+"""Thin Terraform adapter: structured argv only, no HCL/state logic in Python."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from olf.deployment.errors import CommandExecutionError
+from olf.deployment.retry import RetryPolicy, RetryPredicate
+from olf.tooling.process import CommandResult, ProcessRunner
+from olf.tooling.resolver import ExecutableResolver
+
+
+class Terraform:
+    def __init__(self, runner: ProcessRunner, resolver: ExecutableResolver) -> None:
+        self._runner = runner
+        self._resolver = resolver
+
+    def _executable(self) -> Path:
+        return self._resolver.resolve("terraform")
+
+    def _run(
+        self,
+        terraform_dir: Path,
+        args: Sequence[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        check: bool = True,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        argv = [str(self._executable()), f"-chdir={terraform_dir}", *args]
+        return self._runner.run(
+            argv,
+            env=env,
+            check=check,
+            retry_policy=retry_policy,
+            retry_if=retry_if,
+        )
+
+    @staticmethod
+    def _var_args(var_files: Sequence[Path | str], variables: Mapping[str, str] | None) -> list[str]:
+        args: list[str] = [f"-var-file={var_file}" for var_file in var_files]
+        for key, value in (variables or {}).items():
+            args.append(f"-var={key}={value}")
+        return args
+
+    def init(
+        self,
+        terraform_dir: Path,
+        *,
+        extra_args: Sequence[str] = (),
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        return self._run(terraform_dir, ["init", *extra_args], env=env)
+
+    def apply(
+        self,
+        terraform_dir: Path,
+        *,
+        auto_approve: bool = True,
+        var_files: Sequence[Path | str] = (),
+        variables: Mapping[str, str] | None = None,
+        extra_args: Sequence[str] = (),
+        env: Mapping[str, str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        args = ["apply"]
+        if auto_approve:
+            args.append("-auto-approve")
+        args.extend(self._var_args(var_files, variables))
+        args.extend(extra_args)
+        return self._run(terraform_dir, args, env=env, retry_policy=retry_policy, retry_if=retry_if)
+
+    def destroy(
+        self,
+        terraform_dir: Path,
+        *,
+        auto_approve: bool = True,
+        var_files: Sequence[Path | str] = (),
+        variables: Mapping[str, str] | None = None,
+        extra_args: Sequence[str] = (),
+        env: Mapping[str, str] | None = None,
+        retry_policy: RetryPolicy | None = None,
+        retry_if: RetryPredicate | None = None,
+    ) -> CommandResult:
+        args = ["destroy"]
+        if auto_approve:
+            args.append("-auto-approve")
+        args.extend(self._var_args(var_files, variables))
+        args.extend(extra_args)
+        return self._run(terraform_dir, args, env=env, retry_policy=retry_policy, retry_if=retry_if)
+
+    def output_raw(self, terraform_dir: Path, name: str, *, env: Mapping[str, str] | None = None) -> str:
+        result = self._run(terraform_dir, ["output", "-raw", name], env=env)
+        return result.stdout.strip()
+
+    def output_json(self, terraform_dir: Path, name: str, *, env: Mapping[str, str] | None = None) -> Any:
+        result = self._run(terraform_dir, ["output", "-json", name], env=env)
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise CommandExecutionError(
+                result.argv,
+                result.returncode,
+                stdout=result.stdout,
+                stderr=f"terraform output {name!r} did not return valid JSON",
+            ) from exc
+
+    def state_show(
+        self,
+        terraform_dir: Path,
+        resource_addr: str,
+        *,
+        env: Mapping[str, str] | None = None,
+        check: bool = False,
+    ) -> CommandResult:
+        return self._run(terraform_dir, ["state", "show", resource_addr], env=env, check=check)
+
+    def import_resource(
+        self,
+        terraform_dir: Path,
+        resource_addr: str,
+        resource_id: str,
+        *,
+        var_files: Sequence[Path | str] = (),
+        variables: Mapping[str, str] | None = None,
+        extra_args: Sequence[str] = (),
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        args = ["import", *self._var_args(var_files, variables), *extra_args, resource_addr, resource_id]
+        return self._run(terraform_dir, args, env=env)

--- a/tools/olf/tests/_tooling_support.py
+++ b/tools/olf/tests/_tooling_support.py
@@ -1,0 +1,85 @@
+"""Test-only helpers for the `olf.deployment`/`olf.tooling` test modules.
+
+Deliberately not `conftest.py`: this only serves the new deployment-substrate
+tests and must not interact with the shared domain fixtures other test files
+depend on.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from olf.tooling.process import Command, CommandResult, ProcessRunner
+
+FAKE_SCRIPT_TEMPLATE = """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+payload = {{
+    "argv": sys.argv[1:],
+    "env": {{key: os.environ.get(key) for key in {env_keys!r}}},
+    "cwd": os.getcwd(),
+    "stdin": sys.stdin.read(),
+}}
+sys.stderr.write({stderr!r})
+print(json.dumps(payload))
+sys.exit({exit_code})
+"""
+
+
+def write_fake_executable(
+    path: Path,
+    *,
+    env_keys: list[str] | None = None,
+    stderr: str = "",
+    exit_code: int = 0,
+) -> Path:
+    """Write a tiny Python executable that reports its argv/env/stdin as JSON."""
+    script = FAKE_SCRIPT_TEMPLATE.format(env_keys=env_keys or [], stderr=stderr, exit_code=exit_code)
+    path.write_text(script)
+    path.chmod(0o755)
+    return path
+
+
+def write_sleeping_executable(path: Path, *, seconds: float) -> Path:
+    script = f"#!/usr/bin/env python3\nimport time\ntime.sleep({seconds})\n"
+    path.write_text(script)
+    path.chmod(0o755)
+    return path
+
+
+@dataclass
+class RecordedCall:
+    argv: list[str]
+    kwargs: dict[str, Any]
+
+
+class RecordingRunner(ProcessRunner):
+    """A `ProcessRunner` stand-in that records calls instead of executing anything.
+
+    Used by tool-adapter tests, which assert exact argv construction rather
+    than exercising a real subprocess.
+    """
+
+    def __init__(self, result: CommandResult | None = None) -> None:
+        super().__init__()
+        self.calls: list[RecordedCall] = []
+        self._result = result
+
+    def run(  # type: ignore[override]
+        self,
+        command: Command | list[str],
+        **kwargs: Any,
+    ) -> CommandResult:
+        argv = list(command.argv) if isinstance(command, Command) else [str(part) for part in command]
+        self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+        if self._result is not None:
+            return self._result
+        return CommandResult(argv=tuple(argv), returncode=0, stdout="", stderr="", duration_seconds=0.0)
+
+    @property
+    def last_call(self) -> RecordedCall:
+        return self.calls[-1]

--- a/tools/olf/tests/test_deployment_context.py
+++ b/tools/olf/tests/test_deployment_context.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from olf.deployment.context import DeploymentContext, Profile, Provider
+
+
+def test_local_defaults(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+
+    assert ctx.provider == Provider.LOCAL
+    assert ctx.namespace == "lakehouse"
+    assert ctx.kube_context == "kind-openlakeforge-local"
+    assert ctx.paths.kubeconfig_path == tmp_path / ".tmp" / "kubeconfigs" / "local.yaml"
+    assert ctx.paths.platform_terraform_dir == tmp_path / "infra" / "terraform" / "environments" / "local"
+    assert ctx.paths.foundation_terraform_dir == tmp_path / "infra" / "terraform" / "foundations" / "local-kind"
+    assert ctx.paths.docker_config_dir == tmp_path / ".tmp" / "docker" / "local"
+    assert ctx.paths.helm_repository_config == tmp_path / ".tmp" / "helm" / "local" / "repositories.yaml"
+    assert ctx.paths.helm_repository_cache == tmp_path / ".tmp" / "helm" / "local" / "repository-cache"
+
+
+def test_aws_and_azure_produce_independent_scoped_paths(tmp_path: Path) -> None:
+    aws_ctx = DeploymentContext.aws(repo_root=tmp_path)
+    azure_ctx = DeploymentContext.azure(repo_root=tmp_path)
+
+    assert aws_ctx.paths.kubeconfig_path != azure_ctx.paths.kubeconfig_path
+    assert aws_ctx.paths.docker_config_dir != azure_ctx.paths.docker_config_dir
+    assert aws_ctx.paths.helm_repository_config != azure_ctx.paths.helm_repository_config
+    assert aws_ctx.paths.platform_terraform_dir == tmp_path / "infra" / "terraform" / "environments" / "aws-poc"
+    assert azure_ctx.paths.platform_terraform_dir == tmp_path / "infra" / "terraform" / "environments" / "azure-poc"
+
+
+def test_for_provider_dispatches_to_matching_factory(tmp_path: Path) -> None:
+    ctx = DeploymentContext.for_provider("aws", repo_root=tmp_path)
+    assert ctx.provider == Provider.AWS
+
+    ctx = DeploymentContext.for_provider(Provider.AZURE, repo_root=tmp_path)
+    assert ctx.provider == Provider.AZURE
+
+
+def test_slim_profile_disables_optional_layers(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path, profile=Profile.SLIM)
+
+    assert ctx.features.governance_enabled is False
+    assert ctx.features.analytics_enabled is False
+
+
+def test_full_profile_enables_optional_layers(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path, profile=Profile.FULL)
+
+    assert ctx.features.governance_enabled is True
+    assert ctx.features.analytics_enabled is True
+
+
+def test_repo_root_and_distribution_root_can_differ(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    distribution_root = tmp_path / "distribution"
+    repo_root.mkdir()
+    distribution_root.mkdir()
+
+    ctx = DeploymentContext.local(repo_root=repo_root, distribution_root=distribution_root)
+
+    assert ctx.paths.repo_root == repo_root.resolve()
+    assert ctx.paths.distribution_root == distribution_root.resolve()
+    assert ctx.paths.repo_root != ctx.paths.distribution_root
+
+
+def test_distribution_root_defaults_to_repo_root(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+
+    assert ctx.paths.distribution_root == ctx.paths.repo_root
+
+
+def test_command_env_sets_expected_keys_without_mutating_parent(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+    assert "KUBECONFIG" not in os.environ
+
+    env = ctx.command_env(docker_host="unix:///var/run/docker.sock")
+
+    assert env["KUBECONFIG"] == str(ctx.paths.kubeconfig_path)
+    assert env["DOCKER_CONFIG"] == str(ctx.paths.docker_config_dir)
+    assert env["DOCKER_HOST"] == "unix:///var/run/docker.sock"
+    assert env["DOCKER_BUILDKIT"] == "1"
+    assert env["BUILDKIT_PROGRESS"] == "plain"
+    assert env["HELM_REPOSITORY_CONFIG"] == str(ctx.paths.helm_repository_config)
+    assert env["HELM_REPOSITORY_CACHE"] == str(ctx.paths.helm_repository_cache)
+    assert "KUBECONFIG" not in os.environ
+
+
+def test_command_env_without_docker_host_omits_it(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+
+    env = ctx.command_env()
+
+    assert "DOCKER_HOST" not in env
+
+
+def test_command_env_does_not_mutate_supplied_base_mapping(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+    base = {"PATH": "/usr/bin", "DOCKER_BUILDKIT": "0"}
+    base_copy = dict(base)
+
+    env = ctx.command_env(base=base)
+
+    assert base == base_copy
+    assert env["DOCKER_BUILDKIT"] == "0"  # base overrides default when caller pre-sets it
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_prepare_directories_creates_owned_paths(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+
+    ctx.prepare_directories(docker_cli_plugins_source=tmp_path / "no-such-docker-home")
+
+    assert ctx.paths.kubeconfig_path.parent.is_dir()
+    assert ctx.paths.docker_config_dir.is_dir()
+    assert ctx.paths.helm_repository_config.parent.is_dir()
+    assert ctx.paths.helm_repository_cache.is_dir()
+    assert ctx.paths.helm_cache_dir.is_dir()
+    assert ctx.paths.superset_report_work_dir.is_dir()
+
+
+def test_prepare_directories_links_docker_cli_plugins_when_source_exists(tmp_path: Path) -> None:
+    docker_home = tmp_path / "docker-home"
+    plugins_source = docker_home / "cli-plugins"
+    plugins_source.mkdir(parents=True)
+    (plugins_source / "buildx").write_text("fake plugin")
+
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+    ctx.prepare_directories(docker_cli_plugins_source=docker_home)
+
+    destination = ctx.paths.docker_config_dir / "cli-plugins"
+    assert destination.is_symlink()
+    assert destination.resolve() == plugins_source.resolve()
+
+
+def test_prepare_directories_does_not_overwrite_existing_cli_plugins_link(tmp_path: Path) -> None:
+    docker_home = tmp_path / "docker-home"
+    plugins_source = docker_home / "cli-plugins"
+    plugins_source.mkdir(parents=True)
+
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+    ctx.paths.docker_config_dir.mkdir(parents=True)
+    existing_destination = ctx.paths.docker_config_dir / "cli-plugins"
+    existing_destination.mkdir()
+    marker = existing_destination / "already-here"
+    marker.write_text("do not touch")
+
+    ctx.prepare_directories(docker_cli_plugins_source=docker_home)
+
+    assert marker.exists()
+    assert not existing_destination.is_symlink()
+
+
+def test_prepare_directories_no_failure_when_source_missing(tmp_path: Path) -> None:
+    ctx = DeploymentContext.local(repo_root=tmp_path)
+
+    ctx.prepare_directories(docker_cli_plugins_source=tmp_path / "does-not-exist")
+
+    assert not (ctx.paths.docker_config_dir / "cli-plugins").exists()

--- a/tools/olf/tests/test_process.py
+++ b/tools/olf/tests/test_process.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from _tooling_support import write_fake_executable, write_sleeping_executable
+
+from olf.deployment.errors import CommandExecutionError, CommandTimeoutError, ExecutableNotFoundError
+from olf.deployment.retry import RetryPolicy
+from olf.tooling.process import Command, CommandResult, ProcessRunner
+
+
+def test_successful_command_captures_output_and_duration(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake")
+    runner = ProcessRunner()
+
+    result = runner.run([str(script), "hello", "world"])
+
+    assert isinstance(result, CommandResult)
+    assert result.returncode == 0
+    assert result.duration_seconds >= 0
+    assert result.argv == (str(script), "hello", "world")
+    payload = json.loads(result.stdout)
+    assert payload["argv"] == ["hello", "world"]
+
+
+def test_failed_command_raises_typed_error_with_sanitized_argv(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake", stderr="boom", exit_code=3)
+    runner = ProcessRunner()
+
+    with pytest.raises(CommandExecutionError) as excinfo:
+        runner.run([str(script), "--password", "super-secret"])
+
+    error = excinfo.value
+    assert error.returncode == 3
+    assert "super-secret" not in str(error)
+    assert "<redacted>" in str(error)
+    assert error.argv[-2:] == ("--password", "super-secret")  # original argv retained on the error object
+
+
+def test_check_false_returns_failed_result_instead_of_raising(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake", exit_code=7)
+    runner = ProcessRunner()
+
+    result = runner.run([str(script)], check=False)
+
+    assert result.returncode == 7
+
+
+def test_missing_executable_raises_typed_error(tmp_path: Path) -> None:
+    runner = ProcessRunner()
+
+    with pytest.raises(ExecutableNotFoundError) as excinfo:
+        runner.run([str(tmp_path / "does-not-exist")])
+
+    assert excinfo.value.tool == str(tmp_path / "does-not-exist")
+
+
+def test_timeout_raises_typed_error(tmp_path: Path) -> None:
+    script = write_sleeping_executable(tmp_path / "slow", seconds=5)
+    runner = ProcessRunner()
+
+    with pytest.raises(CommandTimeoutError):
+        runner.run([str(script)], timeout_seconds=0.05)
+
+
+def test_cwd_is_observed_by_child(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake")
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    runner = ProcessRunner()
+
+    result = runner.run([str(script)], cwd=work_dir)
+
+    payload = json.loads(result.stdout)
+    assert Path(payload["cwd"]).resolve() == work_dir.resolve()
+
+
+def test_command_env_overlay_reaches_child_without_mutating_parent(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake", env_keys=["OLF_TEST_VAR"])
+    runner = ProcessRunner()
+    assert "OLF_TEST_VAR" not in os.environ
+
+    result = runner.run([str(script)], env={"OLF_TEST_VAR": "scoped-value"})
+
+    payload = json.loads(result.stdout)
+    assert payload["env"]["OLF_TEST_VAR"] == "scoped-value"
+    assert "OLF_TEST_VAR" not in os.environ
+
+
+def test_shell_metacharacters_arrive_as_literal_argv(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake")
+    runner = ProcessRunner()
+    dangerous = "hello; rm -rf / && echo $HOME `whoami` * 'quoted'"
+
+    result = runner.run([str(script), dangerous])
+
+    payload = json.loads(result.stdout)
+    assert payload["argv"] == [dangerous]
+
+
+def test_input_text_reaches_child_and_is_not_recorded_on_result(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake")
+    runner = ProcessRunner()
+
+    result = runner.run([str(script)], input_text="super-secret-stdin")
+
+    payload = json.loads(result.stdout)
+    assert payload["stdin"] == "super-secret-stdin"
+    # CommandResult itself never carries input_text, regardless of whether
+    # the invoked tool happens to echo stdin back on stdout (as this fake
+    # executable does purely to make the assertion above possible).
+    assert "input_text" not in CommandResult.__dataclass_fields__
+
+
+def test_command_normalizes_path_like_argv_entries(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake")
+    command = Command(argv=(script, "arg"))  # type: ignore[arg-type]
+
+    assert command.argv == (str(script), "arg")
+
+
+def test_empty_argv_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        Command(argv=())
+
+
+def test_retry_policy_runs_command_until_success(tmp_path: Path) -> None:
+    marker = tmp_path / "attempts"
+    script = tmp_path / "flaky.py"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        f"marker = {str(marker)!r}\n"
+        "attempts = int(open(marker).read()) if __import__('os').path.exists(marker) else 0\n"
+        "attempts += 1\n"
+        "open(marker, 'w').write(str(attempts))\n"
+        "sys.exit(0 if attempts >= 2 else 1)\n"
+    )
+    script.chmod(0o755)
+    runner = ProcessRunner()
+    sleeps: list[float] = []
+
+    result = runner.run(
+        [str(script)],
+        retry_policy=RetryPolicy(max_attempts=4, delay_seconds=0),
+    )
+
+    assert result.returncode == 0
+    assert int(marker.read_text()) == 2
+    assert sleeps == []  # delay_seconds=0, nothing meaningful to assert beyond no crash

--- a/tools/olf/tests/test_redact.py
+++ b/tools/olf/tests/test_redact.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from _tooling_support import write_fake_executable
+
+from olf.deployment.errors import CommandExecutionError
+from olf.tooling.process import ProcessRunner
+from olf.tooling.redact import is_sensitive_env_name, redact_argv, redact_env
+
+SENSITIVE_NAMES = [
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AZURE_CLIENT_SECRET",
+    "OPENLINEAGE_API_KEY",
+    "DB_PASSWORD",
+    "DOCKER_PASSWD",
+    "GITHUB_TOKEN",
+    "PRIVATE_KEY_PATH",
+    "SOME_CREDENTIAL_FILE",
+    "BASIC_AUTH_HEADER",
+]
+
+
+@pytest.mark.parametrize("name", SENSITIVE_NAMES)
+def test_sensitive_env_names_are_detected(name: str) -> None:
+    assert is_sensitive_env_name(name)
+
+
+@pytest.mark.parametrize("name", ["NAMESPACE", "KUBE_CONTEXT", "PATH", "HOME", "DEPLOYMENT_SCOPE"])
+def test_non_sensitive_env_names_are_not_flagged(name: str) -> None:
+    assert not is_sensitive_env_name(name)
+
+
+def test_redact_env_replaces_only_sensitive_values() -> None:
+    env = {"AWS_SECRET_ACCESS_KEY": "very-secret", "NAMESPACE": "lakehouse"}
+
+    redacted = redact_env(env)
+
+    assert redacted["AWS_SECRET_ACCESS_KEY"] == "<redacted>"
+    assert redacted["NAMESPACE"] == "lakehouse"
+    assert "very-secret" not in redacted.values()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["az", "login", "--service-principal", "-u", "client", "-p", "super-secret"],
+        ["docker", "login", "--username", "foo", "--password", "abc"],
+        ["some-cli", "--token=super-secret"],
+        ["some-cli", "--client-secret", "super-secret"],
+        ["some-cli", "--api-key", "super-secret"],
+    ],
+)
+def test_redact_argv_hides_secret_values_following_known_flags(argv: list[str]) -> None:
+    redacted = redact_argv(argv)
+
+    joined = " ".join(redacted)
+    assert "super-secret" not in joined
+    assert "abc" not in joined
+    assert "<redacted>" in joined
+
+
+def test_redact_argv_preserves_non_secret_tokens() -> None:
+    argv = ["kubectl", "--context", "kind-openlakeforge-local", "get", "pods", "-n", "lakehouse"]
+
+    assert redact_argv(argv) == argv
+
+
+def test_command_execution_error_does_not_leak_env_secrets_in_str() -> None:
+    error = CommandExecutionError(
+        ("az", "login"),
+        1,
+        stderr="",
+        env={"AZURE_CLIENT_SECRET": "very-secret", "NAMESPACE": "lakehouse"},
+    )
+
+    text = str(error)
+    assert "very-secret" not in text
+    assert "<redacted>" in text
+    assert "lakehouse" in text
+
+
+def test_command_execution_error_does_not_leak_argv_secrets_in_str() -> None:
+    error = CommandExecutionError(
+        ("az", "login", "--service-principal", "-u", "client", "-p", "super-secret"),
+        1,
+    )
+
+    text = str(error)
+    assert "super-secret" not in text
+    assert "<redacted>" in text
+
+
+def test_process_runner_raises_error_without_leaking_secret_argv(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake", exit_code=1)
+    runner = ProcessRunner()
+
+    with pytest.raises(CommandExecutionError) as excinfo:
+        runner.run([str(script), "--password", "super-secret"])
+
+    assert "super-secret" not in str(excinfo.value)
+
+
+def test_process_runner_raises_error_without_leaking_secret_env(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake", exit_code=1)
+    runner = ProcessRunner()
+
+    with pytest.raises(CommandExecutionError) as excinfo:
+        runner.run([str(script)], env={"OPENLINEAGE_API_KEY": "very-secret"})
+
+    assert "very-secret" not in str(excinfo.value)
+
+
+def test_original_argv_still_reaches_subprocess_despite_diagnostic_redaction(tmp_path: Path) -> None:
+    script = write_fake_executable(tmp_path / "fake")
+    runner = ProcessRunner()
+
+    result = runner.run([str(script), "--password", "super-secret"])
+
+    payload = json.loads(result.stdout)
+    assert payload["argv"] == ["--password", "super-secret"]

--- a/tools/olf/tests/test_retry.py
+++ b/tools/olf/tests/test_retry.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import pytest
+
+from olf.deployment.errors import CommandExecutionError
+from olf.deployment.retry import RetryPolicy, run_with_retry
+
+
+def _error(returncode: int = 1) -> CommandExecutionError:
+    return CommandExecutionError(("cmd",), returncode, stdout="", stderr="")
+
+
+def test_succeeds_first_attempt_runs_once() -> None:
+    calls = 0
+
+    def fn() -> str:
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    sleeps: list[float] = []
+    result = run_with_retry(fn, policy=RetryPolicy(max_attempts=4, delay_seconds=1), sleep_fn=sleeps.append)
+
+    assert result == "ok"
+    assert calls == 1
+    assert sleeps == []
+
+
+def test_fails_once_then_succeeds_runs_twice() -> None:
+    calls = 0
+
+    def fn() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _error()
+        return "ok"
+
+    sleeps: list[float] = []
+    result = run_with_retry(fn, policy=RetryPolicy(max_attempts=4, delay_seconds=5), sleep_fn=sleeps.append)
+
+    assert result == "ok"
+    assert calls == 2
+    assert sleeps == [5]
+
+
+def test_reaches_max_attempts_raises_final_error() -> None:
+    calls = 0
+
+    def fn() -> str:
+        nonlocal calls
+        calls += 1
+        raise _error(returncode=calls)
+
+    sleeps: list[float] = []
+    with pytest.raises(CommandExecutionError) as excinfo:
+        run_with_retry(fn, policy=RetryPolicy(max_attempts=3, delay_seconds=1), sleep_fn=sleeps.append)
+
+    assert calls == 3
+    assert excinfo.value.returncode == 3
+    # No sleep after the final (non-retried) failure.
+    assert sleeps == [1, 1]
+
+
+def test_retry_predicate_false_stops_immediately() -> None:
+    calls = 0
+
+    def fn() -> str:
+        nonlocal calls
+        calls += 1
+        raise _error()
+
+    sleeps: list[float] = []
+    with pytest.raises(CommandExecutionError):
+        run_with_retry(
+            fn,
+            policy=RetryPolicy(max_attempts=4, delay_seconds=1),
+            retry_if=lambda exc, attempt: False,
+            sleep_fn=sleeps.append,
+        )
+
+    assert calls == 1
+    assert sleeps == []
+
+
+def test_retry_predicate_receives_error_and_attempt_number() -> None:
+    seen: list[tuple[int, int]] = []
+    calls = 0
+
+    def fn() -> str:
+        nonlocal calls
+        calls += 1
+        raise _error(returncode=calls)
+
+    def predicate(exc: CommandExecutionError, attempt: int) -> bool:
+        seen.append((exc.returncode, attempt))
+        return True
+
+    with pytest.raises(CommandExecutionError):
+        run_with_retry(
+            fn,
+            policy=RetryPolicy(max_attempts=3, delay_seconds=0),
+            retry_if=predicate,
+            sleep_fn=lambda _seconds: None,
+        )
+
+    assert seen == [(1, 1), (2, 2), (3, 3)]
+
+
+def test_backoff_multiplier_scales_delay_per_attempt() -> None:
+    calls = 0
+
+    def fn() -> str:
+        nonlocal calls
+        calls += 1
+        raise _error()
+
+    sleeps: list[float] = []
+    with pytest.raises(CommandExecutionError):
+        run_with_retry(
+            fn,
+            policy=RetryPolicy(max_attempts=4, delay_seconds=2, backoff_multiplier=2.0),
+            sleep_fn=sleeps.append,
+        )
+
+    assert sleeps == [2, 4, 8]
+
+
+def test_unit_tests_never_actually_sleep() -> None:
+    """Sanity check that sleep injection is honored end to end."""
+    calls = 0
+
+    def fn() -> str:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise _error()
+        return "ok"
+
+    result = run_with_retry(
+        fn,
+        policy=RetryPolicy(max_attempts=5, delay_seconds=999),
+        sleep_fn=lambda seconds: None,
+    )
+    assert result == "ok"

--- a/tools/olf/tests/test_tool_resolver.py
+++ b/tools/olf/tests/test_tool_resolver.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from olf.deployment.errors import ExecutableNotFoundError
+from olf.tooling.resolver import PathExecutableResolver
+
+
+def test_resolves_executable_from_path() -> None:
+    resolver = PathExecutableResolver(which=lambda tool: f"/usr/bin/{tool}" if tool == "terraform" else None)
+
+    assert resolver.resolve("terraform") == Path("/usr/bin/terraform")
+
+
+def test_missing_executable_raises_typed_error() -> None:
+    resolver = PathExecutableResolver(which=lambda _tool: None)
+
+    with pytest.raises(ExecutableNotFoundError) as excinfo:
+        resolver.resolve("terraform")
+
+    assert excinfo.value.tool == "terraform"
+
+
+def test_override_takes_precedence_over_path_lookup() -> None:
+    calls: list[str] = []
+
+    def which(tool: str) -> str | None:
+        calls.append(tool)
+        return f"/usr/bin/{tool}"
+
+    resolver = PathExecutableResolver(overrides={"terraform": Path("/opt/fake/terraform")}, which=which)
+
+    resolved = resolver.resolve("terraform")
+
+    assert resolved == Path("/opt/fake/terraform")
+    assert calls == []  # PATH lookup is never consulted when an override exists
+
+
+def test_resolver_satisfies_the_protocol_used_by_adapters() -> None:
+    # Adapters only ever call `.resolve(tool)`; any object satisfying that
+    # shape can substitute a managed-toolchain resolver (#127) later.
+    class FakeManagedResolver:
+        def resolve(self, tool: str) -> Path:
+            return Path(f"/managed/{tool}")
+
+    resolver = FakeManagedResolver()
+    assert resolver.resolve("helm") == Path("/managed/helm")

--- a/tools/olf/tests/test_tooling_aws.py
+++ b/tools/olf/tests/test_tooling_aws.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from _tooling_support import RecordingRunner
+
+from olf.tooling.aws import AwsCli
+from olf.tooling.process import CommandResult
+from olf.tooling.resolver import PathExecutableResolver
+
+
+def _aws(result: CommandResult | None = None) -> tuple[AwsCli, RecordingRunner]:
+    runner = RecordingRunner(result)
+    resolver = PathExecutableResolver(overrides={"aws": Path("aws")})
+    return AwsCli(runner, resolver), runner
+
+
+def test_eks_update_kubeconfig_builds_exact_argv() -> None:
+    aws, runner = _aws()
+    kubeconfig = Path("/repo/.tmp/kubeconfigs/aws.yaml")
+
+    aws.eks_update_kubeconfig(
+        "eks-openlakeforge-poc",
+        region="eu-west-1",
+        kubeconfig_path=kubeconfig,
+        alias="eks-openlakeforge-poc",
+    )
+
+    assert runner.last_call.argv == [
+        "aws",
+        "eks",
+        "update-kubeconfig",
+        "--region",
+        "eu-west-1",
+        "--name",
+        "eks-openlakeforge-poc",
+        "--kubeconfig",
+        str(kubeconfig),
+        "--alias",
+        "eks-openlakeforge-poc",
+    ]
+
+
+def test_sts_get_caller_identity_parses_json() -> None:
+    payload = {"Account": "123456789012", "Arn": "arn:aws:iam::123456789012:user/dev"}
+    aws, runner = _aws(
+        CommandResult(argv=(), returncode=0, stdout=json.dumps(payload), stderr="", duration_seconds=0.0)
+    )
+
+    identity = aws.sts_get_caller_identity()
+
+    assert identity == payload
+    assert runner.last_call.argv == ["aws", "sts", "get-caller-identity", "--output", "json"]
+
+
+def test_ecr_get_login_password_strips_output() -> None:
+    aws, runner = _aws(
+        CommandResult(argv=(), returncode=0, stdout="password-value\n", stderr="", duration_seconds=0.0)
+    )
+
+    password = aws.ecr_get_login_password(region="eu-west-1")
+
+    assert password == "password-value"
+    assert runner.last_call.argv == ["aws", "ecr", "get-login-password", "--region", "eu-west-1"]

--- a/tools/olf/tests/test_tooling_azure.py
+++ b/tools/olf/tests/test_tooling_azure.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from _tooling_support import RecordingRunner
+
+from olf.tooling.azure import AzureCli
+from olf.tooling.process import CommandResult
+from olf.tooling.resolver import PathExecutableResolver
+
+
+def _azure(result: CommandResult | None = None) -> tuple[AzureCli, RecordingRunner]:
+    runner = RecordingRunner(result)
+    resolver = PathExecutableResolver(overrides={"az": Path("az")})
+    return AzureCli(runner, resolver), runner
+
+
+def test_aks_get_credentials_builds_exact_argv() -> None:
+    azure, runner = _azure()
+    kubeconfig = Path("/repo/.tmp/kubeconfigs/azure.yaml")
+
+    azure.aks_get_credentials(
+        "aks-openlakeforge-poc",
+        resource_group="openlakeforge-poc-rg",
+        kubeconfig_path=kubeconfig,
+    )
+
+    assert runner.last_call.argv == [
+        "az",
+        "aks",
+        "get-credentials",
+        "--resource-group",
+        "openlakeforge-poc-rg",
+        "--name",
+        "aks-openlakeforge-poc",
+        "--file",
+        str(kubeconfig),
+        "--overwrite-existing",
+    ]
+
+
+def test_account_show_parses_json() -> None:
+    payload = {"id": "sub-id", "name": "OpenLakeForge"}
+    azure, runner = _azure(
+        CommandResult(argv=(), returncode=0, stdout=json.dumps(payload), stderr="", duration_seconds=0.0)
+    )
+
+    account = azure.account_show()
+
+    assert account == payload
+    assert runner.last_call.argv == ["az", "account", "show", "--output", "json"]
+
+
+def test_acr_login_builds_expected_argv() -> None:
+    azure, runner = _azure()
+
+    azure.acr_login("openlakeforgeacr")
+
+    assert runner.last_call.argv == ["az", "acr", "login", "--name", "openlakeforgeacr"]
+
+
+def test_account_set_builds_expected_argv() -> None:
+    azure, runner = _azure()
+
+    azure.account_set("sub-id")
+
+    assert runner.last_call.argv == ["az", "account", "set", "--subscription", "sub-id"]

--- a/tools/olf/tests/test_tooling_docker.py
+++ b/tools/olf/tests/test_tooling_docker.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from _tooling_support import RecordedCall, RecordingRunner
+
+from olf.tooling.docker import Docker
+from olf.tooling.process import CommandResult
+from olf.tooling.resolver import PathExecutableResolver
+
+
+def _docker(result: CommandResult | None = None) -> tuple[Docker, RecordingRunner]:
+    runner = RecordingRunner(result)
+    resolver = PathExecutableResolver(overrides={"docker": Path("docker")})
+    return Docker(runner, resolver), runner
+
+
+def test_build_builds_exact_argv() -> None:
+    docker, runner = _docker()
+
+    docker.build(Path("/repo/images/project-code"), tag="project-code:local", build_args={"REVISION": "abc123"})
+
+    assert runner.last_call.argv == [
+        "docker",
+        "build",
+        "/repo/images/project-code",
+        "-t",
+        "project-code:local",
+        "--build-arg",
+        "REVISION=abc123",
+    ]
+
+
+def test_pull_and_push_build_expected_argv() -> None:
+    docker, runner = _docker()
+
+    docker.pull("ghcr.io/openlakeforge/project-code:local")
+    assert runner.last_call.argv == ["docker", "pull", "ghcr.io/openlakeforge/project-code:local"]
+
+    docker.push("ghcr.io/openlakeforge/project-code:local")
+    assert runner.last_call.argv == ["docker", "push", "ghcr.io/openlakeforge/project-code:local"]
+
+
+def test_tag_builds_expected_argv() -> None:
+    docker, runner = _docker()
+
+    docker.tag("project-code:local", "ghcr.io/openlakeforge/project-code:local")
+
+    assert runner.last_call.argv == [
+        "docker",
+        "tag",
+        "project-code:local",
+        "ghcr.io/openlakeforge/project-code:local",
+    ]
+
+
+def test_login_uses_password_stdin_not_argv() -> None:
+    docker, runner = _docker()
+
+    docker.login("ghcr.io", username="foo", password="abc")
+
+    assert runner.last_call.argv == ["docker", "login", "--username", "foo", "--password-stdin", "ghcr.io"]
+    assert "abc" not in runner.last_call.argv
+    assert runner.last_call.kwargs["input_text"] == "abc"
+
+
+def test_context_show_and_inspect() -> None:
+    docker, runner = _docker(CommandResult(argv=(), returncode=0, stdout="colima\n", stderr="", duration_seconds=0.0))
+
+    name = docker.context_show()
+
+    assert name == "colima"
+    assert runner.last_call.argv == ["docker", "context", "show"]
+
+
+def test_resolve_current_engine_endpoint_chains_show_and_inspect() -> None:
+    class ScriptedRunner(RecordingRunner):
+        def run(self, command, **kwargs):  # type: ignore[override]
+            argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+            self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+            if argv[-2:] == ["context", "show"]:
+                stdout = "colima\n"
+            else:
+                stdout = "unix:///Users/dev/.colima/default/docker.sock\n"
+            return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
+
+    runner = ScriptedRunner()
+    resolver = PathExecutableResolver(overrides={"docker": Path("docker")})
+    docker = Docker(runner, resolver)
+
+    endpoint = docker.resolve_current_engine_endpoint()
+
+    assert endpoint == "unix:///Users/dev/.colima/default/docker.sock"
+    assert runner.calls[0].argv == ["docker", "context", "show"]
+    assert runner.calls[1].argv == [
+        "docker",
+        "context",
+        "inspect",
+        "colima",
+        "--format",
+        "{{.Endpoints.docker.Host}}",
+    ]
+
+
+def test_resolve_current_engine_endpoint_returns_none_on_failure() -> None:
+    from olf.deployment.errors import CommandExecutionError
+
+    class FailingRunner(RecordingRunner):
+        def run(self, command, **kwargs):  # type: ignore[override]
+            raise CommandExecutionError(["docker", "context", "show"], 1, stderr="no docker")
+
+    runner = FailingRunner()
+    resolver = PathExecutableResolver(overrides={"docker": Path("docker")})
+    docker = Docker(runner, resolver)
+
+    assert docker.resolve_current_engine_endpoint() is None

--- a/tools/olf/tests/test_tooling_helm.py
+++ b/tools/olf/tests/test_tooling_helm.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from _tooling_support import RecordingRunner
+
+from olf.tooling.helm import Helm
+from olf.tooling.resolver import PathExecutableResolver
+
+
+def _helm() -> tuple[Helm, RecordingRunner]:
+    runner = RecordingRunner()
+    resolver = PathExecutableResolver(overrides={"helm": Path("helm")})
+    return Helm(runner, resolver), runner
+
+
+def test_repo_add_builds_exact_argv() -> None:
+    helm, runner = _helm()
+
+    helm.repo_add("trino", "https://trinodb.github.io/charts")
+
+    assert runner.last_call.argv == [
+        "helm",
+        "repo",
+        "add",
+        "trino",
+        "https://trinodb.github.io/charts",
+        "--force-update",
+    ]
+
+
+def test_repo_add_without_force_update() -> None:
+    helm, runner = _helm()
+
+    helm.repo_add("trino", "https://trinodb.github.io/charts", force_update=False)
+
+    assert "--force-update" not in runner.last_call.argv
+
+
+def test_repo_and_cache_config_are_passed_as_scoped_environment() -> None:
+    helm, runner = _helm()
+    repo_config = Path("/repo/.tmp/helm/local/repositories.yaml")
+    repo_cache = Path("/repo/.tmp/helm/local/repository-cache")
+
+    helm.repo_update(repository_config=repo_config, repository_cache=repo_cache)
+
+    assert runner.last_call.argv == ["helm", "repo", "update"]
+    assert runner.last_call.kwargs["env"] == {
+        "HELM_REPOSITORY_CONFIG": str(repo_config),
+        "HELM_REPOSITORY_CACHE": str(repo_cache),
+    }
+
+
+def test_pull_builds_expected_argv_with_version_and_destination() -> None:
+    helm, runner = _helm()
+
+    helm.pull("trino/trino", version="1.42.2", destination=Path("/repo/.tmp/helm/local/charts"))
+
+    assert runner.last_call.argv == [
+        "helm",
+        "pull",
+        "trino/trino",
+        "--version",
+        "1.42.2",
+        "--destination",
+        "/repo/.tmp/helm/local/charts",
+    ]
+
+
+def test_pull_with_untar_options() -> None:
+    helm, runner = _helm()
+
+    helm.pull("dagster/dagster", version="1.13.6", untar=True, untar_dir=Path("/tmp/dagster-chart"))
+
+    assert runner.last_call.argv == [
+        "helm",
+        "pull",
+        "dagster/dagster",
+        "--version",
+        "1.13.6",
+        "--untar",
+        "--untardir",
+        "/tmp/dagster-chart",
+    ]
+
+
+def test_show_chart_defaults_to_check_false() -> None:
+    helm, runner = _helm()
+
+    helm.show_chart(Path("/repo/.tmp/helm/local/charts/trino-1.42.2.tgz"))
+
+    assert runner.last_call.kwargs["check"] is False
+
+
+def test_package_builds_expected_argv() -> None:
+    helm, runner = _helm()
+
+    helm.package(Path("/tmp/dagster-chart/dagster"), destination=Path("/repo/.tmp/helm/local/charts"))
+
+    assert runner.last_call.argv == [
+        "helm",
+        "package",
+        "/tmp/dagster-chart/dagster",
+        "--destination",
+        "/repo/.tmp/helm/local/charts",
+    ]

--- a/tools/olf/tests/test_tooling_kind.py
+++ b/tools/olf/tests/test_tooling_kind.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from _tooling_support import RecordingRunner
+
+from olf.tooling.kind import Kind
+from olf.tooling.process import CommandResult
+from olf.tooling.resolver import PathExecutableResolver
+
+
+def _kind(result: CommandResult | None = None) -> tuple[Kind, RecordingRunner]:
+    runner = RecordingRunner(result)
+    resolver = PathExecutableResolver(overrides={"kind": Path("kind")})
+    return Kind(runner, resolver), runner
+
+
+def test_export_kubeconfig_builds_exact_argv() -> None:
+    kind, runner = _kind()
+    kubeconfig = Path("/repo/.tmp/kubeconfigs/local.yaml")
+
+    kind.export_kubeconfig("openlakeforge-local", kubeconfig_path=kubeconfig)
+
+    assert runner.last_call.argv == [
+        "kind",
+        "export",
+        "kubeconfig",
+        "--name",
+        "openlakeforge-local",
+        "--kubeconfig",
+        str(kubeconfig),
+    ]
+
+
+def test_load_docker_image_builds_exact_argv() -> None:
+    kind, runner = _kind()
+
+    kind.load_docker_image("ghcr.io/openlakeforge/project-code:local", cluster_name="openlakeforge-local")
+
+    assert runner.last_call.argv == [
+        "kind",
+        "load",
+        "docker-image",
+        "ghcr.io/openlakeforge/project-code:local",
+        "--name",
+        "openlakeforge-local",
+    ]
+
+
+def test_get_clusters_parses_output_lines() -> None:
+    kind, _runner = _kind(
+        CommandResult(argv=(), returncode=0, stdout="openlakeforge-local\n", stderr="", duration_seconds=0.0)
+    )
+
+    assert kind.get_clusters() == ["openlakeforge-local"]
+
+
+def test_create_and_delete_cluster_build_expected_argv() -> None:
+    kind, runner = _kind()
+    config = Path("/repo/infra/kind/local/kind-cluster.yaml")
+    kubeconfig = Path("/repo/.tmp/kubeconfigs/local.yaml")
+
+    kind.create_cluster("openlakeforge-local", config_path=config, kubeconfig_path=kubeconfig, wait="120s")
+    assert runner.last_call.argv == [
+        "kind",
+        "create",
+        "cluster",
+        "--name",
+        "openlakeforge-local",
+        "--config",
+        str(config),
+        "--kubeconfig",
+        str(kubeconfig),
+        "--wait",
+        "120s",
+    ]
+
+    kind.delete_cluster("openlakeforge-local", kubeconfig_path=kubeconfig)
+    assert runner.last_call.argv == [
+        "kind",
+        "delete",
+        "cluster",
+        "--name",
+        "openlakeforge-local",
+        "--kubeconfig",
+        str(kubeconfig),
+    ]

--- a/tools/olf/tests/test_tooling_kubectl.py
+++ b/tools/olf/tests/test_tooling_kubectl.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from _tooling_support import RecordingRunner
+
+from olf.deployment.errors import CommandExecutionError
+from olf.tooling.kubectl import KubeContextUnreachableError, Kubectl
+from olf.tooling.process import CommandResult
+from olf.tooling.resolver import PathExecutableResolver
+
+
+def _kubectl(result: CommandResult | None = None) -> tuple[Kubectl, RecordingRunner]:
+    runner = RecordingRunner(result)
+    resolver = PathExecutableResolver(overrides={"kubectl": Path("kubectl")})
+    return Kubectl(runner, resolver), runner
+
+
+def test_get_builds_exact_argv() -> None:
+    kubectl, runner = _kubectl()
+
+    kubectl.get("pods", namespace="lakehouse", context="kind-openlakeforge-local")
+
+    assert runner.last_call.argv == [
+        "kubectl",
+        "--context",
+        "kind-openlakeforge-local",
+        "get",
+        "pods",
+        "-n",
+        "lakehouse",
+    ]
+
+
+def test_get_with_name_and_output() -> None:
+    kubectl, runner = _kubectl()
+
+    kubectl.get("secret", name="polaris-credentials", namespace="lakehouse", output="json")
+
+    assert runner.last_call.argv == [
+        "kubectl",
+        "get",
+        "secret",
+        "polaris-credentials",
+        "-n",
+        "lakehouse",
+        "-o",
+        "json",
+    ]
+
+
+def test_kubeconfig_is_passed_via_scoped_environment_not_argv() -> None:
+    kubectl, runner = _kubectl()
+    kubeconfig = Path("/repo/.tmp/kubeconfigs/local.yaml")
+
+    kubectl.cluster_info(context="kind-openlakeforge-local", kubeconfig=kubeconfig)
+
+    assert "--kubeconfig" not in runner.last_call.argv
+    assert runner.last_call.kwargs["env"] == {"KUBECONFIG": str(kubeconfig)}
+
+
+def test_delete_defaults_to_ignore_not_found() -> None:
+    kubectl, runner = _kubectl()
+
+    kubectl.delete("job", "polaris-bootstrap-abc123", namespace="lakehouse")
+
+    assert runner.last_call.argv == [
+        "kubectl",
+        "delete",
+        "job",
+        "polaris-bootstrap-abc123",
+        "-n",
+        "lakehouse",
+        "--ignore-not-found",
+    ]
+
+
+def test_config_get_contexts_parses_output_lines() -> None:
+    kubectl, _runner = _kubectl(
+        CommandResult(
+            argv=(),
+            returncode=0,
+            stdout="kind-openlakeforge-local\neks-openlakeforge-poc\n",
+            stderr="",
+            duration_seconds=0.0,
+        )
+    )
+
+    contexts = kubectl.config_get_contexts()
+
+    assert contexts == ["kind-openlakeforge-local", "eks-openlakeforge-poc"]
+
+
+def test_require_context_reachable_succeeds_when_present_and_reachable() -> None:
+    kubectl, runner = _kubectl(
+        CommandResult(argv=(), returncode=0, stdout="kind-openlakeforge-local\n", stderr="", duration_seconds=0.0)
+    )
+
+    kubectl.require_context_reachable("kind-openlakeforge-local")
+
+    assert len(runner.calls) == 2  # config get-contexts, then cluster-info
+
+
+def test_require_context_reachable_raises_when_context_absent() -> None:
+    kubectl, _runner = _kubectl(
+        CommandResult(argv=(), returncode=0, stdout="some-other-context\n", stderr="", duration_seconds=0.0)
+    )
+
+    with pytest.raises(KubeContextUnreachableError):
+        kubectl.require_context_reachable("kind-openlakeforge-local")
+
+
+def test_require_context_reachable_raises_when_cluster_info_fails() -> None:
+    from _tooling_support import RecordedCall
+
+    class FlakyRunner(RecordingRunner):
+        def run(self, command, **kwargs):  # type: ignore[override]
+            argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+            self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+            if "cluster-info" in argv:
+                raise CommandExecutionError(argv, 1, stderr="connection refused")
+            return CommandResult(
+                argv=tuple(argv), returncode=0, stdout="kind-openlakeforge-local\n", stderr="", duration_seconds=0.0
+            )
+
+    runner = FlakyRunner()
+    resolver = PathExecutableResolver(overrides={"kubectl": Path("kubectl")})
+    kubectl = Kubectl(runner, resolver)
+
+    with pytest.raises(KubeContextUnreachableError):
+        kubectl.require_context_reachable("kind-openlakeforge-local")

--- a/tools/olf/tests/test_tooling_terraform.py
+++ b/tools/olf/tests/test_tooling_terraform.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from _tooling_support import RecordingRunner
+
+from olf.deployment.errors import CommandExecutionError
+from olf.tooling.process import CommandResult
+from olf.tooling.resolver import PathExecutableResolver
+from olf.tooling.terraform import Terraform
+
+
+def _terraform(result: CommandResult | None = None) -> tuple[Terraform, RecordingRunner]:
+    runner = RecordingRunner(result)
+    resolver = PathExecutableResolver(overrides={"terraform": Path("terraform")})
+    return Terraform(runner, resolver), runner
+
+
+def test_output_raw_builds_exact_argv() -> None:
+    terraform, runner = _terraform(
+        CommandResult(argv=(), returncode=0, stdout="my-cluster\n", stderr="", duration_seconds=0.0)
+    )
+    terraform_dir = Path("/repo/infra/terraform/environments/local")
+
+    value = terraform.output_raw(terraform_dir, "cluster_name")
+
+    assert value == "my-cluster"
+    assert runner.last_call.argv == [
+        "terraform",
+        f"-chdir={terraform_dir}",
+        "output",
+        "-raw",
+        "cluster_name",
+    ]
+
+
+def test_output_json_parses_terraform_output() -> None:
+    payload = {"a": 1, "b": [2, 3]}
+    terraform, runner = _terraform(
+        CommandResult(argv=(), returncode=0, stdout=json.dumps(payload), stderr="", duration_seconds=0.0)
+    )
+
+    value = terraform.output_json(Path("/repo/infra"), "provider_contracts")
+
+    assert value == payload
+    assert runner.last_call.argv[-3:] == ["output", "-json", "provider_contracts"]
+
+
+def test_output_json_raises_typed_error_on_invalid_json() -> None:
+    terraform, _runner = _terraform(
+        CommandResult(argv=(), returncode=0, stdout="not json", stderr="", duration_seconds=0.0)
+    )
+
+    with pytest.raises(CommandExecutionError):
+        terraform.output_json(Path("/repo/infra"), "provider_contracts")
+
+
+def test_apply_builds_auto_approve_var_files_and_variables() -> None:
+    terraform, runner = _terraform()
+    terraform_dir = Path("/repo/infra/terraform/environments/local")
+
+    terraform.apply(
+        terraform_dir,
+        var_files=[Path("/repo/local.tfvars")],
+        variables={"namespace": "lakehouse", "kube_context": "kind-openlakeforge-local"},
+        extra_args=["-parallelism=1"],
+    )
+
+    assert runner.last_call.argv == [
+        "terraform",
+        f"-chdir={terraform_dir}",
+        "apply",
+        "-auto-approve",
+        "-var-file=/repo/local.tfvars",
+        "-var=namespace=lakehouse",
+        "-var=kube_context=kind-openlakeforge-local",
+        "-parallelism=1",
+    ]
+
+
+def test_apply_without_auto_approve_omits_the_flag() -> None:
+    terraform, runner = _terraform()
+
+    terraform.apply(Path("/repo/infra"), auto_approve=False)
+
+    assert "-auto-approve" not in runner.last_call.argv
+
+
+def test_destroy_builds_expected_argv() -> None:
+    terraform, runner = _terraform()
+    terraform_dir = Path("/repo/infra")
+
+    terraform.destroy(terraform_dir, variables={"namespace": "lakehouse"})
+
+    assert runner.last_call.argv == [
+        "terraform",
+        f"-chdir={terraform_dir}",
+        "destroy",
+        "-auto-approve",
+        "-var=namespace=lakehouse",
+    ]
+
+
+def test_state_show_defaults_to_check_false() -> None:
+    terraform, runner = _terraform()
+
+    terraform.state_show(Path("/repo/infra"), "kubernetes_namespace_v1.lakehouse")
+
+    assert runner.last_call.kwargs["check"] is False
+    assert runner.last_call.argv[-3:] == ["state", "show", "kubernetes_namespace_v1.lakehouse"]
+
+
+def test_import_resource_builds_expected_argv() -> None:
+    terraform, runner = _terraform()
+    terraform_dir = Path("/repo/infra")
+
+    terraform.import_resource(
+        terraform_dir,
+        "kubernetes_namespace_v1.lakehouse",
+        "lakehouse",
+        variables={"namespace": "lakehouse"},
+    )
+
+    assert runner.last_call.argv == [
+        "terraform",
+        f"-chdir={terraform_dir}",
+        "import",
+        "-var=namespace=lakehouse",
+        "kubernetes_namespace_v1.lakehouse",
+        "lakehouse",
+    ]
+
+
+def test_init_builds_expected_argv() -> None:
+    terraform, runner = _terraform()
+    terraform_dir = Path("/repo/infra/terraform/foundations/local-kind")
+
+    terraform.init(terraform_dir)
+
+    assert runner.last_call.argv == ["terraform", f"-chdir={terraform_dir}", "init"]
+
+
+def test_apply_forwards_retry_policy_to_runner() -> None:
+    from olf.deployment.retry import RetryPolicy
+
+    terraform, runner = _terraform()
+    policy = RetryPolicy(max_attempts=2, delay_seconds=0)
+
+    terraform.apply(Path("/repo/infra"), retry_policy=policy)
+
+    assert runner.last_call.kwargs["retry_policy"] is policy


### PR DESCRIPTION
Closes #123

## Summary

Establishes the reusable Python deployment substrate under `tools/olf` that
later migration issues (#124/#125) will build on, per ADR 0017 and #122.
This PR intentionally does not change existing deployment entrypoints:
shell/Make deployment remains functional exactly as before until
#124–#126 port provider lifecycle. No `olf deploy` command or provider
lifecycle sequencing was added, and no Make targets were touched.

New packages (all under `tools/olf/olf/`):

- **`tooling.process`** — `ProcessRunner`/`Command`/`CommandResult`: one
  canonical process API for all new deployment code. Executes structured
  argv only (`subprocess.run([...], shell=False)`, never a shell string),
  supports `cwd`, command-scoped `env` (layered on a copy of the parent
  environment, never mutating `os.environ`), `timeout_seconds`,
  `input_text` (e.g. for password-stdin logins), and `check` semantics.
  Duration is measured with `time.perf_counter()`.
- **`deployment.errors`** — typed hierarchy
  (`DeploymentError` → `ToolingError` → `ExecutableNotFoundError` /
  `CommandExecutionError` / `CommandTimeoutError`); raw
  `subprocess.CalledProcessError` is never exposed to callers.
- **`deployment.retry`** — `RetryPolicy` + `run_with_retry`: explicit,
  bounded retry (max attempts, delay, backoff multiplier) with an
  injectable `retry_if` predicate and `sleep_fn` (tests never actually
  sleep). Kept separate from process execution — nothing retries
  automatically.
- **`tooling.redact`** — centralized diagnostic sanitization for argv and
  environment (secret-like env-var names, `--password`/`--token`/`-p`-style
  flags). Only diagnostics are sanitized; the real subprocess always
  receives the unredacted values. `CommandExecutionError`'s `str()` never
  leaks secrets.
- **`tooling.resolver`** — `ExecutableResolver` protocol +
  `PathExecutableResolver` (PATH-backed via `shutil.which`, with explicit
  overrides). Adapters never call `shutil.which`/PATH directly, so #127's
  managed-toolchain resolver can substitute later without touching any
  adapter.
- **Tool adapters** (`tooling.{terraform,helm,kubectl,docker,kind,aws,azure}`)
  — thin wrappers exposing structured invocation and typed errors for
  Terraform, Helm, kubectl, Docker, kind, AWS CLI, and Azure CLI. None of
  them reimplement the underlying tool's behavior (no HCL parsing, no
  Kubernetes resource management, no boto3/Azure SDK provisioning).
  Terraform's `-chdir=` is used instead of changing the Python process
  cwd. Docker's `login` uses `--password-stdin` so secrets never appear in
  argv. `kubectl` requires an explicit `context`/`kubeconfig` rather than
  relying on the ambient context, and adds
  `require_context_reachable(...)` (ported from `require_kube_context`).
- **`deployment.context.DeploymentContext`** — typed provider (`local` /
  `aws` / `azure`) and profile (`slim` / `full`) identity with
  `DeploymentPaths`/`DeploymentFeatures`, factories (`.local()`, `.aws()`,
  `.azure()`, `.for_provider()`) for provider-neutral path derivation
  (no cloud/Terraform/kind calls at construction time), `command_env()`
  (ports `configure_deployment_scope`'s environment construction without
  mutating `os.environ`), and `prepare_directories()` (ports the safe
  Docker CLI-plugins symlinking behavior — never overwrites an existing
  destination, no failure when the source is absent). Supports
  `repo_root != distribution_root` for future #128 use. Kept separate from
  `olf.config`, which stays the lightweight runtime-contract helper it is
  today.
- **`tooling.docker.resolve_current_engine_endpoint()`** — preserves the
  "resolve the selected Docker context's endpoint before scoping
  `DOCKER_CONFIG`" behavior so an isolated Docker config can't silently
  fall back to `/var/run/docker.sock` on hosts using Colima or another
  non-default context.

## Tests

New, isolated test modules under `tools/olf/tests/` (409 tests total pass,
existing suite included) covering: process execution success/failure/
timeout/cwd/env-isolation/shell-metacharacter-literalness/stdin, retry
bounding/backoff/predicate/no-sleep-after-final-failure, resolver PATH
lookup and override precedence, aggressive secret-redaction cases (env
names and argv flags, including `AWS_ACCESS_KEY_ID`, `az ... -u ... -p
...`, `docker login --password ...`), and each tool adapter's exact argv
construction. Tests use a tiny fake Python executable harness (recording
argv/env/stdin as JSON) plus a recording `ProcessRunner` stand-in for
adapter argv assertions — no Docker/Kubernetes/Terraform/Helm/AWS/Azure
credentials required. `tools/olf/tests/conftest.py` was not touched.

## Validation

```
uv run --project tools/olf ruff check tools/olf/olf tools/olf/tests   # pass
uv run --project tools/olf pytest tools/olf/tests                     # 409 passed
make check-structure    # pass
make check-lockfiles    # pass
make check-contracts    # pass
make check-components   # pass
make check-project-code # pass
make check-dbt          # pass
```

`make check-infra` could not run in this sandbox (`terraform` is not on
PATH here) — this PR does not touch Terraform, Helm, kubectl, Docker,
`domains/`, `sources/`, `packages/domain-model`, `libs/product_dagster.py`,
Floe contracts, dbt projects, OpenMetadata modeling, project-code image
contents, or the sample topology, so it should stay isolated from #109's
concurrent data-architecture work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ2T9s3pz26MR2Lzicy5B9)_