### PR TITLE
fix: coerce e2e timeout input

### DIFF
--- a/.github/workflows/local-full-e2e.yml
+++ b/.github/workflows/local-full-e2e.yml
@@ -68,7 +68,7 @@ jobs:
   e2e:
     name: Deploy and validate local stack (${{ inputs.suite }})
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5


### PR DESCRIPTION
## Summary
- coerce the manual timeout input to a numeric value for the e2e job

## Validation
- actionlint .github/workflows/local-full-e2e.yml
- git diff --check