### PR TITLE
feat: add a versioned managed toolchain owned by olf

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -161,23 +161,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Ensure Docker uses the classic (non-containerd) image store
-        run: |
-          set -euo pipefail
-          echo "Docker info before:"
-          docker info --format '{{json .DriverStatus}}' 2>/dev/null || true
-          sudo mkdir -p /etc/docker
-          if [ -f /etc/docker/daemon.json ] && [ -s /etc/docker/daemon.json ]; then
-            sudo jq '.features."containerd-snapshotter" = false' /etc/docker/daemon.json \
-              | sudo tee /etc/docker/daemon.json.new >/dev/null
-            sudo mv /etc/docker/daemon.json.new /etc/docker/daemon.json
-          else
-            echo '{"features": {"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.json >/dev/null
-          fi
-          sudo systemctl restart docker
-          echo "Docker info after:"
-          docker info --format '{{json .DriverStatus}}'
-
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,18 +27,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: 1.8.5
-
-      - name: Setup Helm
-        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a
-        with:
-          version: v3.18.6
-
       - name: Setup uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
+
+      - name: Cache OpenLakeForge toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.openlakeforge
+          key: olf-toolchain-${{ hashFiles('release/component-catalog.yaml') }}
+
+      - name: Provision OpenLakeForge toolchain
+        run: uv run --project tools/olf --locked olf toolchain install
 
       - name: Check immutable release inputs
         run: uv run --project tools/olf --locked olf check components
@@ -124,16 +123,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: 1.8.5
-
-      - name: Setup Helm
-        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a
-        with:
-          version: v3.18.6
-
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -141,6 +130,15 @@ jobs:
 
       - name: Setup uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
+
+      - name: Cache OpenLakeForge toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.openlakeforge
+          key: olf-toolchain-${{ hashFiles('release/component-catalog.yaml') }}
+
+      - name: Provision OpenLakeForge toolchain
+        run: uv run --project tools/olf --locked olf toolchain install
 
       - name: Validate release readiness (catches drift before a tag is cut)
         run: uv run --project tools/olf --locked olf check all
@@ -163,16 +161,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: 1.8.5
-
-      - name: Setup Helm
-        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a
-        with:
-          version: v3.18.6
-
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -181,12 +169,14 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
 
-      - name: Install kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3
+      - name: Cache OpenLakeForge toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
-          install_only: true
-          version: v0.26.0
-          kubectl_version: v1.31.4
+          path: ~/.openlakeforge
+          key: olf-toolchain-${{ hashFiles('release/component-catalog.yaml') }}
+
+      - name: Provision OpenLakeForge toolchain
+        run: uv run --project tools/olf --locked olf toolchain install
 
       - name: Deploy and validate slim smoke (45 minute budget)
         run: uv run --project tools/olf --locked olf smoke run

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -161,6 +161,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Ensure Docker uses the classic (non-containerd) image store
+        run: |
+          set -euo pipefail
+          echo "Docker info before:"
+          docker info --format '{{json .DriverStatus}}' 2>/dev/null || true
+          sudo mkdir -p /etc/docker
+          if [ -f /etc/docker/daemon.json ] && [ -s /etc/docker/daemon.json ]; then
+            sudo jq '.features."containerd-snapshotter" = false' /etc/docker/daemon.json \
+              | sudo tee /etc/docker/daemon.json.new >/dev/null
+            sudo mv /etc/docker/daemon.json.new /etc/docker/daemon.json
+          else
+            echo '{"features": {"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.json >/dev/null
+          fi
+          sudo systemctl restart docker
+          echo "Docker info after:"
+          docker info --format '{{json .DriverStatus}}'
+
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:

--- a/.github/workflows/local-full-e2e.yml
+++ b/.github/workflows/local-full-e2e.yml
@@ -9,8 +9,8 @@ name: Local full e2e (manual)
 #
 # The job runs the supported `olf` lifecycle and e2e commands directly.
 #
-# It reuses the kind-smoke plumbing from checks.yml (same toolchain setup,
-# kind-action install, and `olf diagnostics collect` on failure) but
+# It reuses the kind-smoke plumbing from checks.yml (same managed-toolchain
+# provisioning and `olf diagnostics collect` on failure) but
 # deploys the full profile by default and runs the complete assertion suite:
 # Polaris namespaces, Dagster product pipelines, Silver and Gold tables,
 # Polaris restart recovery, Superset dashboards, OpenMetadata assets, and
@@ -71,16 +71,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_version: 1.8.5
-
-      - name: Setup Helm
-        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a
-        with:
-          version: v3.18.6
-
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -89,12 +79,14 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
 
-      - name: Install kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3
+      - name: Cache OpenLakeForge toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
-          install_only: true
-          version: v0.26.0
-          kubectl_version: v1.31.4
+          path: ~/.openlakeforge
+          key: olf-toolchain-${{ hashFiles('release/component-catalog.yaml') }}
+
+      - name: Provision OpenLakeForge toolchain
+        run: uv run --project tools/olf --locked olf toolchain install
 
       - name: Deploy the local stack (fresh foundation)
         run: uv run --project tools/olf --locked olf deploy --provider local --profile ${{ inputs.suite == 'smoke' && 'slim' || 'full' }} --cluster-name ${{ env.CLUSTER_NAME }} --kubeconfig-path ${{ env.LOCAL_KUBECONFIG_PATH }}

--- a/.github/workflows/local-full-e2e.yml
+++ b/.github/workflows/local-full-e2e.yml
@@ -71,6 +71,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Ensure Docker uses the classic (non-containerd) image store
+        run: |
+          set -euo pipefail
+          echo "Docker info before:"
+          docker info --format '{{json .DriverStatus}}' 2>/dev/null || true
+          sudo mkdir -p /etc/docker
+          if [ -f /etc/docker/daemon.json ] && [ -s /etc/docker/daemon.json ]; then
+            sudo jq '.features."containerd-snapshotter" = false' /etc/docker/daemon.json \
+              | sudo tee /etc/docker/daemon.json.new >/dev/null
+            sudo mv /etc/docker/daemon.json.new /etc/docker/daemon.json
+          else
+            echo '{"features": {"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.json >/dev/null
+          fi
+          sudo systemctl restart docker
+          echo "Docker info after:"
+          docker info --format '{{json .DriverStatus}}'
+
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:

--- a/.github/workflows/local-full-e2e.yml
+++ b/.github/workflows/local-full-e2e.yml
@@ -71,23 +71,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - name: Ensure Docker uses the classic (non-containerd) image store
-        run: |
-          set -euo pipefail
-          echo "Docker info before:"
-          docker info --format '{{json .DriverStatus}}' 2>/dev/null || true
-          sudo mkdir -p /etc/docker
-          if [ -f /etc/docker/daemon.json ] && [ -s /etc/docker/daemon.json ]; then
-            sudo jq '.features."containerd-snapshotter" = false' /etc/docker/daemon.json \
-              | sudo tee /etc/docker/daemon.json.new >/dev/null
-            sudo mv /etc/docker/daemon.json.new /etc/docker/daemon.json
-          else
-            echo '{"features": {"containerd-snapshotter": false}}' | sudo tee /etc/docker/daemon.json >/dev/null
-          fi
-          sudo systemctl restart docker
-          echo "Docker info after:"
-          docker info --format '{{json .DriverStatus}}'
-
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ The easiest way to evaluate OpenLakeForge is with the local Kubernetes environme
 
 You need a working:
 
-**Docker engine · kind · kubectl · Terraform >= 1.7 · Helm · Python >= 3.12 · uv**
+**Docker engine · Python >= 3.12 · uv**
+
+`olf` (#127) provisions its own versioned Terraform, Helm, kubectl, and kind
+under `~/.openlakeforge` at the exact versions
+[`release/component-catalog.yaml`](release/component-catalog.yaml) pins — you
+do not need to install them yourself. Set `OLF_TOOLCHAIN_MODE=host` to use
+your own host-installed copies instead.
 
 Make sure Docker is available from your shell:
 
@@ -71,12 +77,18 @@ Make sure Docker is available from your shell:
 docker ps
 ```
 
-Then clone OpenLakeForge and start the **Slim** profile:
+Then clone OpenLakeForge and check the toolchain before deploying:
 
 ```bash
 git clone https://github.com/malon64/openlakeforge.git
 cd openlakeforge
 
+uv run --project tools/olf --locked olf doctor --provider local --profile slim
+```
+
+Start the **Slim** profile:
+
+```bash
 uv run --project tools/olf --locked olf deploy --provider local --profile slim
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,8 @@ It provides shared cross-environment functionality used by local, AWS, and Azure
 * Kubernetes project-code image updates
 * release validation
 * end-to-end environment testing
+* a managed Terraform/Helm/kubectl/kind toolchain, so those tools do not
+  need to be installed on the host
 
 The current CLI is primarily used by OpenLakeForge's deployment workflows and Make targets, but its commands can also be invoked directly for advanced workflows and debugging.
 

--- a/docs/adr/0029-olf-owns-a-managed-toolchain.md
+++ b/docs/adr/0029-olf-owns-a-managed-toolchain.md
@@ -1,0 +1,123 @@
+# ADR 0029: `olf` owns a managed CLI toolchain
+
+## Status
+
+Accepted. Extends ADR 0028: `tools/olf` remains the only repository
+orchestration implementation, and this ADR adds toolchain provisioning to
+what it owns. Does not change ADR 0008's two-phase deploy boundary or the
+`DeploymentProvider`/`Toolkit` seam ADR 0025/0027 established.
+
+## Context
+
+Issue [#80](https://github.com/malon64/openlakeforge/issues/80) scopes the
+distribution model as "`olf` is the product deployment engine, and
+OpenLakeForge owns the execution environment it needs." ADR 0028 completed
+the orchestration half of that (no tracked shell, `olf` sequences
+Terraform/Helm) but left the tool installation half open by design - its
+Decision section states plainly that it "does not add a managed toolchain."
+Until now, a consumer still had to install Terraform, Helm, kubectl, and
+kind globally at version-compatible releases before `olf deploy` would run,
+which means OpenLakeForge's implementation details were still the user's
+prerequisite list.
+
+Issue [#127](https://github.com/malon64/openlakeforge/issues/127) is the
+distribution-foundation half of #80: the release owns, downloads, verifies,
+and privately invokes its own CLI binaries. `tools/olf/olf/tooling/
+resolver.py`'s `ExecutableResolver` seam (built for issue #123) already
+anticipated this - its docstring named #127 as the reason tool adapters
+resolve through an injected resolver rather than calling `shutil.which`
+directly.
+
+## Decision
+
+- `tools/olf/olf/toolchain/` is a new package: `platform.py` detects the
+  host `<os>-<arch>` (darwin/linux x amd64/arm64 only); `spec.py` builds a
+  `ToolSpec` per tool from `release/component-catalog.yaml`'s new
+  `components.toolchain` block plus a typed Python URL template per tool
+  (upstream release layout is not catalog data); `download.py` fetches into
+  a content-addressed cache and verifies the catalog's own `sha256` before
+  anything is trusted; `install.py` extracts atomically (stage, `chmod`,
+  `os.replace`) so a partial or unverified artifact never becomes the
+  active binary; `manager.py`'s `ToolchainManager` ties this together with
+  a JSON receipt recording exactly what is installed per distribution
+  version and platform.
+- Every managed tool lives under
+  `<OLF_HOME>/toolchains/<distribution-version>/<os>-<arch>/bin/<tool>`
+  (`OLF_HOME` defaults to `~/.openlakeforge`), so multiple OpenLakeForge
+  versions keep independent toolchains and nothing here ever mutates `PATH`
+  or requires root.
+- `tools/olf/olf/tooling/resolver.py` gains `ManagedExecutableResolver`,
+  substituted into `Toolkit.default()` by a new `build_resolver()` factory.
+  This is the only integration point - no tool adapter in `olf.tooling.*`
+  changed, exactly what the #123 seam was built to allow. `OLF_TOOLCHAIN_MODE`
+  selects `managed` (the default) or `host` (restores pre-#127 `PATH`
+  resolution); an explicit resolver `overrides` mapping always wins over
+  either mode, for tests and advanced overrides alike.
+- Resolution fails closed: a managed tool that cannot be provisioned raises
+  `ToolchainError` (a `DeploymentError`) rather than silently falling back
+  to whatever happens to be on `PATH`. `olf doctor` reports resolution mode,
+  distribution version, platform, and per-tool managed/host provenance, and
+  provisions the toolchain as a side effect - the documented way to
+  pre-warm a clean machine before `olf deploy`.
+- `olf toolchain list|install|path|clean` is the diagnostic/maintenance
+  surface. `clean` resolves every target against `OLF_HOME` and refuses
+  anything outside it, so it cannot remove a host-installed tool.
+- `olf release check` gained a pin-drift gate (`_check_toolchain_pinned`):
+  every managed tool needs a concrete version (never `latest`) and a
+  well-formed digest for every supported platform. The compatibility matrix
+  gained a "Managed toolchain" table rendered from the same catalog block.
+- CI (`checks.yml`, `local-full-e2e.yml`) replaced `hashicorp/setup-terraform`,
+  `azure/setup-helm`, and `helm/kind-action` with `olf toolchain install`
+  behind an `actions/cache` step keyed on the catalog file, so a normal CI
+  run proves the exact clean-machine path a consumer takes.
+
+### Scope: which tools are managed
+
+Only `terraform`, `helm`, `kubectl`, and `kind` are managed binaries.
+Reimplementing Terraform, Helm, Docker, or Kubernetes in Python is an
+explicit #80 non-goal, and no Python SDK exists for any of them - CDKTF and
+Pulumi's Automation API still drive a downloaded engine binary, so "SDK
+instead of binary" was never on the table for these three. `kubectl` does
+have an official Python client, but it doesn't cover the long-lived
+background port-forward processes `olf.deployment.portforward` depends on,
+and a single ~50MB static binary is the cheapest thing here to manage
+regardless - not worth that refactor's risk for this change.
+
+`docker` stays a host capability, per #127's explicit scope (do not attempt
+to install/manage the host container engine in v0.2) and per #80's
+non-goals.
+
+`aws` and `az` stay declared host prerequisites for the cloud providers,
+deliberately deferred rather than in scope here. Both have real Python SDKs
+already available - `boto3` is already a dependency
+(`tools/olf/pyproject.toml`) and used elsewhere (`olf.s3`, `olf.glue`), and
+`azure-mgmt-containerservice`'s `list_cluster_user_credentials()` returns a
+complete AKS kubeconfig. The reason they are not folded into this change is
+`eks_update_kubeconfig`: a normal EKS kubeconfig carries an `exec:` block
+that shells out to `aws eks get-token`, which would reintroduce the CLI at
+kubectl runtime unless replaced with a Python-minted presigned STS token
+(and its ~15-minute expiry managed explicitly). That is an authentication
+semantics change, not an installation mechanics change, affects only the
+POC-stage cloud providers, and deserves its own ADR - tracked as a follow-up
+issue under #80 rather than bundled here.
+
+## Consequences
+
+- A clean machine with Docker, Python, and `olf` runs `olf doctor` then
+  `olf deploy --provider local --profile slim` with no globally installed
+  Terraform, Helm, kubectl, or kind, at exactly the versions
+  `release/component-catalog.yaml` declares.
+- Every `olf` code path that previously built a bare `["kubectl", ...]` or
+  `["terraform", ...]` argv (predating the #123 tooling package: `olf.k8s`,
+  `olf.contracts`, `olf.e2e._shell`, `olf.e2e._runner`) now resolves through
+  the same seam, so CI dropping its setup actions doesn't silently break
+  Phase 2 artifact deployment or e2e assertions.
+- `aws`/`az` remain on the host prerequisite list for AWS/Azure until the
+  follow-up SDK-replacement issue lands; #127's "local prerequisite list
+  reduces to `olf` + a container engine" acceptance criterion is met, its
+  cloud-CLI criterion is answered but deliberately not yet executed.
+- Packaging `olf` itself without a host Python runtime, and the immutable
+  no-clone platform payload, remain
+  [#128](https://github.com/malon64/openlakeforge/issues/128)'s scope - this
+  ADR provisions the toolchain a distribution needs, not the distribution
+  mechanism itself.

--- a/docs/adr/0029-olf-owns-a-managed-toolchain.md
+++ b/docs/adr/0029-olf-owns-a-managed-toolchain.md
@@ -42,10 +42,14 @@ directly.
   a JSON receipt recording exactly what is installed per distribution
   version and platform.
 - Every managed tool lives under
-  `<OLF_HOME>/toolchains/<distribution-version>/<os>-<arch>/bin/<tool>`
+  `<OLF_HOME>/toolchains/<distribution-version>/<os>-<arch>/bin/<tool>-<digest>`
   (`OLF_HOME` defaults to `~/.openlakeforge`), so multiple OpenLakeForge
   versions keep independent toolchains and nothing here ever mutates `PATH`
-  or requires root.
+  or requires root. The activated filename is content-addressed by the
+  tool's own digest, not a plain `<tool>` - two checkouts sharing
+  `OLF_HOME` at the same `distribution.version` but different catalog pins
+  can never collide on one mutable path that a later install could swap
+  out from under an already-resolved caller.
 - `tools/olf/olf/tooling/resolver.py` gains `ManagedExecutableResolver`,
   substituted into `Toolkit.default()` by a new `build_resolver()` factory.
   This is the only integration point - no tool adapter in `olf.tooling.*`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -117,3 +117,9 @@ profile selection) behind `AwsBackend`/`AzureBackend`.
 `0028-python-owns-repository-orchestration.md` fully supersedes ADR 0017's
 shell-orchestration decision. `olf` owns repository orchestration; Make and
 workflow commands are delegates, while Terraform and Helm remain their engines.
+
+`0029-olf-owns-a-managed-toolchain.md` extends ADR 0028: `olf` downloads,
+verifies, and privately invokes its own versioned Terraform, Helm, kubectl,
+and kind binaries under `OLF_HOME` instead of requiring them installed
+globally, closing issue #127. `aws`/`az` remain host prerequisites for now,
+with the SDK-replacement path documented and deferred to a follow-up issue.

--- a/docs/release/compatibility-matrix.md
+++ b/docs/release/compatibility-matrix.md
@@ -67,7 +67,7 @@ Terraform, Helm, kubectl, and kind are provisioned by `olf toolchain` (#127) rat
 | Tool | Version |
 | --- | --- |
 | helm | 3.18.6 |
-| kind | 0.26.0 |
+| kind | 0.30.0 |
 | kubectl | 1.31.4 |
 | terraform | 1.8.5 |
 

--- a/docs/release/compatibility-matrix.md
+++ b/docs/release/compatibility-matrix.md
@@ -60,6 +60,17 @@ The exact version `.terraform.lock.hcl` pins for each root -- what a consumer of
 | superset | 0.15.5 |
 | trino | 1.42.2 |
 
+## Managed toolchain
+
+Terraform, Helm, kubectl, and kind are provisioned by `olf toolchain` (#127) rather than installed by the consumer; versions below are what the current release provisions.
+
+| Tool | Version |
+| --- | --- |
+| helm | 3.18.6 |
+| kind | 0.26.0 |
+| kubectl | 1.31.4 |
+| terraform | 1.8.5 |
+
 ## Container images
 
 | Image | Reference |

--- a/docs/release/compatibility-matrix.md
+++ b/docs/release/compatibility-matrix.md
@@ -67,7 +67,7 @@ Terraform, Helm, kubectl, and kind are provisioned by `olf toolchain` (#127) rat
 | Tool | Version |
 | --- | --- |
 | helm | 3.18.6 |
-| kind | 0.30.0 |
+| kind | 0.32.0 |
 | kubectl | 1.31.4 |
 | terraform | 1.8.5 |
 

--- a/docs/release/component-catalog.md
+++ b/docs/release/component-catalog.md
@@ -1,8 +1,9 @@
 # Component catalog
 
 `release/component-catalog.yaml` is the release input inventory. It records the
-distribution version, tracked Terraform providers, Python lockfiles,
-container digests, and GitHub Action commits used by a release.
+distribution version, tracked Terraform providers, the managed CLI toolchain
+(Terraform, Helm, kubectl, kind), Python lockfiles, container digests, and
+GitHub Action commits used by a release.
 
 Release tags are create-only semantic-version tags. Development tags may move,
 but a release tag must never be force-updated. A dependency update changes the
@@ -17,11 +18,19 @@ for the matrix rendered from it. `make release-check` is the release-readiness
 gate. It runs `olf release check` (fails if the tag doesn't match
 `distribution.version`, if any catalog image is missing its `@sha256` digest,
 if any workflow action isn't SHA-pinned and recorded under
-`components.actions`, if an action catalog entry is unused, or if a Dockerfile
-base image is unpinned) and `olf check lockfiles` (reads every
-lockfile declared in `components.python` and fails if one is out of sync with
-its sibling `pyproject.toml`, checked with `uv` directly rather than a
-duplicate implementation here).
+`components.actions`, if an action catalog entry is unused, if a Dockerfile
+base image is unpinned, or if `components.toolchain` is missing a tool, uses
+`latest` instead of a concrete version, or is missing a digest for any
+supported platform) and `olf check lockfiles` (reads every lockfile declared
+in `components.python` and fails if one is out of sync with its sibling
+`pyproject.toml`, checked with `uv` directly rather than a duplicate
+implementation here).
+
+`components.toolchain` is what `olf toolchain` (ADR 0029) provisions into
+`OLF_HOME` instead of requiring a host installation of Terraform, Helm,
+kubectl, or kind: a version plus a `sha256` digest per supported platform
+(`darwin-amd64`, `darwin-arm64`, `linux-amd64`, `linux-arm64`), verified
+before any downloaded artifact is extracted or activated.
 
 The gate also rejects a catalog Terraform requirement that differs from any
 Terraform root's own `terraform.required_version`, so the compatibility matrix

--- a/docs/setup/cloud-poc-setup.md
+++ b/docs/setup/cloud-poc-setup.md
@@ -10,8 +10,12 @@ environment variables (Azure).
 
 ## Prerequisites
 
-Install and put on your `PATH`: `terraform` (>= 1.7.0), `kubectl`, `helm`,
-`docker`, `python3`, `uv`, `make`, plus the CLI for your cloud (`aws` or `az`).
+Install and put on your `PATH`: `docker`, `python3`, `uv`, `make`, plus the
+CLI for your cloud (`aws` or `az` — these are not yet managed by `olf`; see
+ADR 0029). `olf` provisions its own versioned `terraform`, `kubectl`, and
+`helm` under `OLF_HOME` (default `~/.openlakeforge`) — a host installation of
+those three is not required. Set `OLF_TOOLCHAIN_MODE=host` to use your own
+instead.
 
 Terraform state is stored **locally** (no remote backend), so run the `make`
 targets from the same machine/checkout each time for a given environment.

--- a/docs/setup/local.md
+++ b/docs/setup/local.md
@@ -47,17 +47,20 @@ OpenLakeForge currently runs locally from a source checkout.
 
 You need the following tools available on your `PATH`:
 
-| Tool             | Purpose                               |
-| ---------------- | ------------------------------------- |
-| Git              | Clone OpenLakeForge                   |
-| Docker engine    | Container runtime used by kind        |
-| kind             | Local Kubernetes cluster              |
-| kubectl          | Kubernetes access and troubleshooting |
-| Terraform >= 1.7 | Infrastructure provisioning           |
-| Helm             | Kubernetes application deployment     |
-| Python >= 3.12   | OpenLakeForge tooling                 |
-| uv               | Python dependency and CLI execution   |
-| Make             | OpenLakeForge workflow entry points   |
+| Tool           | Purpose                              |
+| -------------- | ------------------------------------- |
+| Git            | Clone OpenLakeForge                   |
+| Docker engine  | Container runtime used by kind        |
+| Python >= 3.12 | OpenLakeForge tooling                 |
+| uv             | Python dependency and CLI execution   |
+| Make           | OpenLakeForge workflow entry points   |
+
+`olf` ([#127](https://github.com/malon64/openlakeforge/issues/127))
+provisions its own versioned Terraform, Helm, kubectl, and kind under
+`~/.openlakeforge` at the exact versions
+[`release/component-catalog.yaml`](../../release/component-catalog.yaml)
+pins — you do not need to install them yourself. Set
+`OLF_TOOLCHAIN_MODE=host` to use your own host-installed copies instead.
 
 You do **not** need Docker Desktop specifically.
 
@@ -70,10 +73,6 @@ Check that each command is available:
 ```bash
 git --version
 docker --version
-kind --version
-kubectl version --client
-terraform version
-helm version
 python3 --version
 uv --version
 make --version
@@ -86,6 +85,12 @@ docker ps
 ```
 
 If this command fails, fix your Docker installation before continuing.
+
+Then check the managed toolchain is provisioned:
+
+```bash
+uv run --project tools/olf --locked olf doctor --provider local --profile slim
+```
 
 ---
 
@@ -533,15 +538,25 @@ Make sure your Docker-compatible engine is running and accessible from the same 
 
 ## A required command is missing
 
-The deployment scripts fail early when required tools are not available on `PATH`.
-
-For example:
+`olf` provisions its own managed Terraform, Helm, kubectl, and kind, so this
+usually means Git, Docker, Python, uv, or Make (the actual host
+prerequisites) is missing:
 
 ```text
-ERROR: 'terraform' not found on PATH
+ERROR: 'docker' not found on PATH
 ```
 
 Install the missing tool and run the command again.
+
+If `olf` itself reports it cannot provision a managed tool, run
+`olf doctor` for the actionable reason:
+
+```bash
+uv run --project tools/olf --locked olf doctor --provider local --profile slim
+```
+
+If you set `OLF_TOOLCHAIN_MODE=host` to use your own host-installed
+Terraform, Helm, kubectl, or kind, make sure that tool is on `PATH`.
 
 ---
 

--- a/docs/setup/local.md
+++ b/docs/setup/local.md
@@ -86,12 +86,6 @@ docker ps
 
 If this command fails, fix your Docker installation before continuing.
 
-Then check the managed toolchain is provisioned:
-
-```bash
-uv run --project tools/olf --locked olf doctor --provider local --profile slim
-```
-
 ---
 
 ## Clone OpenLakeForge
@@ -104,6 +98,12 @@ cd openlakeforge
 OpenLakeForge commands in this guide should be executed from the repository root.
 
 > OpenLakeForge is currently alpha. A standalone installation artifact is being developed so future releases will not require operating directly from a source checkout.
+
+Then check the managed toolchain is provisioned:
+
+```bash
+uv run --project tools/olf --locked olf doctor --provider local --profile slim
+```
 
 ---
 

--- a/infra/terraform/foundations/local-kind/main.tf
+++ b/infra/terraform/foundations/local-kind/main.tf
@@ -18,6 +18,7 @@ resource "terraform_data" "kind_cluster" {
     kube_context          = local.kube_context
     kubeconfig_path       = local.kubeconfig_path
     repo_root             = local.repo_root
+    kind_executable_path  = var.kind_executable_path
   }
 
   triggers_replace = [
@@ -29,8 +30,11 @@ resource "terraform_data" "kind_cluster" {
     command = <<-EOT
       set -euo pipefail
 
-      if ! kubectl version --client >/dev/null 2>&1; then
-        echo "ERROR: kubectl is not executable. Install a native Linux kubectl binary and retry." >&2
+      kind="$${KIND_BIN:-kind}"
+      kubectl="$${KUBECTL_BIN:-kubectl}"
+
+      if ! "$kubectl" version --client >/dev/null 2>&1; then
+        echo "ERROR: kubectl ($kubectl) is not executable. Install a native Linux kubectl binary and retry." >&2
         exit 1
       fi
 
@@ -46,26 +50,26 @@ resource "terraform_data" "kind_cluster" {
 
       mkdir -p "$(dirname "$KUBECONFIG_PATH")"
 
-      if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+      if "$kind" get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
         if [[ "$RESET_EXISTING_CLUSTER" == "true" ]]; then
           echo "==> Deleting existing kind cluster '$CLUSTER_NAME'..."
-          kind delete cluster --name "$CLUSTER_NAME"
+          "$kind" delete cluster --name "$CLUSTER_NAME"
         else
           echo "Kind cluster '$CLUSTER_NAME' already exists. Reusing it."
-          kind export kubeconfig --name "$CLUSTER_NAME" --kubeconfig "$KUBECONFIG_PATH"
-          kubectl --kubeconfig "$KUBECONFIG_PATH" cluster-info --context "kind-$CLUSTER_NAME"
+          "$kind" export kubeconfig --name "$CLUSTER_NAME" --kubeconfig "$KUBECONFIG_PATH"
+          "$kubectl" --kubeconfig "$KUBECONFIG_PATH" cluster-info --context "kind-$CLUSTER_NAME"
           exit 0
         fi
       fi
 
       echo "==> Creating kind cluster '$CLUSTER_NAME'..."
-      kind create cluster \
+      "$kind" create cluster \
         --name "$CLUSTER_NAME" \
         --config "$CLUSTER_CONFIG" \
         --kubeconfig "$KUBECONFIG_PATH" \
         --wait "$KIND_WAIT_TIMEOUT"
 
-      kubectl --kubeconfig "$KUBECONFIG_PATH" get nodes --context "kind-$CLUSTER_NAME"
+      "$kubectl" --kubeconfig "$KUBECONFIG_PATH" get nodes --context "kind-$CLUSTER_NAME"
     EOT
 
     interpreter = ["/usr/bin/env", "bash", "-c"]
@@ -76,6 +80,8 @@ resource "terraform_data" "kind_cluster" {
       KIND_WAIT_TIMEOUT      = var.kind_wait_timeout
       KUBECONFIG_PATH        = local.kubeconfig_path
       RESET_EXISTING_CLUSTER = tostring(var.reset_existing_cluster)
+      KIND_BIN               = var.kind_executable_path
+      KUBECTL_BIN            = var.kubectl_executable_path
     }
   }
 
@@ -84,9 +90,11 @@ resource "terraform_data" "kind_cluster" {
     command = <<-EOT
       set -euo pipefail
 
-      if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+      kind="$${KIND_BIN:-kind}"
+
+      if "$kind" get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
         echo "==> Deleting kind cluster '$CLUSTER_NAME'..."
-        kind delete cluster --name "$CLUSTER_NAME"
+        "$kind" delete cluster --name "$CLUSTER_NAME"
       else
         echo "Kind cluster '$CLUSTER_NAME' does not exist."
       fi
@@ -96,6 +104,7 @@ resource "terraform_data" "kind_cluster" {
 
     environment = {
       CLUSTER_NAME = self.input.cluster_name
+      KIND_BIN     = self.input.kind_executable_path
     }
   }
 }

--- a/infra/terraform/foundations/local-kind/main.tf
+++ b/infra/terraform/foundations/local-kind/main.tf
@@ -123,7 +123,10 @@ resource "terraform_data" "kind_cluster" {
 
     environment = {
       CLUSTER_NAME = self.input.cluster_name
-      KIND_BIN     = self.input.kind_executable_path
+      # State created before kind_executable_path existed on `input` has no
+      # such attribute; try() falls back to "" (the bare `kind` on PATH
+      # path below) instead of blocking teardown of that older state.
+      KIND_BIN = try(self.input.kind_executable_path, "")
     }
   }
 }

--- a/infra/terraform/foundations/local-kind/main.tf
+++ b/infra/terraform/foundations/local-kind/main.tf
@@ -92,6 +92,25 @@ resource "terraform_data" "kind_cluster" {
 
       kind="$${KIND_BIN:-kind}"
 
+      # The stored KIND_BIN is a managed-toolchain path resolved at apply
+      # time (Terraform destroy-time provisioners can only read `self`, so
+      # a freshly-resolved path can't be threaded in here). If OLF_HOME
+      # changed or `olf toolchain clean` removed that version since apply,
+      # the path may no longer exist. Falling through to "cluster does not
+      # exist" in that case would be wrong: it would drop this resource
+      # from state while the real kind cluster keeps running, unmanaged
+      # and undetected. Try a bare `kind` on PATH as a last resort, then
+      # fail loudly rather than silently declaring victory.
+      if ! "$kind" version >/dev/null 2>&1; then
+        if command -v kind >/dev/null 2>&1; then
+          echo "WARNING: managed kind at '$kind' is not executable (stale OLF_HOME or pruned toolchain); falling back to 'kind' on PATH." >&2
+          kind="kind"
+        else
+          echo "ERROR: kind ('$kind') is not executable and no 'kind' was found on PATH. Refusing to report cluster '$CLUSTER_NAME' as absent - that would silently orphan it. Set KIND_BIN to a working kind binary and retry." >&2
+          exit 1
+        fi
+      fi
+
       if "$kind" get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
         echo "==> Deleting kind cluster '$CLUSTER_NAME'..."
         "$kind" delete cluster --name "$CLUSTER_NAME"

--- a/infra/terraform/foundations/local-kind/variables.tf
+++ b/infra/terraform/foundations/local-kind/variables.tf
@@ -27,3 +27,15 @@ variable "reset_existing_cluster" {
   type        = bool
   default     = false
 }
+
+variable "kind_executable_path" {
+  description = "Absolute path to the kind executable the local-exec provisioner invokes. Empty resolves 'kind' from PATH (host mode, or direct 'terraform apply' outside olf); olf's managed toolchain (#127) always sets this explicitly."
+  type        = string
+  default     = ""
+}
+
+variable "kubectl_executable_path" {
+  description = "Absolute path to the kubectl executable the local-exec provisioner invokes. Empty resolves 'kubectl' from PATH (host mode, or direct 'terraform apply' outside olf); olf's managed toolchain (#127) always sets this explicitly."
+  type        = string
+  default     = ""
+}

--- a/release/component-catalog.yaml
+++ b/release/component-catalog.yaml
@@ -39,12 +39,12 @@ components:
         linux-amd64: sha256:298e19e9c6c17199011404278f0ff8168a7eca4217edad9097af577023a5620f
         linux-arm64: sha256:b97e93c20e3be4b8c8fa1235a41b4d77d4f2022ed3d899230dbbbbd43d26f872
     kind:
-      version: "0.30.0"
+      version: "0.32.0"
       platforms:
-        darwin-amd64: sha256:4f0b6e3b88bdc66d922c08469f05ef507d4903dd236e6319199bb9c868eed274
-        darwin-arm64: sha256:ceaf40df1d1551c481fb50e3deb5c3deecad5fd599df5469626b70ddf52a1518
-        linux-amd64: sha256:517ab7fc89ddeed5fa65abf71530d90648d9638ef0c4cde22c2c11f8097b8889
-        linux-arm64: sha256:7ea2de9d2d190022ed4a8a4e3ac0636c8a455e460b9a13ccf19f15d07f4f00eb
+        darwin-amd64: sha256:295ac6d0d634c9819c9907df45e3017d1f13166bd13c3404c45e79f7faa47498
+        darwin-arm64: sha256:dca67911095a110c2b5c36e26df6cac860c602033e456c0db47be498cdef1ebb
+        linux-amd64: sha256:50030de23cf40a18505f20426f6a8506bedf13c6e509244bd1fa9463721b0f54
+        linux-arm64: sha256:b92cd615e97585de8ddade28ed5cd7feb4248d717c233eea5b03c37298900f5d
   python:
     project_code_lock: images/project-code/requirements.lock
     tooling_lock: tools/olf/uv.lock

--- a/release/component-catalog.yaml
+++ b/release/component-catalog.yaml
@@ -39,12 +39,12 @@ components:
         linux-amd64: sha256:298e19e9c6c17199011404278f0ff8168a7eca4217edad9097af577023a5620f
         linux-arm64: sha256:b97e93c20e3be4b8c8fa1235a41b4d77d4f2022ed3d899230dbbbbd43d26f872
     kind:
-      version: "0.26.0"
+      version: "0.30.0"
       platforms:
-        darwin-amd64: sha256:a2c30525db86a7807ad4bba0094437406518f41d8a2882e6ea659d94099adcc4
-        darwin-arm64: sha256:e5bf92d8d46017e23482bfe266929d4d82e6f8c754e216c105cb7fbea937bea2
-        linux-amd64: sha256:d445b44c28297bc23fd67e51cc24bb294ae7b977712be2d4d312883d0835829b
-        linux-arm64: sha256:53fffdc37bd7149ccea440b1bdde2464f517d2c462dc8913ad37e7939e7f422d
+        darwin-amd64: sha256:4f0b6e3b88bdc66d922c08469f05ef507d4903dd236e6319199bb9c868eed274
+        darwin-arm64: sha256:ceaf40df1d1551c481fb50e3deb5c3deecad5fd599df5469626b70ddf52a1518
+        linux-amd64: sha256:517ab7fc89ddeed5fa65abf71530d90648d9638ef0c4cde22c2c11f8097b8889
+        linux-arm64: sha256:7ea2de9d2d190022ed4a8a4e3ac0636c8a455e460b9a13ccf19f15d07f4f00eb
   python:
     project_code_lock: images/project-code/requirements.lock
     tooling_lock: tools/olf/uv.lock

--- a/release/component-catalog.yaml
+++ b/release/component-catalog.yaml
@@ -16,6 +16,35 @@ components:
       hashicorp/kubernetes: 2.38.0
       hashicorp/random: 3.9.0
       hashicorp/tls: 4.3.0
+  toolchain:
+    terraform:
+      version: "1.8.5"
+      platforms:
+        darwin-amd64: sha256:051c702e156a4d1a1c628783cf2ca0e1db8cca7b4c0f1686ea623558ed5560f9
+        darwin-arm64: sha256:627c5005ab4a2bee36316f4967a41f16d55f79ea737f78b6bb34325c728c73e1
+        linux-amd64: sha256:bb1ee3e8314da76658002e2e584f2d8854b6def50b7f124e27b957a42ddacfea
+        linux-arm64: sha256:17b3a243ea24003a58ab324c197da8609fccae136bcb8a424bf61ec475b3a203
+    helm:
+      version: "3.18.6"
+      platforms:
+        darwin-amd64: sha256:80cad0470e38cf25731cdead7c32dfbeb887bc177bd6fa01e31b065722f8f06b
+        darwin-arm64: sha256:48e30d236a1f334c6acb78501be5a851eaa2a267fefeb1131b6484eb2f9f30d7
+        linux-amd64: sha256:3f43c0aa57243852dd542493a0f54f1396c0bc8ec7296bbb2c01e802010819ce
+        linux-arm64: sha256:5b8e00b6709caab466cbbb0bc29ee09059b8dc9417991dd04b497530e49b1737
+    kubectl:
+      version: "1.31.4"
+      platforms:
+        darwin-amd64: sha256:fd996e9f41fd42c6c1c781a5a85990f4d0d8337ede00a7719afa23be886e0abd
+        darwin-arm64: sha256:a756bb911298a85af35c0111c371728a26c532d504fe8b534eb684501fcaf996
+        linux-amd64: sha256:298e19e9c6c17199011404278f0ff8168a7eca4217edad9097af577023a5620f
+        linux-arm64: sha256:b97e93c20e3be4b8c8fa1235a41b4d77d4f2022ed3d899230dbbbbd43d26f872
+    kind:
+      version: "0.26.0"
+      platforms:
+        darwin-amd64: sha256:a2c30525db86a7807ad4bba0094437406518f41d8a2882e6ea659d94099adcc4
+        darwin-arm64: sha256:e5bf92d8d46017e23482bfe266929d4d82e6f8c754e216c105cb7fbea937bea2
+        linux-amd64: sha256:d445b44c28297bc23fd67e51cc24bb294ae7b977712be2d4d312883d0835829b
+        linux-arm64: sha256:53fffdc37bd7149ccea440b1bdde2464f517d2c462dc8913ad37e7939e7f422d
   python:
     project_code_lock: images/project-code/requirements.lock
     tooling_lock: tools/olf/uv.lock
@@ -36,9 +65,7 @@ components:
     actions/checkout: 34e114876b0b11c390a56381ad16ebd13914f8d5
     actions/setup-python: a26af69be951a213d495a4c3e4e4022e16d87065
     astral-sh/setup-uv: e58605a9b6da7c637471fab8847a5e5a6b8df081
-    azure/setup-helm: bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a
-    hashicorp/setup-terraform: b9cd54a3c349d3f38e8881555d616ced269862dd
-    helm/kind-action: a1b0e391336a6ee6713a0583f8c6240d70863de3
+    actions/cache: 55cc8345863c7cc4c66a329aec7e433d2d1c52a9
     docker/setup-buildx-action: f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
     docker/login-action: c94ce9fb468520275223c153574b00df6fe4bcc9
     docker/build-push-action: 4f58ea79222b3b9dc2c8bbdd6debcef730109a75

--- a/tools/olf/README.md
+++ b/tools/olf/README.md
@@ -7,12 +7,18 @@ Terraform remains the state/drift engine and Helm remains the chart/release
 engine; `olf` invokes both with structured argv, retries, and diagnostics. See
 [ADR 0028](../../docs/adr/0028-python-owns-repository-orchestration.md).
 
+`olf` also owns its own versioned Terraform, Helm, kubectl, and kind under
+`OLF_HOME` (default `~/.openlakeforge`) - a host installation of those tools
+is not required. `OLF_TOOLCHAIN_MODE=host` resolves them from `PATH` instead.
+See [ADR 0029](../../docs/adr/0029-olf-owns-a-managed-toolchain.md).
+
 ## Commands
 
 | Command | Purpose |
 | --- | --- |
-| `olf doctor --provider P [--phase PHASE]` / `olf plan --provider P [--phase PHASE]` | Read-only preflight and Terraform planning with typed provider/profile/phase options. |
+| `olf doctor --provider P [--phase PHASE]` / `olf plan --provider P [--phase PHASE]` | Read-only preflight and Terraform planning with typed provider/profile/phase options; provisions the managed toolchain as a side effect. |
 | `olf deploy\|destroy\|status\|forward --provider P` | Orchestrate a provider lifecycle without shell wrappers. |
+| `olf toolchain list\|install\|path\|clean` | Inspect, provision, or remove the managed Terraform/Helm/kubectl/kind toolchain under `OLF_HOME`. |
 | `olf check structure\|components\|contracts\|infra\|project-code\|dbt\|lockfiles\|all` | Repository validation gates. |
 | `olf images build\|load project-code\|superset` | Local Docker build and Kind load operations. |
 | `olf diagnostics collect OUTPUT_DIR` | Collect bounded host, Docker, Kubernetes, event, and pod-log evidence. |

--- a/tools/olf/olf/cli.py
+++ b/tools/olf/olf/cli.py
@@ -30,6 +30,7 @@ from olf.commands import (
     smoke,
     source,
     superset,
+    toolchain,
 )
 
 app = typer.Typer(
@@ -58,6 +59,7 @@ app.add_typer(release.app, name="release")
 app.add_typer(source.app, name="source")
 app.add_typer(domain.app, name="domain")
 app.add_typer(product.app, name="product")
+app.add_typer(toolchain.app, name="toolchain")
 
 app.command("deploy")(deployment.deploy)
 app.command("plan")(deployment.plan)

--- a/tools/olf/olf/commands/contracts.py
+++ b/tools/olf/olf/commands/contracts.py
@@ -8,6 +8,7 @@ import typer
 
 from olf import config
 from olf import contracts as contracts_module
+from olf.commands._shared import fail
 
 app = typer.Typer(help="Provider-contract runtime environment helpers.")
 
@@ -25,7 +26,17 @@ def contracts_env(
     Falls back to local defaults when the Terraform stack has not been applied
     yet. Intended for `eval` from scripts/contracts/load-runtime-env.sh.
     """
-    provider_contracts = contracts_module.load_provider_contracts(terraform_dir)
+    from olf.deployment.errors import DeploymentError
+
+    try:
+        provider_contracts = contracts_module.load_provider_contracts(terraform_dir)
+    except DeploymentError as exc:
+        # A managed-toolchain provisioning failure (#127) resolving
+        # terraform is a real operational problem, not "not applied yet" -
+        # load_provider_contracts() already distinguishes the two and lets
+        # this propagate; normalize it into the same clean CLI failure
+        # every other olf command produces instead of a raw traceback.
+        raise typer.Exit(code=fail(str(exc))) from exc
     exports, unsets = contracts_module.build_contract_env(os.environ, provider_contracts, repo_root=config.repo_root())
     output = contracts_module.render_shell_exports(exports, unsets)
     if output:

--- a/tools/olf/olf/commands/e2e.py
+++ b/tools/olf/olf/commands/e2e.py
@@ -70,6 +70,7 @@ def e2e_run(
     """
     from olf import e2e
     from olf.deployment import contract_env
+    from olf.deployment.errors import DeploymentError
 
     valid_envs = {"local", "azure", "aws"}
     valid_suites = {"", "full", "smoke"}
@@ -104,5 +105,10 @@ def e2e_run(
                 kube_context=kube_context,
                 repo_root=repo_root,
             )
-    except e2e.E2EError as exc:
+    except (e2e.E2EError, DeploymentError) as exc:
+        # DeploymentError covers a managed-toolchain provisioning failure
+        # (#127) raised while resolving the provider-contract environment,
+        # before e2e.run() (and its own E2EError-only preflight) is ever
+        # reached - it must fail the same clean way, not escape as a raw
+        # traceback.
         raise typer.Exit(code=fail(str(exc))) from exc

--- a/tools/olf/olf/commands/toolchain.py
+++ b/tools/olf/olf/commands/toolchain.py
@@ -1,0 +1,118 @@
+"""`olf toolchain`: inspect and manage the versioned managed toolchain (#127).
+
+Terraform/Helm/kubectl/kind are provisioned from `release/component-catalog.yaml`
+into `OLF_HOME` (default `~/.openlakeforge`), scoped per distribution version
+and platform. See `olf.toolchain` for the manager, and
+`olf.tooling.resolver.build_resolver` for how deployment commands pick this
+up automatically.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from olf import config
+from olf.commands._shared import fail
+
+app = typer.Typer(help="Inspect and manage the managed CLI toolchain (Terraform, Helm, kubectl, kind).")
+
+
+def _manager():  # noqa: ANN202
+    from olf.toolchain.manager import ToolchainManager
+
+    catalog_path = config.repo_root() / "release" / "component-catalog.yaml"
+    return ToolchainManager.from_catalog_path(catalog_path)
+
+
+@app.command("list")
+def list_tools() -> None:
+    """Show each managed tool's declared (catalog) and installed versions."""
+    from olf.toolchain.errors import ToolchainError
+
+    try:
+        manager = _manager()
+    except ToolchainError as exc:
+        raise typer.Exit(code=fail(str(exc))) from exc
+
+    typer.echo(f"distribution {manager.distribution_version}  platform {manager.platform}  home {manager.home}")
+    for name, spec in manager.specs.items():
+        installed = manager.installed(name)
+        if installed is None:
+            state = "not installed"
+        elif installed.version == spec.version and installed.sha256 == spec.sha256:
+            state = f"installed at {installed.path}"
+        else:
+            state = f"stale (installed {installed.version}, catalog wants {spec.version}) at {installed.path}"
+        typer.echo(f"  {name:10} catalog={spec.version:12} {state}")
+
+
+@app.command("install")
+def install_tools(
+    tool: str = typer.Option("", "--tool", help="Provision only this tool; default provisions all managed tools."),
+) -> None:
+    """Provision managed tools from the release catalog (CI calls this to pre-warm the cache)."""
+    from olf.deployment.errors import DeploymentError
+    from olf.toolchain.errors import ToolchainError
+
+    try:
+        manager = _manager()
+        if tool:
+            if tool not in manager.specs:
+                raise typer.Exit(code=fail(f"unknown --tool: {tool!r} (expected one of {tuple(manager.specs)})"))
+            path = manager.resolve(tool)
+            typer.echo(f"{tool} -> {path}")
+            return
+        for name, path in manager.ensure_all().items():
+            typer.echo(f"{name} -> {path}")
+    except (ToolchainError, DeploymentError) as exc:
+        raise typer.Exit(code=fail(str(exc))) from exc
+
+
+@app.command("path")
+def path(
+    tool: str = typer.Argument("", help="Print only this tool's resolved path; default prints the managed bin dir."),
+) -> None:
+    """Print the managed bin directory, or one tool's resolved (and provisioned) path."""
+    from olf.deployment.errors import DeploymentError
+    from olf.toolchain.errors import ToolchainError
+
+    try:
+        manager = _manager()
+        if not tool:
+            typer.echo(str(manager.bin_dir))
+            return
+        if tool not in manager.specs:
+            raise typer.Exit(code=fail(f"unknown tool: {tool!r} (expected one of {tuple(manager.specs)})"))
+        typer.echo(str(manager.resolve(tool)))
+    except (ToolchainError, DeploymentError) as exc:
+        raise typer.Exit(code=fail(str(exc))) from exc
+
+
+@app.command("clean")
+def clean(
+    version: str = typer.Option("", "--version", help="Remove only this distribution version's toolchain."),
+    keep_current: bool = typer.Option(
+        False, "--keep-current", help="Remove every installed version except the current distribution's."
+    ),
+    all_versions: bool = typer.Option(False, "--all", help="Remove every installed toolchain version."),
+) -> None:
+    """Remove installed toolchain versions under OLF_HOME. Never touches host-installed tools."""
+    from olf.toolchain.errors import ToolchainError
+
+    selected = sum(bool(x) for x in (version, keep_current, all_versions))
+    if selected != 1:
+        raise typer.Exit(code=fail("exactly one of --version, --keep-current, or --all is required"))
+    try:
+        manager = _manager()
+        removed = manager.prune(
+            version=version or None,
+            keep_current=keep_current,
+            remove_all=all_versions,
+        )
+    except ToolchainError as exc:
+        raise typer.Exit(code=fail(str(exc))) from exc
+    if not removed:
+        typer.echo("Nothing to remove.")
+        return
+    for entry in removed:
+        typer.echo(f"removed {entry}")

--- a/tools/olf/olf/commands/toolchain.py
+++ b/tools/olf/olf/commands/toolchain.py
@@ -51,9 +51,6 @@ def install_tools(
     tool: str = typer.Option("", "--tool", help="Provision only this tool; default provisions all managed tools."),
 ) -> None:
     """Provision managed tools from the release catalog (CI calls this to pre-warm the cache)."""
-    from olf.deployment.errors import DeploymentError
-    from olf.toolchain.errors import ToolchainError
-
     try:
         manager = _manager()
         if tool:
@@ -64,7 +61,14 @@ def install_tools(
             return
         for name, path in manager.ensure_all().items():
             typer.echo(f"{name} -> {path}")
-    except (ToolchainError, DeploymentError) as exc:
+    except typer.Exit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - this command calls ToolchainManager
+        # directly, bypassing ManagedExecutableResolver's catch-and-wrap, so
+        # provisioning failures here can be anything the manager's own I/O
+        # raises natively (PermissionError, a full disk, a corrupt archive
+        # extraction) - all of it funnels into one concise CLI failure
+        # rather than a raw traceback.
         raise typer.Exit(code=fail(str(exc))) from exc
 
 
@@ -73,9 +77,6 @@ def path(
     tool: str = typer.Argument("", help="Print only this tool's resolved path; default prints the managed bin dir."),
 ) -> None:
     """Print the managed bin directory, or one tool's resolved (and provisioned) path."""
-    from olf.deployment.errors import DeploymentError
-    from olf.toolchain.errors import ToolchainError
-
     try:
         manager = _manager()
         if not tool:
@@ -84,7 +85,9 @@ def path(
         if tool not in manager.specs:
             raise typer.Exit(code=fail(f"unknown tool: {tool!r} (expected one of {tuple(manager.specs)})"))
         typer.echo(str(manager.resolve(tool)))
-    except (ToolchainError, DeploymentError) as exc:
+    except typer.Exit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - see install_tools
         raise typer.Exit(code=fail(str(exc))) from exc
 
 
@@ -97,8 +100,6 @@ def clean(
     all_versions: bool = typer.Option(False, "--all", help="Remove every installed toolchain version."),
 ) -> None:
     """Remove installed toolchain versions under OLF_HOME. Never touches host-installed tools."""
-    from olf.toolchain.errors import ToolchainError
-
     selected = sum(bool(x) for x in (version, keep_current, all_versions))
     if selected != 1:
         raise typer.Exit(code=fail("exactly one of --version, --keep-current, or --all is required"))
@@ -109,7 +110,9 @@ def clean(
             keep_current=keep_current,
             remove_all=all_versions,
         )
-    except ToolchainError as exc:
+    except typer.Exit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - see install_tools
         raise typer.Exit(code=fail(str(exc))) from exc
     if not removed:
         typer.echo("Nothing to remove.")

--- a/tools/olf/olf/contracts.py
+++ b/tools/olf/olf/contracts.py
@@ -37,9 +37,15 @@ class ProviderContractError(ValueError):
 
 def load_provider_contracts(terraform_dir: str) -> dict[str, Any] | None:
     """Read the Terraform provider_contracts output, or None before apply."""
+    from olf.tooling.resolver import build_resolver
+
+    try:
+        terraform = str(build_resolver().resolve("terraform"))
+    except Exception:  # noqa: BLE001 - unresolved terraform is equivalent to "not applied yet" here
+        return None
     try:
         result = subprocess.run(
-            ["terraform", f"-chdir={terraform_dir}", "output", "-json", "provider_contracts"],
+            [terraform, f"-chdir={terraform_dir}", "output", "-json", "provider_contracts"],
             capture_output=True,
             text=True,
             check=True,

--- a/tools/olf/olf/contracts.py
+++ b/tools/olf/olf/contracts.py
@@ -36,12 +36,25 @@ class ProviderContractError(ValueError):
 
 
 def load_provider_contracts(terraform_dir: str) -> dict[str, Any] | None:
-    """Read the Terraform provider_contracts output, or None before apply."""
+    """Read the Terraform provider_contracts output, or None before apply.
+
+    Only a missing executable (`ExecutableNotFoundError`) is treated as
+    "not applied yet" - matching this function's pre-#127 behaviour, where
+    `terraform` simply not being on `PATH` fell into the same `OSError`
+    branch below. A managed-toolchain provisioning failure
+    (`ToolchainError`: a bad digest, a broken download, a malformed
+    catalog) is a real operational problem, not an unapplied-state signal,
+    and must propagate rather than be silently treated as "no contracts
+    yet" - a caller that swallowed it would fall back to defaults (e.g.
+    enabling governance/analytics for what should be a slim deployment)
+    instead of failing closed.
+    """
+    from olf.deployment.errors import ExecutableNotFoundError
     from olf.tooling.resolver import build_resolver
 
     try:
         terraform = str(build_resolver().resolve("terraform"))
-    except Exception:  # noqa: BLE001 - unresolved terraform is equivalent to "not applied yet" here
+    except ExecutableNotFoundError:
         return None
     try:
         result = subprocess.run(

--- a/tools/olf/olf/deployment/engine.py
+++ b/tools/olf/olf/deployment/engine.py
@@ -27,7 +27,7 @@ from olf.tooling.helm import Helm
 from olf.tooling.kind import Kind
 from olf.tooling.kubectl import Kubectl
 from olf.tooling.process import ProcessRunner
-from olf.tooling.resolver import ExecutableResolver, PathExecutableResolver
+from olf.tooling.resolver import ExecutableResolver, build_resolver
 from olf.tooling.terraform import Terraform
 
 if TYPE_CHECKING:
@@ -62,9 +62,10 @@ class Toolkit:
         *,
         log_commands: bool = False,
         overrides: Mapping[str, Path] | None = None,
+        environ: Mapping[str, str] | None = None,
     ) -> Toolkit:
         runner = ProcessRunner(log_commands=log_commands)
-        resolver = PathExecutableResolver(overrides=overrides)
+        resolver = build_resolver(overrides=overrides, environ=environ)
         return cls(
             runner=runner,
             resolver=resolver,

--- a/tools/olf/olf/deployment/errors.py
+++ b/tools/olf/olf/deployment/errors.py
@@ -95,3 +95,19 @@ class DeploymentPreconditionError(DeploymentError):
 
 class UnsupportedProviderError(DeploymentError):
     """Raised when a `DeploymentProvider` has not been implemented yet."""
+
+
+class ToolchainError(ToolingError):
+    """Raised when the managed toolchain (#127) cannot resolve or provision a
+    tool: unsupported host platform, digest verification failure, or a
+    download failure. Never falls back to an unmanaged host binary; the
+    message names the `OLF_TOOLCHAIN_MODE=host` escape hatch.
+    """
+
+    def __init__(self, tool: str, *, reason: str) -> None:
+        self.tool = tool
+        self.reason = reason
+        super().__init__(
+            f"managed toolchain could not provision {tool!r}: {reason} "
+            "(set OLF_TOOLCHAIN_MODE=host to use a host-installed binary instead)"
+        )

--- a/tools/olf/olf/deployment/inspection.py
+++ b/tools/olf/olf/deployment/inspection.py
@@ -1,8 +1,10 @@
 """Read-only deployment inspection helpers used by ``olf doctor``.
 
 The deployment engine owns preflight checks rather than leaving them in Make
-or shell wrappers.  The report is deliberately small: managed toolchains and
-version installation are an extension point for issue #127.
+or shell wrappers. Managed-toolchain awareness (#127) reports which tools
+are provisioned from `release/component-catalog.yaml` versus resolved from
+`PATH`, and provisions on first use - `olf doctor` is the documented way to
+pre-warm a clean machine's toolchain before `olf deploy`.
 """
 
 from __future__ import annotations
@@ -12,7 +14,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from olf.deployment.errors import DeploymentError, ExecutableNotFoundError
+from olf.deployment.errors import DeploymentError, ExecutableNotFoundError, ToolchainError
+from olf.tooling.resolver import ManagedExecutableResolver
 
 if TYPE_CHECKING:
     from olf.deployment.engine import Toolkit
@@ -41,6 +44,15 @@ class DoctorReport:
         return "\n".join(lines)
 
 
+def _toolchain_mode_item(tools: Toolkit) -> DoctorItem:
+    resolver = tools.resolver
+    if not isinstance(resolver, ManagedExecutableResolver):
+        return DoctorItem("toolchain mode", True, "host (OLF_TOOLCHAIN_MODE=host; PATH resolution only)")
+    manager = resolver.manager
+    detail = f"managed; distribution {manager.distribution_version}; platform {manager.platform}; home {manager.home}"
+    return DoctorItem("toolchain mode", True, detail)
+
+
 def base_report(
     *,
     repo_root: Path,
@@ -50,14 +62,24 @@ def base_report(
     items = [
         DoctorItem("repository", (repo_root / "lakehouse_code/lakehouse.yaml").is_file(), str(repo_root)),
         DoctorItem("terraform roots", (repo_root / "infra/terraform").is_dir(), str(repo_root / "infra/terraform")),
+        _toolchain_mode_item(tools),
     ]
+    resolver = tools.resolver
+    managed_names: frozenset[str] = frozenset()
+    if isinstance(resolver, ManagedExecutableResolver):
+        from olf.toolchain.spec import MANAGED_TOOLS
+
+        managed_names = frozenset(MANAGED_TOOLS)
     for name in required_tools:
         try:
-            path = tools.resolver.resolve(name)
+            path = resolver.resolve(name)
         except ExecutableNotFoundError:
             items.append(DoctorItem(name, False, "not found on PATH"))
+        except ToolchainError as exc:
+            items.append(DoctorItem(name, False, str(exc)))
         else:
-            items.append(DoctorItem(name, True, str(path)))
+            source = "managed" if name in managed_names else "PATH"
+            items.append(DoctorItem(name, True, f"{path} ({source})"))
     return items
 
 

--- a/tools/olf/olf/deployment/local/foundation.py
+++ b/tools/olf/olf/deployment/local/foundation.py
@@ -18,21 +18,31 @@ from olf.deployment.local.config import LocalDeploymentConfig
 from olf.tooling.kubectl import KubeContextUnreachableError
 
 
-def foundation_apply_variables(config: LocalDeploymentConfig) -> dict[str, str]:
+def foundation_apply_variables(config: LocalDeploymentConfig, tools: Toolkit) -> dict[str, str]:
+    """`kind_executable_path`/`kubectl_executable_path` route the foundation
+    Terraform root's `local-exec` provisioner (`infra/terraform/foundations/
+    local-kind/main.tf`) through the same resolver every other `olf`-invoked
+    tool uses, instead of it invoking bare `kind`/`kubectl` from whatever
+    happens to be on PATH when Terraform runs - which, under the managed
+    toolchain (#127), is not the same binary this `Toolkit` resolved.
+    """
     return {
         "cluster_name": config.cluster.name,
         "cluster_config_path": str(config.cluster.config_path),
         "kubeconfig_path": str(config.paths.kubeconfig_path),
         "kind_wait_timeout": config.cluster.wait_timeout,
         "reset_existing_cluster": "true" if config.cluster.reset_existing else "false",
+        "kind_executable_path": str(tools.resolver.resolve("kind")),
+        "kubectl_executable_path": str(tools.resolver.resolve("kubectl")),
     }
 
 
-def foundation_destroy_variables(config: LocalDeploymentConfig) -> dict[str, str]:
+def foundation_destroy_variables(config: LocalDeploymentConfig, tools: Toolkit) -> dict[str, str]:
     return {
         "cluster_name": config.cluster.name,
         "cluster_config_path": str(config.cluster.config_path),
         "kubeconfig_path": str(config.paths.kubeconfig_path),
+        "kind_executable_path": str(tools.resolver.resolve("kind")),
     }
 
 
@@ -44,7 +54,7 @@ def foundation_up(config: LocalDeploymentConfig, tools: Toolkit, *, env: Mapping
     tools.terraform.init(foundation_dir, env=env)
 
     log.step("Applying Terraform local kind foundation...")
-    tools.terraform.apply(foundation_dir, variables=foundation_apply_variables(config), env=env)
+    tools.terraform.apply(foundation_dir, variables=foundation_apply_variables(config, tools), env=env)
 
     tools.kind.export_kubeconfig(config.cluster.name, kubeconfig_path=config.paths.kubeconfig_path, env=env)
 
@@ -103,5 +113,5 @@ def foundation_down(
             )
 
     log.step("Destroying Terraform local kind foundation...")
-    tools.terraform.destroy(foundation_dir, variables=foundation_destroy_variables(config), env=env)
+    tools.terraform.destroy(foundation_dir, variables=foundation_destroy_variables(config, tools), env=env)
     log.step("Local foundation is destroyed.")

--- a/tools/olf/olf/deployment/local/provider.py
+++ b/tools/olf/olf/deployment/local/provider.py
@@ -131,7 +131,7 @@ class LocalProvider:
             self.tools.terraform.init(self.config.paths.foundation_terraform_dir, env=self.env)
             result = self.tools.terraform.plan(
                 self.config.paths.foundation_terraform_dir,
-                variables=foundation.foundation_apply_variables(self.config),
+                variables=foundation.foundation_apply_variables(self.config, self.tools),
                 detailed_exitcode=True,
                 env=self.env,
             )

--- a/tools/olf/olf/e2e/_runner.py
+++ b/tools/olf/olf/e2e/_runner.py
@@ -27,6 +27,7 @@ from olf.e2e._shell import (
     E2EError,
     Environment,
     Suite,
+    _kubectl_executable,
     _run,
     _run_retry,
     terraform_output,
@@ -141,12 +142,23 @@ def _contract_dir(repo_root: Path, default: str) -> Path:
 
 
 def check_commands(cfg: E2EConfig) -> None:
-    commands = ["kubectl", "terraform"]
+    from olf.deployment.errors import ExecutableNotFoundError
+    from olf.tooling.resolver import build_resolver
+
+    missing: list[str] = []
+    resolver = build_resolver()
+    for managed_tool in ("kubectl", "terraform"):
+        try:
+            resolver.resolve(managed_tool)
+        except ExecutableNotFoundError:
+            missing.append(managed_tool)
+
+    host_commands: list[str] = []
     if cfg.env == "azure":
-        commands.append("az")
+        host_commands.append("az")
     if cfg.env == "aws":
-        commands.append("aws")
-    missing = [cmd for cmd in commands if shutil.which(cmd) is None]
+        host_commands.append("aws")
+    missing.extend(cmd for cmd in host_commands if shutil.which(cmd) is None)
     if missing:
         raise E2EError(f"missing required command(s): {', '.join(missing)}")
 
@@ -195,7 +207,9 @@ def prepare_kube_context(cfg: E2EConfig) -> None:
                 cfg.kube_context,
             ]
         )
-    _run_retry(["kubectl", "cluster-info", "--context", cfg.kube_context], capture=True, attempts=6, delay=5)
+    _run_retry(
+        [_kubectl_executable(), "cluster-info", "--context", cfg.kube_context], capture=True, attempts=6, delay=5
+    )
 
 
 def configure_kubeconfig(cfg: E2EConfig) -> Path:
@@ -214,7 +228,7 @@ def configure_kubeconfig(cfg: E2EConfig) -> Path:
 
 def kube_context_is_ready(kube_context: str) -> bool:
     try:
-        _run(["kubectl", "cluster-info", "--context", kube_context], capture=True)
+        _run([_kubectl_executable(), "cluster-info", "--context", kube_context], capture=True)
     except E2EError:
         return False
     return True

--- a/tools/olf/olf/e2e/_runner.py
+++ b/tools/olf/olf/e2e/_runner.py
@@ -142,7 +142,7 @@ def _contract_dir(repo_root: Path, default: str) -> Path:
 
 
 def check_commands(cfg: E2EConfig) -> None:
-    from olf.deployment.errors import ExecutableNotFoundError
+    from olf.deployment.errors import ExecutableNotFoundError, ToolchainError
     from olf.tooling.resolver import build_resolver
 
     missing: list[str] = []
@@ -152,6 +152,13 @@ def check_commands(cfg: E2EConfig) -> None:
             resolver.resolve(managed_tool)
         except ExecutableNotFoundError:
             missing.append(managed_tool)
+        except ToolchainError as exc:
+            # A managed tool that couldn't be provisioned (bad digest,
+            # broken download, unwritable cache) is a different failure
+            # from "not found", but `olf e2e run` only catches E2EError -
+            # surface it there too, with the actionable reason, instead of
+            # letting it escape as a raw traceback.
+            missing.append(f"{managed_tool} ({exc})")
 
     host_commands: list[str] = []
     if cfg.env == "azure":

--- a/tools/olf/olf/e2e/_shell.py
+++ b/tools/olf/olf/e2e/_shell.py
@@ -18,6 +18,7 @@ from typing import Any, Literal
 from openlakeforge_domain import DomainInventory
 
 from olf import contracts, log
+from olf.tooling.resolver import build_resolver
 
 Environment = Literal["local", "azure", "aws"]
 Suite = Literal["full", "smoke"]
@@ -55,6 +56,21 @@ class E2EConfig:
     seaweedfs_local_port: int | None = None
 
 
+def _kubectl_executable() -> str:
+    """The resolved (possibly managed, #127) kubectl executable path.
+
+    A separate function so tests can substitute a literal `"kubectl"`
+    without exercising real toolchain resolution.
+    """
+    return str(build_resolver().resolve("kubectl"))
+
+
+def _terraform_executable() -> str:
+    """The resolved (possibly managed, #127) terraform executable path. See
+    `_kubectl_executable`."""
+    return str(build_resolver().resolve("terraform"))
+
+
 def kubectl(
     cfg: E2EConfig,
     args: list[str],
@@ -62,7 +78,7 @@ def kubectl(
     capture: bool = False,
     retry_transient: bool = False,
 ) -> str:
-    command = ["kubectl", "--context", cfg.kube_context, *args]
+    command = [_kubectl_executable(), "--context", cfg.kube_context, *args]
     if retry_transient:
         return _run_retry_transient_kubectl(command, capture=capture)
     return _run(command, capture=capture)
@@ -120,13 +136,15 @@ def is_transient_kubectl_error(error: Exception) -> bool:
 def terraform_output(terraform_dir: Path | None, name: str) -> str:
     if terraform_dir is None:
         raise E2EError(f"cannot read Terraform output {name}: no Terraform directory configured.")
-    return _run(["terraform", f"-chdir={terraform_dir}", "output", "-raw", name], capture=True).strip()
+    return _run(
+        [_terraform_executable(), f"-chdir={terraform_dir}", "output", "-raw", name], capture=True
+    ).strip()
 
 
 def terraform_output_json(terraform_dir: Path | None, name: str) -> Any:
     if terraform_dir is None:
         raise E2EError(f"cannot read Terraform output {name}: no Terraform directory configured.")
-    raw = _run(["terraform", f"-chdir={terraform_dir}", "output", "-json", name], capture=True)
+    raw = _run([_terraform_executable(), f"-chdir={terraform_dir}", "output", "-json", name], capture=True)
     try:
         return json.loads(raw)
     except json.JSONDecodeError as exc:

--- a/tools/olf/olf/k8s.py
+++ b/tools/olf/olf/k8s.py
@@ -20,6 +20,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 
 from olf import log
+from olf.tooling.resolver import build_resolver
 
 
 class KubectlError(RuntimeError):
@@ -40,6 +41,26 @@ def kubectl_command(args: list[str], *, kube_context: str | None = None) -> list
     return command
 
 
+def _kubectl_executable() -> str:
+    """The resolved (possibly managed, #127) kubectl executable path.
+
+    A separate function so tests can substitute a literal `"kubectl"`
+    without exercising real toolchain resolution.
+    """
+    return str(build_resolver().resolve("kubectl"))
+
+
+def _resolved_kubectl_argv(args: list[str], *, kube_context: str | None = None) -> list[str]:
+    """`kubectl_command`'s argv with `kubectl` substituted for its resolved
+    executable path, used at every actual subprocess execution site.
+    `kubectl_command` itself stays a pure argv builder so callers/tests that
+    only need the command shape never pay for resolution.
+    """
+    command = kubectl_command(args, kube_context=kube_context)
+    command[0] = _kubectl_executable()
+    return command
+
+
 def _kubectl(
     args: list[str],
     *,
@@ -47,7 +68,7 @@ def _kubectl(
     check: bool = True,
     kube_context: str | None = None,
 ) -> str:
-    command = kubectl_command(args, kube_context=kube_context)
+    command = _resolved_kubectl_argv(args, kube_context=kube_context)
     result = subprocess.run(
         command,
         capture_output=capture,
@@ -137,7 +158,7 @@ def port_forward(
     service-specific health probe (Polaris OAuth, OpenMetadata JWKS, S3 bucket).
     """
     port = local_port or _free_local_port()
-    command = kubectl_command(
+    command = _resolved_kubectl_argv(
         [
             "port-forward",
             f"svc/{service}",

--- a/tools/olf/olf/release/_compatibility.py
+++ b/tools/olf/olf/release/_compatibility.py
@@ -116,6 +116,22 @@ def render_compatibility_matrix(catalog: dict[str, Any], repo_root: str | Path =
         lines.append(f"| {chart} | {chart_version} |")
     lines.append("")
 
+    toolchain = components.get("toolchain") or {}
+    if toolchain:
+        lines.append("## Managed toolchain")
+        lines.append("")
+        lines.append(
+            "Terraform, Helm, kubectl, and kind are provisioned by `olf toolchain` "
+            "(#127) rather than installed by the consumer; versions below are what "
+            "the current release provisions."
+        )
+        lines.append("")
+        lines.append("| Tool | Version |")
+        lines.append("| --- | --- |")
+        for tool, entry in sorted(toolchain.items()):
+            lines.append(f"| {tool} | {entry.get('version', 'unknown') if isinstance(entry, dict) else 'unknown'} |")
+        lines.append("")
+
     lines.append("## Container images")
     lines.append("")
     lines.append("| Image | Reference |")

--- a/tools/olf/olf/release/_readiness.py
+++ b/tools/olf/olf/release/_readiness.py
@@ -48,6 +48,49 @@ def _check_version_matches_tag(catalog: dict[str, Any], tag: str | None) -> Chec
     return CheckResult("tag matches catalog distribution.version", True, f"{tag} == {expected_tag}")
 
 
+_TOOLCHAIN_SHA256_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+_TOOLCHAIN_PLATFORMS = ("darwin-amd64", "darwin-arm64", "linux-amd64", "linux-arm64")
+
+
+def _check_toolchain_pinned(catalog: dict[str, Any]) -> CheckResult:
+    """Every managed tool (#127) has a concrete version - never `latest` -
+    and a well-formed digest for every supported platform."""
+    from olf.toolchain.spec import MANAGED_TOOLS
+
+    toolchain = (catalog.get("components") or {}).get("toolchain")
+    if not isinstance(toolchain, dict):
+        return CheckResult("managed toolchain is pinned", False, "components.toolchain is missing")
+
+    problems: list[str] = []
+    missing_tools = [tool for tool in MANAGED_TOOLS if tool not in toolchain]
+    if missing_tools:
+        problems.append(f"missing entries: {', '.join(missing_tools)}")
+
+    for tool in MANAGED_TOOLS:
+        entry = toolchain.get(tool)
+        if not isinstance(entry, dict):
+            continue
+        version = entry.get("version")
+        if not isinstance(version, str) or not version or version == "latest":
+            problems.append(f"{tool}.version must be a concrete version, got {version!r}")
+        platforms = entry.get("platforms")
+        if not isinstance(platforms, dict):
+            problems.append(f"{tool}.platforms must be a mapping")
+            continue
+        missing_platforms = [p for p in _TOOLCHAIN_PLATFORMS if p not in platforms]
+        if missing_platforms:
+            problems.append(f"{tool}.platforms is missing {', '.join(missing_platforms)}")
+        malformed = sorted(
+            p for p, digest in platforms.items() if not _TOOLCHAIN_SHA256_PATTERN.match(str(digest))
+        )
+        if malformed:
+            problems.append(f"{tool}.platforms has malformed digest(s) for {', '.join(malformed)}")
+
+    if problems:
+        return CheckResult("managed toolchain is pinned", False, "; ".join(problems))
+    return CheckResult("managed toolchain is pinned", True, f"{len(MANAGED_TOOLS)} tool(s) checked")
+
+
 def _check_images_digest_pinned(catalog: dict[str, Any]) -> CheckResult:
     images = (catalog.get("components") or {}).get("images") or {}
     if not images:
@@ -409,6 +452,7 @@ def run_release_check(
     report = ReleaseCheckReport()
     report.results.append(_check_version_matches_tag(catalog, tag))
     report.results.append(_check_images_digest_pinned(catalog))
+    report.results.append(_check_toolchain_pinned(catalog))
     report.results.append(_check_images_match_deployment_sources(root, catalog))
     report.results.append(_check_actions_sha_pinned(root, catalog))
     report.results.append(_check_dockerfiles_pinned(root))

--- a/tools/olf/olf/release/_readiness.py
+++ b/tools/olf/olf/release/_readiness.py
@@ -68,7 +68,10 @@ def _check_toolchain_pinned(catalog: dict[str, Any]) -> CheckResult:
 
     for tool in MANAGED_TOOLS:
         entry = toolchain.get(tool)
+        if tool in missing_tools:
+            continue
         if not isinstance(entry, dict):
+            problems.append(f"{tool} entry must be a mapping, got {entry!r}")
             continue
         version = entry.get("version")
         if not isinstance(version, str) or not version or version == "latest":

--- a/tools/olf/olf/smoke.py
+++ b/tools/olf/olf/smoke.py
@@ -47,7 +47,7 @@ def run(
         with _deadline(timeout_seconds):
             with patch.dict(os.environ, env, clear=False):
                 log.step("Deploying slim local platform...")
-                provider = build_provider(context, toolkit=Toolkit.default(environ=env), environ=env)
+                provider = build_provider(context, toolkit=Toolkit.default(), environ=env)
                 DeploymentEngine(provider).deploy(DeploymentPhase.ALL)
                 _require_remaining(
                     started, timeout_seconds, monotonic, "validating one product pipeline and Gold table"

--- a/tools/olf/olf/smoke.py
+++ b/tools/olf/olf/smoke.py
@@ -47,7 +47,7 @@ def run(
         with _deadline(timeout_seconds):
             with patch.dict(os.environ, env, clear=False):
                 log.step("Deploying slim local platform...")
-                provider = build_provider(context, toolkit=Toolkit.default(), environ=env)
+                provider = build_provider(context, toolkit=Toolkit.default(environ=env), environ=env)
                 DeploymentEngine(provider).deploy(DeploymentPhase.ALL)
                 _require_remaining(
                     started, timeout_seconds, monotonic, "validating one product pipeline and Gold table"

--- a/tools/olf/olf/superset.py
+++ b/tools/olf/olf/superset.py
@@ -212,7 +212,9 @@ def _exec_pod_python(pod: str, namespace: str, script: str, args: list[str]) -> 
     quoted = " ".join(f"'{arg}'" for arg in args)
     command = f". /app/pythonpath/superset_bootstrap.sh; python - {quoted}"
     subprocess.run(
-        k8s.kubectl_command(["exec", "-i", pod, "-c", "superset", "-n", namespace, "--", "/bin/sh", "-ec", command]),
+        k8s._resolved_kubectl_argv(  # noqa: SLF001 - internal helper reuse
+            ["exec", "-i", pod, "-c", "superset", "-n", namespace, "--", "/bin/sh", "-ec", command]
+        ),
         input=script,
         text=True,
         check=True,
@@ -258,7 +260,7 @@ def deploy_reports(
         log.step(f"Copying {bundle_path} to {pod}:{remote_bundle}")
         with bundle_path.open("rb") as body:
             subprocess.run(
-                k8s.kubectl_command(
+                k8s._resolved_kubectl_argv(  # noqa: SLF001 - internal helper reuse
                     [
                         "exec",
                         "-i",
@@ -307,7 +309,9 @@ def export_report(
 
     with local_bundle.open("wb") as out:
         subprocess.run(
-            k8s.kubectl_command(["exec", pod, "-c", "superset", "-n", namespace, "--", "cat", remote_bundle]),
+            k8s._resolved_kubectl_argv(  # noqa: SLF001 - internal helper reuse
+                ["exec", pod, "-c", "superset", "-n", namespace, "--", "cat", remote_bundle]
+            ),
             stdout=out,
             check=True,
         )

--- a/tools/olf/olf/toolchain/__init__.py
+++ b/tools/olf/olf/toolchain/__init__.py
@@ -1,0 +1,25 @@
+"""A versioned, private toolchain of external CLI binaries owned by `olf`.
+
+`olf.toolchain` downloads, verifies, and activates the exact Terraform/Helm/
+kubectl/kind versions pinned in `release/component-catalog.yaml`, scoped
+under `OLF_HOME` (default `~/.openlakeforge`). It never touches a system
+package manager and never mutates `PATH`. See `olf.tooling.resolver` for the
+seam that substitutes this manager for `PathExecutableResolver`.
+"""
+
+from __future__ import annotations
+
+from olf.toolchain.errors import ToolchainVerificationError
+from olf.toolchain.manager import ToolchainManager
+from olf.toolchain.platform import Platform, UnsupportedPlatformError
+from olf.toolchain.spec import MANAGED_TOOLS, ToolSpec, load_specs
+
+__all__ = [
+    "MANAGED_TOOLS",
+    "Platform",
+    "ToolSpec",
+    "ToolchainManager",
+    "ToolchainVerificationError",
+    "UnsupportedPlatformError",
+    "load_specs",
+]

--- a/tools/olf/olf/toolchain/download.py
+++ b/tools/olf/olf/toolchain/download.py
@@ -7,7 +7,6 @@ built on the `requests` dependency `olf` already carries.
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import os
 import tempfile
@@ -71,6 +70,12 @@ def fetch_verified(downloader: Downloader, spec: ToolSpec, *, cache_root: Path) 
     `unlink()` - the loser gets `FileNotFoundError` instead of the cache
     being repaired.
     """
+    # Deferred: POSIX-only, and importing it eagerly at module load would
+    # fail on an unsupported platform (e.g. Windows) before Platform.detect()
+    # ever gets to raise its own actionable error - manager.py imports this
+    # module unconditionally.
+    import fcntl
+
     destination = cache_path(cache_root, spec)
     destination.parent.mkdir(parents=True, exist_ok=True)
     lock_path = destination.parent / f"{destination.name}.lock"

--- a/tools/olf/olf/toolchain/download.py
+++ b/tools/olf/olf/toolchain/download.py
@@ -1,0 +1,82 @@
+"""Fetching a tool archive into the content-addressed download cache.
+
+`Downloader` is a narrow protocol so tests substitute an in-memory fake
+instead of hitting the network; `HttpDownloader` is the real implementation,
+built on the `requests` dependency `olf` already carries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from pathlib import Path
+from typing import Protocol
+
+from olf.toolchain.errors import ToolchainDownloadError, ToolchainVerificationError
+from olf.toolchain.spec import ToolSpec
+
+
+class Downloader(Protocol):
+    def fetch(self, url: str, *, destination: Path) -> None:
+        """Write the full content of `url` to `destination`. Must not leave a
+        partial file at `destination` on failure."""
+        ...
+
+
+class HttpDownloader:
+    def __init__(self, *, timeout_seconds: float = 120.0, chunk_size: int = 1 << 16) -> None:
+        self._timeout_seconds = timeout_seconds
+        self._chunk_size = chunk_size
+
+    def fetch(self, url: str, *, destination: Path) -> None:
+        import requests
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(dir=destination.parent, prefix=".download-")
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                try:
+                    response = requests.get(url, stream=True, timeout=self._timeout_seconds)
+                    response.raise_for_status()
+                    for chunk in response.iter_content(chunk_size=self._chunk_size):
+                        if chunk:
+                            handle.write(chunk)
+                except requests.RequestException as exc:
+                    raise ToolchainDownloadError(f"failed to download {url}: {exc}") from exc
+            os.replace(tmp_path, destination)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
+def cache_path(cache_root: Path, spec: ToolSpec) -> Path:
+    digest = spec.sha256.removeprefix("sha256:")
+    return cache_root / "downloads" / digest
+
+
+def fetch_verified(downloader: Downloader, spec: ToolSpec, *, cache_root: Path) -> Path:
+    """Return a cached, digest-verified copy of `spec`'s archive, downloading
+    it first if it is not already cached (or if a stale cache entry no longer
+    matches its own name)."""
+    destination = cache_path(cache_root, spec)
+    if destination.is_file() and _sha256(destination) == spec.sha256.removeprefix("sha256:"):
+        return destination
+    if destination.exists():
+        destination.unlink()
+
+    downloader.fetch(spec.url, destination=destination)
+    actual = _sha256(destination)
+    expected = spec.sha256.removeprefix("sha256:")
+    if actual != expected:
+        destination.unlink(missing_ok=True)
+        raise ToolchainVerificationError(spec.name, expected=expected, actual=actual)
+    return destination
+
+
+def _sha256(path: Path, *, chunk_size: int = 1 << 20) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/tools/olf/olf/toolchain/download.py
+++ b/tools/olf/olf/toolchain/download.py
@@ -7,6 +7,7 @@ built on the `requests` dependency `olf` already carries.
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import os
 import tempfile
@@ -58,12 +59,34 @@ def cache_path(cache_root: Path, spec: ToolSpec) -> Path:
 def fetch_verified(downloader: Downloader, spec: ToolSpec, *, cache_root: Path) -> Path:
     """Return a cached, digest-verified copy of `spec`'s archive, downloading
     it first if it is not already cached (or if a stale cache entry no longer
-    matches its own name)."""
+    matches its own name).
+
+    Locked per digest, independent of any caller-side lock: this cache is
+    content-addressed and intentionally shared across every
+    `ToolchainManager` (and thus every distribution version) pointed at the
+    same `OLF_HOME`, so a manager's own per-version lock does not protect
+    it. Without a lock scoped here, two managers that happen to pin the
+    same tool digest and concurrently find a stale/corrupted cache entry
+    could both pass the staleness check and then race each other's
+    `unlink()` - the loser gets `FileNotFoundError` instead of the cache
+    being repaired.
+    """
     destination = cache_path(cache_root, spec)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = destination.parent / f"{destination.name}.lock"
+    with lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            return _fetch_verified_locked(downloader, spec, destination)
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def _fetch_verified_locked(downloader: Downloader, spec: ToolSpec, destination: Path) -> Path:
     if destination.is_file() and _sha256(destination) == spec.sha256.removeprefix("sha256:"):
         return destination
     if destination.exists():
-        destination.unlink()
+        destination.unlink(missing_ok=True)
 
     downloader.fetch(spec.url, destination=destination)
     actual = _sha256(destination)

--- a/tools/olf/olf/toolchain/errors.py
+++ b/tools/olf/olf/toolchain/errors.py
@@ -1,0 +1,27 @@
+"""Errors raised while resolving or installing a managed tool.
+
+These are internal to `olf.toolchain`; `olf.tooling.resolver` catches them
+and re-raises `olf.deployment.errors.ToolchainError` (a `DeploymentError`),
+matching how every other deployment failure surfaces to `olf doctor` and the
+CLI's `--phase`/lifecycle commands.
+"""
+
+from __future__ import annotations
+
+
+class ToolchainError(RuntimeError):
+    """Base class for `olf.toolchain` failures."""
+
+
+class ToolchainDownloadError(ToolchainError):
+    """Raised when a tool archive could not be downloaded."""
+
+
+class ToolchainVerificationError(ToolchainError):
+    """Raised when a downloaded artifact's digest does not match the catalog."""
+
+    def __init__(self, tool: str, *, expected: str, actual: str) -> None:
+        self.tool = tool
+        self.expected = expected
+        self.actual = actual
+        super().__init__(f"digest mismatch for {tool!r}: expected {expected}, got {actual}")

--- a/tools/olf/olf/toolchain/install.py
+++ b/tools/olf/olf/toolchain/install.py
@@ -17,18 +17,20 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from olf.toolchain.spec import ToolSpec
+from olf.toolchain.spec import ToolSpec, activated_filename
 
 
 def install(archive_path: Path, spec: ToolSpec, *, bin_dir: Path) -> Path:
     """Extract `archive_path` (already digest-verified) and activate `spec`'s
-    executable at `bin_dir/<name>`. Returns the activated path."""
+    executable at `bin_dir/<name>-<digest>` (see `activated_filename`) -
+    content-addressed, not a plain `<name>`, so two different pins can never
+    share one mutable path. Returns the activated path."""
     bin_dir.mkdir(parents=True, exist_ok=True)
     staging_dir = Path(tempfile.mkdtemp(dir=bin_dir, prefix=f".staging-{spec.name}-"))
     try:
         extracted = _extract(archive_path, spec, staging_dir=staging_dir)
         extracted.chmod(extracted.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        target = bin_dir / spec.name
+        target = bin_dir / activated_filename(spec.name, spec.sha256)
         os.replace(extracted, target)
         return target
     finally:

--- a/tools/olf/olf/toolchain/install.py
+++ b/tools/olf/olf/toolchain/install.py
@@ -1,0 +1,58 @@
+"""Extracting a verified archive into an active, executable managed tool.
+
+`install` never lets a partial or unverified artifact become the active
+binary: it stages into a process-unique directory, sets the executable bit,
+then `os.replace`s onto the final path — an atomic rename on the same
+filesystem, so a reader either sees the previous binary or the new one, never
+a half-written file.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+from olf.toolchain.spec import ToolSpec
+
+
+def install(archive_path: Path, spec: ToolSpec, *, bin_dir: Path) -> Path:
+    """Extract `archive_path` (already digest-verified) and activate `spec`'s
+    executable at `bin_dir/<name>`. Returns the activated path."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    staging_dir = Path(tempfile.mkdtemp(dir=bin_dir, prefix=f".staging-{spec.name}-"))
+    try:
+        extracted = _extract(archive_path, spec, staging_dir=staging_dir)
+        extracted.chmod(extracted.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        target = bin_dir / spec.name
+        os.replace(extracted, target)
+        return target
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+def _extract(archive_path: Path, spec: ToolSpec, *, staging_dir: Path) -> Path:
+    if spec.archive == "raw":
+        destination = staging_dir / spec.name
+        shutil.copyfile(archive_path, destination)
+        return destination
+
+    if spec.archive == "zip":
+        with zipfile.ZipFile(archive_path) as archive:
+            archive.extractall(staging_dir)  # noqa: S202 - archive_path is a digest-verified upstream release
+    elif spec.archive == "tar.gz":
+        with tarfile.open(archive_path, mode="r:gz") as archive:
+            archive.extractall(staging_dir, filter="data")  # noqa: S202 - see above
+    else:
+        raise ValueError(f"unsupported archive kind: {spec.archive!r}")
+
+    if spec.member is None:
+        raise ValueError(f"{spec.name}: archive kind {spec.archive!r} requires an explicit member path")
+    member_path = staging_dir / spec.member
+    if not member_path.is_file():
+        raise ValueError(f"{spec.name}: archive did not contain expected member {spec.member!r}")
+    return member_path

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -26,7 +26,7 @@ import yaml
 from olf.toolchain.download import Downloader, HttpDownloader, fetch_verified
 from olf.toolchain.install import install as install_archive
 from olf.toolchain.platform import Platform
-from olf.toolchain.spec import MANAGED_TOOLS, ToolchainCatalogError, ToolSpec, load_specs
+from olf.toolchain.spec import MANAGED_TOOLS, ToolchainCatalogError, ToolSpec, activated_filename, load_specs
 
 DEFAULT_CATALOG_PATH = "release/component-catalog.yaml"
 RECEIPT_FILENAME = "receipt.json"
@@ -154,10 +154,13 @@ class ToolchainManager:
 
     def installed(self, tool: str) -> InstalledTool | None:
         receipt = self._read_receipt().get(tool)
-        path = self.bin_dir / tool
-        if not receipt or not path.is_file():
+        if not receipt:
             return None
-        return InstalledTool(name=tool, version=receipt.get("version", ""), sha256=receipt.get("sha256", ""), path=path)
+        sha256 = receipt.get("sha256", "")
+        path = self.bin_dir / activated_filename(tool, sha256)
+        if not path.is_file():
+            return None
+        return InstalledTool(name=tool, version=receipt.get("version", ""), sha256=sha256, path=path)
 
     def _spec(self, tool: str) -> ToolSpec:
         if tool not in self.specs:

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -12,9 +12,11 @@ catalog's pinned version and digest.
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import json
 import os
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -103,6 +105,31 @@ class ToolchainManager:
     def receipt_path(self) -> Path:
         return self.version_dir / RECEIPT_FILENAME
 
+    @property
+    def _lock_path(self) -> Path:
+        return self.version_dir / f"{RECEIPT_FILENAME}.lock"
+
+    @contextlib.contextmanager
+    def _locked_receipt(self) -> Iterator[None]:
+        """Serialize receipt read-modify-write across concurrent `olf`
+        processes sharing this `OLF_HOME` (e.g. two local invocations, or a
+        future parallel CI matrix sharing a persistent toolchain cache).
+
+        Without this, two processes racing to provision the same
+        never-before-installed toolchain can each read an empty receipt,
+        install their own tool, and then clobber each other's write - the
+        loser's tool entry is silently discarded, forcing a wasteful
+        reprovision next run. `flock` is POSIX-only, matching this
+        project's darwin/linux-only `Platform` support.
+        """
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock_path.open("a+") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+
     def _read_receipt(self) -> dict[str, Any]:
         if not self.receipt_path.is_file():
             return {}
@@ -113,7 +140,10 @@ class ToolchainManager:
 
     def _write_receipt(self, receipt: Mapping[str, Any]) -> None:
         self.receipt_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = self.receipt_path.with_suffix(".json.tmp")
+        # A PID-scoped tmp name, not a shared `.json.tmp`, so two processes
+        # racing here can never unlink or rename over each other's staged
+        # write - only the locked read-modify-write above needs exclusivity.
+        tmp_path = self.receipt_path.with_name(f"{RECEIPT_FILENAME}.{os.getpid()}.tmp")
         tmp_path.write_text(json.dumps(dict(receipt), indent=2, sort_keys=True))
         os.replace(tmp_path, self.receipt_path)
 
@@ -139,9 +169,10 @@ class ToolchainManager:
         archive_path = fetch_verified(self.downloader, spec, cache_root=self.cache_root)
         activated = install_archive(archive_path, spec, bin_dir=self.bin_dir)
 
-        receipt = self._read_receipt()
-        receipt[tool] = {"version": spec.version, "sha256": spec.sha256}
-        self._write_receipt(receipt)
+        with self._locked_receipt():
+            receipt = self._read_receipt()
+            receipt[tool] = {"version": spec.version, "sha256": spec.sha256}
+            self._write_receipt(receipt)
         return activated
 
     def ensure_all(self) -> dict[str, Path]:

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -70,8 +70,15 @@ class ToolchainManager:
         platform: Platform | None = None,
         downloader: Downloader | None = None,
     ) -> ToolchainManager:
+        if not isinstance(catalog, dict):
+            raise ToolchainCatalogError(f"release catalog must be a mapping, got {type(catalog).__name__}")
+        distribution = catalog.get("distribution")
+        if distribution is not None and not isinstance(distribution, dict):
+            raise ToolchainCatalogError(
+                f"release catalog's distribution must be a mapping, got {type(distribution).__name__}"
+            )
         resolved_platform = platform or Platform.detect()
-        distribution_version = ((catalog.get("distribution") or {}).get("version")) or "unknown"
+        distribution_version = (distribution or {}).get("version") or "unknown"
         return cls(
             home=home or default_home(),
             distribution_version=str(distribution_version),
@@ -92,7 +99,10 @@ class ToolchainManager:
         path = Path(catalog_path)
         if not path.is_file():
             raise ToolchainCatalogError(f"release catalog not found at {path}")
-        catalog = yaml.safe_load(path.read_text())
+        try:
+            catalog = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            raise ToolchainCatalogError(f"release catalog at {path} is not valid YAML: {exc}") from exc
         return cls.from_catalog(catalog, home=home, platform=platform, downloader=downloader)
 
     @property

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -13,7 +13,6 @@ catalog's pinned version and digest.
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import json
 import os
 from collections.abc import Iterator, Mapping
@@ -127,6 +126,11 @@ class ToolchainManager:
         inconsistent. `flock` is POSIX-only, matching this project's
         darwin/linux-only `Platform` support.
         """
+        # Deferred: POSIX-only, and importing it eagerly at module load
+        # would fail on an unsupported platform (e.g. Windows) before
+        # Platform.detect() ever gets to raise its own actionable error.
+        import fcntl
+
         self._lock_path.parent.mkdir(parents=True, exist_ok=True)
         with self._lock_path.open("a+") as lock_file:
             fcntl.flock(lock_file, fcntl.LOCK_EX)

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -183,7 +183,16 @@ class ToolchainManager:
         if not isinstance(version, str) or not version or not is_valid_digest(sha256):
             return None
         path = self.bin_dir / activated_filename(tool, sha256)
-        if not path.is_file():
+        if not path.is_file() or not os.access(path, os.X_OK):
+            # A cheap, existence/permission-only check, not a full re-hash
+            # of the binary's content on every call - re-verifying the
+            # digest here would defeat the entire point of the receipt as a
+            # fast path (network/extraction-free resolution). It does
+            # catch the common corruption shapes: the file being deleted,
+            # or losing its executable bit (e.g. a partial backup restore
+            # of a damaged OLF_HOME). If the content itself is silently
+            # altered while staying executable, `resolve()` still won't
+            # notice - a receipt is a cache, not a signature.
             return None
         return InstalledTool(name=tool, version=version, sha256=sha256, path=path)
 

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -25,7 +25,14 @@ import yaml
 from olf.toolchain.download import Downloader, HttpDownloader, fetch_verified
 from olf.toolchain.install import install as install_archive
 from olf.toolchain.platform import Platform
-from olf.toolchain.spec import MANAGED_TOOLS, ToolchainCatalogError, ToolSpec, activated_filename, load_specs
+from olf.toolchain.spec import (
+    MANAGED_TOOLS,
+    ToolchainCatalogError,
+    ToolSpec,
+    activated_filename,
+    is_valid_digest,
+    load_specs,
+)
 
 DEFAULT_CATALOG_PATH = "release/component-catalog.yaml"
 RECEIPT_FILENAME = "receipt.json"
@@ -167,11 +174,18 @@ class ToolchainManager:
         receipt = self._read_receipt().get(tool)
         if not isinstance(receipt, dict):
             return None
-        sha256 = receipt.get("sha256", "")
+        version = receipt.get("version")
+        sha256 = receipt.get("sha256")
+        # A structurally valid dict can still carry a malformed field (e.g.
+        # `{"version": "1.8.5", "sha256": null}`) - validate both before
+        # deriving the activated path from `sha256`, or a corrupt-but-typed
+        # receipt crashes every resolve() instead of being reprovisioned.
+        if not isinstance(version, str) or not version or not is_valid_digest(sha256):
+            return None
         path = self.bin_dir / activated_filename(tool, sha256)
         if not path.is_file():
             return None
-        return InstalledTool(name=tool, version=receipt.get("version", ""), sha256=sha256, path=path)
+        return InstalledTool(name=tool, version=version, sha256=sha256, path=path)
 
     def _spec(self, tool: str) -> ToolSpec:
         if tool not in self.specs:

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -1,0 +1,180 @@
+"""`ToolchainManager`: the single object that turns a catalog + platform into
+activated, on-disk managed executables.
+
+Every managed tool lives under
+`<home>/toolchains/<distribution-version>/<platform>/bin/<tool>`, so
+multiple OpenLakeForge versions keep independent toolchains and nothing here
+ever needs to touch a previous or newer version's install. A JSON receipt
+next to `bin/` records exactly what was installed, so `resolve()` can skip
+network and extraction entirely once a tool is already active at the
+catalog's pinned version and digest.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from olf.toolchain.download import Downloader, HttpDownloader, fetch_verified
+from olf.toolchain.install import install as install_archive
+from olf.toolchain.platform import Platform
+from olf.toolchain.spec import MANAGED_TOOLS, ToolchainCatalogError, ToolSpec, load_specs
+
+DEFAULT_CATALOG_PATH = "release/component-catalog.yaml"
+RECEIPT_FILENAME = "receipt.json"
+
+
+def default_home() -> Path:
+    override = os.environ.get("OLF_HOME")
+    if override:
+        return Path(override).expanduser().resolve()
+    return Path.home() / ".openlakeforge"
+
+
+@dataclass(frozen=True)
+class InstalledTool:
+    name: str
+    version: str
+    sha256: str
+    path: Path
+
+
+@dataclass
+class ToolchainManager:
+    home: Path
+    distribution_version: str
+    platform: Platform
+    specs: Mapping[str, ToolSpec]
+    downloader: Downloader
+
+    @classmethod
+    def from_catalog(
+        cls,
+        catalog: Mapping[str, Any],
+        *,
+        home: Path | None = None,
+        platform: Platform | None = None,
+        downloader: Downloader | None = None,
+    ) -> ToolchainManager:
+        resolved_platform = platform or Platform.detect()
+        distribution_version = ((catalog.get("distribution") or {}).get("version")) or "unknown"
+        return cls(
+            home=home or default_home(),
+            distribution_version=str(distribution_version),
+            platform=resolved_platform,
+            specs=load_specs(catalog, platform=resolved_platform),
+            downloader=downloader or HttpDownloader(),
+        )
+
+    @classmethod
+    def from_catalog_path(
+        cls,
+        catalog_path: str | Path = DEFAULT_CATALOG_PATH,
+        *,
+        home: Path | None = None,
+        platform: Platform | None = None,
+        downloader: Downloader | None = None,
+    ) -> ToolchainManager:
+        path = Path(catalog_path)
+        if not path.is_file():
+            raise ToolchainCatalogError(f"release catalog not found at {path}")
+        catalog = yaml.safe_load(path.read_text())
+        return cls.from_catalog(catalog, home=home, platform=platform, downloader=downloader)
+
+    @property
+    def version_dir(self) -> Path:
+        return self.home / "toolchains" / self.distribution_version / self.platform.key
+
+    @property
+    def bin_dir(self) -> Path:
+        return self.version_dir / "bin"
+
+    @property
+    def cache_root(self) -> Path:
+        return self.home / "cache"
+
+    @property
+    def receipt_path(self) -> Path:
+        return self.version_dir / RECEIPT_FILENAME
+
+    def _read_receipt(self) -> dict[str, Any]:
+        if not self.receipt_path.is_file():
+            return {}
+        try:
+            return json.loads(self.receipt_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _write_receipt(self, receipt: Mapping[str, Any]) -> None:
+        self.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.receipt_path.with_suffix(".json.tmp")
+        tmp_path.write_text(json.dumps(dict(receipt), indent=2, sort_keys=True))
+        os.replace(tmp_path, self.receipt_path)
+
+    def installed(self, tool: str) -> InstalledTool | None:
+        receipt = self._read_receipt().get(tool)
+        path = self.bin_dir / tool
+        if not receipt or not path.is_file():
+            return None
+        return InstalledTool(name=tool, version=receipt.get("version", ""), sha256=receipt.get("sha256", ""), path=path)
+
+    def _spec(self, tool: str) -> ToolSpec:
+        if tool not in self.specs:
+            raise KeyError(f"{tool!r} is not a managed tool (expected one of {MANAGED_TOOLS})")
+        return self.specs[tool]
+
+    def resolve(self, tool: str) -> Path:
+        """Return the activated path for `tool`, provisioning it on first use."""
+        spec = self._spec(tool)
+        current = self.installed(tool)
+        if current is not None and current.version == spec.version and current.sha256 == spec.sha256:
+            return current.path
+
+        archive_path = fetch_verified(self.downloader, spec, cache_root=self.cache_root)
+        activated = install_archive(archive_path, spec, bin_dir=self.bin_dir)
+
+        receipt = self._read_receipt()
+        receipt[tool] = {"version": spec.version, "sha256": spec.sha256}
+        self._write_receipt(receipt)
+        return activated
+
+    def ensure_all(self) -> dict[str, Path]:
+        return {tool: self.resolve(tool) for tool in self.specs}
+
+    def prune(self, *, version: str | None = None, keep_current: bool = False, remove_all: bool = False) -> list[Path]:
+        """Remove installed toolchain versions under `home`, never anything
+        outside it. Exactly one of `version`, `keep_current`, `remove_all`
+        selects what to remove. Returns the version directories removed."""
+        import shutil
+
+        if sum(bool(x) for x in (version, keep_current, remove_all)) != 1:
+            raise ValueError("prune requires exactly one of version, keep_current, or remove_all")
+
+        toolchains_root = (self.home / "toolchains").resolve()
+        if not toolchains_root.is_dir():
+            return []
+
+        removed: list[Path] = []
+        for entry in sorted(toolchains_root.iterdir()):
+            if not entry.is_dir():
+                continue
+            resolved = entry.resolve()
+            if resolved.parent != toolchains_root:
+                continue  # never remove anything that escaped OLF_HOME/toolchains (e.g. a symlink)
+            if version is not None:
+                should_remove = entry.name == version
+            elif keep_current:
+                should_remove = entry.name != self.distribution_version
+            else:
+                should_remove = True
+            if not should_remove:
+                continue
+            shutil.rmtree(entry)
+            removed.append(entry)
+        return removed

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -110,17 +110,22 @@ class ToolchainManager:
         return self.version_dir / f"{RECEIPT_FILENAME}.lock"
 
     @contextlib.contextmanager
-    def _locked_receipt(self) -> Iterator[None]:
-        """Serialize receipt read-modify-write across concurrent `olf`
-        processes sharing this `OLF_HOME` (e.g. two local invocations, or a
-        future parallel CI matrix sharing a persistent toolchain cache).
+    def _locked_toolchain_update(self) -> Iterator[None]:
+        """Serialize an entire provision-and-record sequence across
+        concurrent `olf` processes sharing this `OLF_HOME` (e.g. two
+        checkouts with different catalog pins, or a future parallel CI
+        matrix sharing a persistent toolchain cache).
 
-        Without this, two processes racing to provision the same
-        never-before-installed toolchain can each read an empty receipt,
-        install their own tool, and then clobber each other's write - the
-        loser's tool entry is silently discarded, forcing a wasteful
-        reprovision next run. `flock` is POSIX-only, matching this
-        project's darwin/linux-only `Platform` support.
+        The lock must span the installed-state check, the download/install,
+        and the receipt write together - not just the receipt write. Two
+        processes wanting different versions of the same tool can otherwise
+        both pass the (unlocked) staleness check, race each other's
+        `os.replace` onto the same activated binary path, and then each
+        record their own version in the receipt: the loser's receipt entry
+        can win even though the winner's binary is what's actually active,
+        leaving the receipt and the on-disk binary permanently
+        inconsistent. `flock` is POSIX-only, matching this project's
+        darwin/linux-only `Platform` support.
         """
         self._lock_path.parent.mkdir(parents=True, exist_ok=True)
         with self._lock_path.open("a+") as lock_file:
@@ -162,18 +167,30 @@ class ToolchainManager:
     def resolve(self, tool: str) -> Path:
         """Return the activated path for `tool`, provisioning it on first use."""
         spec = self._spec(tool)
-        current = self.installed(tool)
-        if current is not None and current.version == spec.version and current.sha256 == spec.sha256:
-            return current.path
+        current = self._current_if_matching(tool, spec)
+        if current is not None:
+            return current
 
-        archive_path = fetch_verified(self.downloader, spec, cache_root=self.cache_root)
-        activated = install_archive(archive_path, spec, bin_dir=self.bin_dir)
+        with self._locked_toolchain_update():
+            # Re-check now that the lock is held: another process may have
+            # just finished installing this exact version while we waited.
+            current = self._current_if_matching(tool, spec)
+            if current is not None:
+                return current
 
-        with self._locked_receipt():
+            archive_path = fetch_verified(self.downloader, spec, cache_root=self.cache_root)
+            activated = install_archive(archive_path, spec, bin_dir=self.bin_dir)
+
             receipt = self._read_receipt()
             receipt[tool] = {"version": spec.version, "sha256": spec.sha256}
             self._write_receipt(receipt)
-        return activated
+            return activated
+
+    def _current_if_matching(self, tool: str, spec: ToolSpec) -> Path | None:
+        current = self.installed(tool)
+        if current is not None and current.version == spec.version and current.sha256 == spec.sha256:
+            return current.path
+        return None
 
     def ensure_all(self) -> dict[str, Path]:
         return {tool: self.resolve(tool) for tool in self.specs}

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -207,7 +207,13 @@ class ToolchainManager:
         if sum(bool(x) for x in (version, keep_current, remove_all)) != 1:
             raise ValueError("prune requires exactly one of version, keep_current, or remove_all")
 
+        home_resolved = self.home.resolve()
         toolchains_root = (self.home / "toolchains").resolve()
+        if toolchains_root.parent != home_resolved:
+            # `<home>/toolchains` itself resolved outside `home` (e.g. it is
+            # a symlink) - refuse to trust it as prune's root at all, rather
+            # than deleting whatever it points at.
+            return []
         if not toolchains_root.is_dir():
             return []
 

--- a/tools/olf/olf/toolchain/manager.py
+++ b/tools/olf/olf/toolchain/manager.py
@@ -140,12 +140,19 @@ class ToolchainManager:
                 fcntl.flock(lock_file, fcntl.LOCK_UN)
 
     def _read_receipt(self) -> dict[str, Any]:
+        """A malformed receipt (missing, unparsable JSON, or valid JSON in
+        the wrong shape - `null`, a list, a scalar) is treated the same as
+        an absent one: the receipt is a disposable cache of what's already
+        installed, not a source of truth, so `resolve()` should repair it
+        by reprovisioning rather than fail the whole command on it.
+        """
         if not self.receipt_path.is_file():
             return {}
         try:
-            return json.loads(self.receipt_path.read_text())
+            data = json.loads(self.receipt_path.read_text())
         except (json.JSONDecodeError, OSError):
             return {}
+        return data if isinstance(data, dict) else {}
 
     def _write_receipt(self, receipt: Mapping[str, Any]) -> None:
         self.receipt_path.parent.mkdir(parents=True, exist_ok=True)
@@ -158,7 +165,7 @@ class ToolchainManager:
 
     def installed(self, tool: str) -> InstalledTool | None:
         receipt = self._read_receipt().get(tool)
-        if not receipt:
+        if not isinstance(receipt, dict):
             return None
         sha256 = receipt.get("sha256", "")
         path = self.bin_dir / activated_filename(tool, sha256)

--- a/tools/olf/olf/toolchain/platform.py
+++ b/tools/olf/olf/toolchain/platform.py
@@ -1,0 +1,58 @@
+"""Host platform detection for the managed toolchain.
+
+Only the four platforms OpenLakeForge's release pipeline builds kind/CI
+images for are supported: darwin/linux x amd64/arm64.
+"""
+
+from __future__ import annotations
+
+import platform as _platform
+from dataclasses import dataclass
+
+
+class UnsupportedPlatformError(RuntimeError):
+    """Raised when the host OS/architecture has no managed toolchain build."""
+
+    def __init__(self, system: str, machine: str) -> None:
+        self.system = system
+        self.machine = machine
+        super().__init__(
+            f"no managed toolchain is published for {system}/{machine}; "
+            "set OLF_TOOLCHAIN_MODE=host and install Terraform/Helm/kubectl/kind yourself"
+        )
+
+
+_OS_NAMES = {"darwin": "darwin", "linux": "linux"}
+_ARCH_NAMES = {
+    "x86_64": "amd64",
+    "amd64": "amd64",
+    "aarch64": "arm64",
+    "arm64": "arm64",
+}
+
+
+@dataclass(frozen=True)
+class Platform:
+    """A managed-toolchain platform identity, e.g. `darwin-arm64`."""
+
+    os: str
+    arch: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.os}-{self.arch}"
+
+    def __str__(self) -> str:
+        return self.key
+
+    @classmethod
+    def detect(cls) -> Platform:
+        return cls.from_uname(system=_platform.system(), machine=_platform.machine())
+
+    @classmethod
+    def from_uname(cls, *, system: str, machine: str) -> Platform:
+        os_name = _OS_NAMES.get(system.lower())
+        arch_name = _ARCH_NAMES.get(machine.lower())
+        if os_name is None or arch_name is None:
+            raise UnsupportedPlatformError(system, machine)
+        return cls(os=os_name, arch=arch_name)

--- a/tools/olf/olf/toolchain/platform.py
+++ b/tools/olf/olf/toolchain/platform.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import platform as _platform
 from dataclasses import dataclass
 
+from olf.toolchain.errors import ToolchainError
 
-class UnsupportedPlatformError(RuntimeError):
+
+class UnsupportedPlatformError(ToolchainError):
     """Raised when the host OS/architecture has no managed toolchain build."""
 
     def __init__(self, system: str, machine: str) -> None:

--- a/tools/olf/olf/toolchain/spec.py
+++ b/tools/olf/olf/toolchain/spec.py
@@ -1,0 +1,116 @@
+"""Per-tool download specs: URL templates, archive layout, and catalog loading.
+
+Upstream URL layout is typed Python, not catalog data — only the pinned
+version and per-platform digest come from `release/component-catalog.yaml`
+(`components.toolchain`). That keeps the catalog's shape symmetric with its
+existing `components.images`/`components.actions` blocks: a version plus a
+digest, nothing else.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from olf.toolchain.platform import Platform
+
+ArchiveKind = Literal["zip", "tar.gz", "raw"]
+
+MANAGED_TOOLS: tuple[str, ...] = ("terraform", "helm", "kubectl", "kind")
+
+_SHA256_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ToolchainCatalogError(ValueError):
+    """Raised when `components.toolchain` in the catalog is missing or malformed."""
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Everything needed to fetch, verify, and activate one managed tool."""
+
+    name: str
+    version: str
+    platform: Platform
+    sha256: str
+    url: str
+    archive: ArchiveKind
+    member: str | None = None
+    """Path of the executable inside the archive; unused when `archive == "raw"`."""
+
+
+def _terraform_url(version: str, platform: Platform) -> str:
+    return (
+        f"https://releases.hashicorp.com/terraform/{version}/"
+        f"terraform_{version}_{platform.os}_{platform.arch}.zip"
+    )
+
+
+def _helm_url(version: str, platform: Platform) -> str:
+    return f"https://get.helm.sh/helm-v{version}-{platform.os}-{platform.arch}.tar.gz"
+
+
+def _kubectl_url(version: str, platform: Platform) -> str:
+    return f"https://dl.k8s.io/release/v{version}/bin/{platform.os}/{platform.arch}/kubectl"
+
+
+def _kind_url(version: str, platform: Platform) -> str:
+    return (
+        f"https://github.com/kubernetes-sigs/kind/releases/download/v{version}/"
+        f"kind-{platform.os}-{platform.arch}"
+    )
+
+
+_BUILDERS: dict[str, tuple[Any, ArchiveKind, str | None]] = {
+    "terraform": (_terraform_url, "zip", "terraform"),
+    "helm": (_helm_url, "tar.gz", "{os}-{arch}/helm"),
+    "kubectl": (_kubectl_url, "raw", None),
+    "kind": (_kind_url, "raw", None),
+}
+
+
+def _digest(value: object, *, tool: str, platform_key: str) -> str:
+    if not isinstance(value, str) or not _SHA256_PATTERN.match(value):
+        raise ToolchainCatalogError(
+            f"components.toolchain.{tool}.platforms.{platform_key} must be 'sha256:<64 hex chars>', got {value!r}"
+        )
+    return value
+
+
+def build_spec(tool: str, entry: Mapping[str, Any], *, platform: Platform) -> ToolSpec:
+    if tool not in _BUILDERS:
+        raise ToolchainCatalogError(f"unmanaged tool {tool!r}; expected one of {MANAGED_TOOLS}")
+    version = entry.get("version")
+    if not isinstance(version, str) or not version:
+        raise ToolchainCatalogError(f"components.toolchain.{tool}.version must be a non-empty string")
+    platforms = entry.get("platforms")
+    if not isinstance(platforms, Mapping):
+        raise ToolchainCatalogError(f"components.toolchain.{tool}.platforms must be a mapping")
+    if platform.key not in platforms:
+        raise ToolchainCatalogError(f"components.toolchain.{tool}.platforms is missing {platform.key!r}")
+    sha256 = _digest(platforms[platform.key], tool=tool, platform_key=platform.key)
+
+    url_builder, archive, member_template = _BUILDERS[tool]
+    member = member_template.format(os=platform.os, arch=platform.arch) if member_template else None
+    return ToolSpec(
+        name=tool,
+        version=version,
+        platform=platform,
+        sha256=sha256,
+        url=url_builder(version, platform),
+        archive=archive,
+        member=member,
+    )
+
+
+def load_specs(catalog: Mapping[str, Any], *, platform: Platform) -> dict[str, ToolSpec]:
+    """Build every managed `ToolSpec` declared in `catalog` for `platform`."""
+    toolchain = (catalog.get("components") or {}).get("toolchain")
+    if not isinstance(toolchain, Mapping):
+        raise ToolchainCatalogError("release catalog is missing components.toolchain")
+    missing = [tool for tool in MANAGED_TOOLS if tool not in toolchain]
+    if missing:
+        raise ToolchainCatalogError(f"components.toolchain is missing entries for {missing}")
+    return {tool: build_spec(tool, toolchain[tool], platform=platform) for tool in MANAGED_TOOLS}

--- a/tools/olf/olf/toolchain/spec.py
+++ b/tools/olf/olf/toolchain/spec.py
@@ -132,7 +132,10 @@ def activated_filename(name: str, sha256: str) -> str:
 
 def load_specs(catalog: Mapping[str, Any], *, platform: Platform) -> dict[str, ToolSpec]:
     """Build every managed `ToolSpec` declared in `catalog` for `platform`."""
-    toolchain = (catalog.get("components") or {}).get("toolchain")
+    components = catalog.get("components")
+    if components is not None and not isinstance(components, Mapping):
+        raise ToolchainCatalogError(f"release catalog's components must be a mapping, got {type(components).__name__}")
+    toolchain = (components or {}).get("toolchain")
     if not isinstance(toolchain, Mapping):
         raise ToolchainCatalogError("release catalog is missing components.toolchain")
     missing = [tool for tool in MANAGED_TOOLS if tool not in toolchain]

--- a/tools/olf/olf/toolchain/spec.py
+++ b/tools/olf/olf/toolchain/spec.py
@@ -72,12 +72,19 @@ _BUILDERS: dict[str, tuple[Any, ArchiveKind, str | None]] = {
 }
 
 
+def is_valid_digest(value: object) -> bool:
+    """Whether `value` is a well-formed `sha256:<64 hex chars>` digest
+    string - shared between catalog validation here and receipt validation
+    in `manager.py`, so both reject the same malformed shapes."""
+    return isinstance(value, str) and bool(_SHA256_PATTERN.match(value))
+
+
 def _digest(value: object, *, tool: str, platform_key: str) -> str:
-    if not isinstance(value, str) or not _SHA256_PATTERN.match(value):
+    if not is_valid_digest(value):
         raise ToolchainCatalogError(
             f"components.toolchain.{tool}.platforms.{platform_key} must be 'sha256:<64 hex chars>', got {value!r}"
         )
-    return value
+    return value  # type: ignore[return-value]
 
 
 def build_spec(tool: str, entry: Mapping[str, Any], *, platform: Platform) -> ToolSpec:

--- a/tools/olf/olf/toolchain/spec.py
+++ b/tools/olf/olf/toolchain/spec.py
@@ -106,6 +106,23 @@ def build_spec(tool: str, entry: Mapping[str, Any], *, platform: Platform) -> To
     )
 
 
+def activated_filename(name: str, sha256: str) -> str:
+    """The content-addressed filename an activated executable is stored
+    under: `<tool>-<digest>`, not just `<tool>`.
+
+    Two different pins of the same tool (e.g. two checkouts sharing
+    `OLF_HOME` at the same `distribution.version` but different catalog
+    pins) must never share one mutable path - a caller that resolved one
+    pin could otherwise have its already-returned path silently swapped
+    out by another process installing a different pin before the caller's
+    subprocess actually runs it. Naming by digest makes every activated
+    file immutable once written: the same digest always means the same
+    bytes, so reusing an existing file written by another process is
+    always safe.
+    """
+    return f"{name}-{sha256.removeprefix('sha256:')}"
+
+
 def load_specs(catalog: Mapping[str, Any], *, platform: Platform) -> dict[str, ToolSpec]:
     """Build every managed `ToolSpec` declared in `catalog` for `platform`."""
     toolchain = (catalog.get("components") or {}).get("toolchain")

--- a/tools/olf/olf/toolchain/spec.py
+++ b/tools/olf/olf/toolchain/spec.py
@@ -14,6 +14,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from olf.toolchain.errors import ToolchainError
 from olf.toolchain.platform import Platform
 
 ArchiveKind = Literal["zip", "tar.gz", "raw"]
@@ -23,7 +24,7 @@ MANAGED_TOOLS: tuple[str, ...] = ("terraform", "helm", "kubectl", "kind")
 _SHA256_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
-class ToolchainCatalogError(ValueError):
+class ToolchainCatalogError(ToolchainError):
     """Raised when `components.toolchain` in the catalog is missing or malformed."""
 
 

--- a/tools/olf/olf/tooling/resolver.py
+++ b/tools/olf/olf/tooling/resolver.py
@@ -1,18 +1,23 @@
 """Injectable executable resolution.
 
 Tool adapters must resolve executables through an `ExecutableResolver`
-rather than calling `shutil.which` directly, so a future managed-toolchain
-resolver (#127) can be substituted without touching any adapter.
+rather than calling `shutil.which` directly. `ManagedExecutableResolver`
+(#127) is the managed-toolchain resolver this docstring originally
+anticipated: managed tool names (`terraform`, `helm`, `kubectl`, `kind`) are
+provisioned from `release/component-catalog.yaml` under `OLF_HOME`; every
+other name (`docker`, `aws`, `az`, `uv`, `git`, ...) falls through to the
+host `PATH`, unchanged from before #127.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Protocol
 
-from olf.deployment.errors import ExecutableNotFoundError
+from olf.deployment.errors import ExecutableNotFoundError, ToolchainError
 
 
 class ExecutableResolver(Protocol):
@@ -40,3 +45,83 @@ class PathExecutableResolver:
         if found is None:
             raise ExecutableNotFoundError(tool, searched="PATH")
         return Path(found)
+
+
+class ManagedExecutableResolver:
+    """Resolves managed tools (#127) from a private, version-scoped
+    toolchain; delegates every other tool to a `PathExecutableResolver`.
+
+    Never falls back to an unmanaged host binary for a managed tool name —
+    a provisioning failure raises `ToolchainError` rather than silently
+    resolving whatever happens to be on `PATH`. `overrides` is checked
+    first for every tool name (managed or not), so an explicit override
+    always wins and never triggers real toolchain provisioning - the same
+    contract `PathExecutableResolver` gives its callers.
+    """
+
+    def __init__(
+        self,
+        manager: object,
+        *,
+        fallback: ExecutableResolver,
+        overrides: Mapping[str, Path] | None = None,
+    ) -> None:
+        self.manager = manager
+        self.fallback = fallback
+        self._overrides = dict(overrides or {})
+
+    def resolve(self, tool: str) -> Path:
+        override = self._overrides.get(tool)
+        if override is not None:
+            return Path(override)
+
+        from olf.toolchain.spec import MANAGED_TOOLS
+
+        if tool not in MANAGED_TOOLS:
+            return self.fallback.resolve(tool)
+        try:
+            return self.manager.resolve(tool)  # type: ignore[attr-defined]
+        except ExecutableNotFoundError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - every toolchain failure funnels through one typed error
+            raise ToolchainError(tool, reason=str(exc)) from exc
+
+
+def build_resolver(
+    overrides: Mapping[str, Path] | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> ExecutableResolver:
+    """Build the resolver `Toolkit.default()` uses.
+
+    `OLF_TOOLCHAIN_MODE` selects the strategy: `managed` (the default)
+    provisions Terraform/Helm/kubectl/kind from the release catalog;
+    `host` restores plain `PATH` resolution for every tool, matching
+    behaviour before #127. `overrides` always wins over either strategy -
+    every existing test that pins a tool path via `overrides` keeps working
+    unchanged.
+    """
+    env = environ if environ is not None else os.environ
+    fallback = PathExecutableResolver(overrides=overrides)
+    mode = env.get("OLF_TOOLCHAIN_MODE", "managed")
+    if mode == "host":
+        return fallback
+    if mode != "managed":
+        raise ValueError(f"unknown OLF_TOOLCHAIN_MODE: {mode!r} (expected 'managed' or 'host')")
+
+    from olf import config
+    from olf.toolchain.manager import ToolchainManager
+    from olf.toolchain.platform import UnsupportedPlatformError
+    from olf.toolchain.spec import ToolchainCatalogError
+
+    home = Path(env["OLF_HOME"]).expanduser().resolve() if env.get("OLF_HOME") else None
+    catalog_path = config.repo_root() / "release" / "component-catalog.yaml"
+    try:
+        manager = ToolchainManager.from_catalog_path(catalog_path, home=home)
+    except (UnsupportedPlatformError, ToolchainCatalogError) as exc:
+        # Either failure means every managed-tool resolve() would fail
+        # identically, so fail closed here rather than on first use, through
+        # the same typed error family every deployment command already
+        # catches.
+        raise ToolchainError("toolchain", reason=str(exc)) from exc
+    return ManagedExecutableResolver(manager, fallback=fallback, overrides=overrides)

--- a/tools/olf/olf/tooling/resolver.py
+++ b/tools/olf/olf/tooling/resolver.py
@@ -107,7 +107,13 @@ def build_resolver(
     if mode == "host":
         return fallback
     if mode != "managed":
-        raise ValueError(f"unknown OLF_TOOLCHAIN_MODE: {mode!r} (expected 'managed' or 'host')")
+        # A user configuration mistake, not a provisioning failure - but
+        # every olf lifecycle command's boundary only catches DeploymentError
+        # (ToolchainError's base), so this must raise that family too rather
+        # than a plain ValueError, or it escapes as a raw traceback.
+        raise ToolchainError(
+            "OLF_TOOLCHAIN_MODE", reason=f"unknown value {mode!r} (expected 'managed' or 'host')"
+        )
 
     from olf import config
     from olf.toolchain.manager import ToolchainManager

--- a/tools/olf/tests/conftest.py
+++ b/tools/olf/tests/conftest.py
@@ -9,9 +9,29 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from openlakeforge_domain import inventory_for
 
 from olf.e2e._shell import E2EConfig, Environment, Suite
+
+
+@pytest.fixture(autouse=True)
+def _isolate_toolchain(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Every test defaults to host-mode executable resolution with an
+    isolated `OLF_HOME`.
+
+    `olf.tooling.resolver.build_resolver()` provisions managed tools (#127)
+    over the network into `OLF_HOME` (`~/.openlakeforge` by default) unless
+    told otherwise. Without this guard, any test that exercises a real
+    (unmocked) `kubectl`/`terraform` execution path - directly or via
+    `olf.k8s`/`olf.e2e._shell` - would silently download real Terraform/
+    kubectl/helm/kind binaries onto the network and into the developer's
+    actual home directory. Tests that specifically exercise managed-mode
+    resolution (`tests/test_toolchain_*.py`) override both variables
+    themselves with an injected fake downloader.
+    """
+    monkeypatch.setenv("OLF_TOOLCHAIN_MODE", "host")
+    monkeypatch.setenv("OLF_HOME", str(tmp_path_factory.mktemp("olf-home")))
 
 E2E_REPO_ROOT = Path(__file__).resolve().parents[3]
 E2E_INVENTORY = inventory_for(E2E_REPO_ROOT)

--- a/tools/olf/tests/test_cli_contracts.py
+++ b/tools/olf/tests/test_cli_contracts.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from olf.cli import app
+
+runner = CliRunner()
+
+
+def test_contracts_env_surfaces_a_toolchain_failure_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`olf contracts env` calls load_provider_contracts() outside any
+    DeploymentError boundary of its own - a managed-toolchain provisioning
+    failure (#127) resolving terraform must still surface the same clean
+    CLI failure every other olf command produces, not a raw traceback."""
+    from olf import contracts as contracts_module
+    from olf.deployment.errors import ToolchainError
+
+    def _raise(terraform_dir: str):  # noqa: ANN202
+        raise ToolchainError("terraform", reason="digest mismatch")
+
+    monkeypatch.setattr(contracts_module, "load_provider_contracts", _raise)
+
+    result = runner.invoke(app, ["contracts", "env"])
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, ToolchainError)
+    assert "digest mismatch" in result.output

--- a/tools/olf/tests/test_cli_deployment.py
+++ b/tools/olf/tests/test_cli_deployment.py
@@ -183,3 +183,21 @@ def test_unknown_profile_is_rejected_before_building_an_engine(monkeypatch: pyte
     result = runner.invoke(app, ["deploy", "--profile", "bogus"])
 
     assert result.exit_code == 1
+
+
+def test_an_invalid_toolchain_mode_surfaces_as_a_clean_cli_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A misspelled OLF_TOOLCHAIN_MODE is a user configuration mistake, not
+    a provisioning failure - but Toolkit.default() (built inside every
+    lifecycle command's _build_engine) raises it while resolving the
+    executable strategy, well before any provider-specific setup runs. It
+    must surface the same clean way every other DeploymentError does, not
+    as a raw traceback."""
+    from olf.deployment.errors import ToolchainError
+
+    monkeypatch.setenv("OLF_TOOLCHAIN_MODE", "bogus")
+
+    result = runner.invoke(app, ["doctor", "--provider", "local"])
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, ToolchainError)
+    assert "OLF_TOOLCHAIN_MODE" in result.output

--- a/tools/olf/tests/test_cli_e2e.py
+++ b/tools/olf/tests/test_cli_e2e.py
@@ -128,3 +128,26 @@ def test_e2e_run_maps_e2e_error_to_exit_1(monkeypatch: pytest.MonkeyPatch, tmp_p
 
     assert result.exit_code == 1
     assert "cluster not reachable" in result.output
+
+
+def test_e2e_run_surfaces_a_toolchain_failure_from_contract_resolution_cleanly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A managed-toolchain provisioning failure (#127) raised while
+    resolving the provider-contract environment - before e2e.run() and its
+    own E2EError-only preflight are ever reached - must fail the same clean
+    way as an E2EError, not escape as a raw ToolchainError traceback."""
+    from olf import contracts as contracts_module
+    from olf.deployment.errors import ToolchainError
+
+    def _raise(terraform_dir):  # noqa: ANN001, ANN202
+        raise ToolchainError("terraform", reason="digest mismatch")
+
+    monkeypatch.setattr(contracts_module, "load_provider_contracts", _raise)
+    monkeypatch.setenv("OPENLAKEFORGE_REPO_ROOT", str(tmp_path))
+
+    result = runner.invoke(app, ["e2e", "run", "--env", "local"])
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, ToolchainError)
+    assert "digest mismatch" in result.output

--- a/tools/olf/tests/test_cli_toolchain.py
+++ b/tools/olf/tests/test_cli_toolchain.py
@@ -60,3 +60,49 @@ def test_platform_and_catalog_errors_are_toolchain_errors() -> None:
 
     assert isinstance(UnsupportedPlatformError("Windows", "x86_64"), ToolchainError)
     assert isinstance(ToolchainCatalogError("bad catalog"), ToolchainError)
+
+
+@pytest.mark.parametrize("command", [["toolchain", "install"], ["toolchain", "path", "terraform"]])
+@pytest.mark.parametrize(
+    "native_error",
+    [PermissionError("permission denied: /some/path"), OSError("no space left on device")],
+)
+def test_provisioning_failures_normalize_to_a_clean_cli_error(
+    monkeypatch: pytest.MonkeyPatch, command: list[str], native_error: Exception
+) -> None:
+    """`olf toolchain install`/`path` call `ToolchainManager` directly,
+    bypassing `ManagedExecutableResolver`'s catch-and-wrap - a native I/O or
+    archive-extraction failure the manager doesn't wrap itself (a
+    permission error, a full disk, a corrupt archive) must still surface as
+    the CLI's normal concise failure, not a raw traceback."""
+
+    class _FailingManager:
+        specs = {"terraform": object()}
+
+        def resolve(self, tool: str):  # noqa: ANN202
+            raise native_error
+
+        def ensure_all(self):  # noqa: ANN202
+            raise native_error
+
+    monkeypatch.setattr(toolchain, "_manager", lambda: _FailingManager())
+
+    result = runner.invoke(app, command)
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, type(native_error))
+    assert str(native_error) in result.output
+
+
+def test_clean_normalizes_a_prune_failure_to_a_clean_cli_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FailingManager:
+        def prune(self, **kwargs):  # noqa: ANN003, ANN202
+            raise OSError("no space left on device")
+
+    monkeypatch.setattr(toolchain, "_manager", lambda: _FailingManager())
+
+    result = runner.invoke(app, ["toolchain", "clean", "--all"])
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, OSError)
+    assert "no space left on device" in result.output

--- a/tools/olf/tests/test_cli_toolchain.py
+++ b/tools/olf/tests/test_cli_toolchain.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from olf.cli import app
+from olf.commands import toolchain
+from olf.toolchain.platform import UnsupportedPlatformError
+from olf.toolchain.spec import ToolchainCatalogError
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        UnsupportedPlatformError("Windows", "x86_64"),
+        ToolchainCatalogError("release catalog not found"),
+    ],
+)
+@pytest.mark.parametrize("command", [["toolchain", "list"], ["toolchain", "install"], ["toolchain", "path"]])
+def test_manager_construction_failures_surface_as_a_clean_cli_error(
+    monkeypatch: pytest.MonkeyPatch, error: Exception, command: list[str]
+) -> None:
+    """`_manager()` failing with either error - an unsupported host or a
+    missing/malformed catalog - must produce the same actionable exit
+    rather than an uncaught traceback, since both are ToolchainError (#127)
+    regardless of which internal module raised them."""
+
+    def _raise() -> None:
+        raise error
+
+    monkeypatch.setattr(toolchain, "_manager", _raise)
+
+    result = runner.invoke(app, command)
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, (UnsupportedPlatformError, ToolchainCatalogError))
+
+
+def test_clean_surfaces_manager_construction_failures_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`clean` must be able to report a construction failure cleanly even
+    though its own job is removing old cached toolchains - it shouldn't
+    need a working platform/catalog to at least report the error."""
+    def _raise() -> None:
+        raise UnsupportedPlatformError("Windows", "x86_64")
+
+    monkeypatch.setattr(toolchain, "_manager", _raise)
+
+    result = runner.invoke(app, ["toolchain", "clean", "--all"])
+
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, UnsupportedPlatformError)
+
+
+def test_platform_and_catalog_errors_are_toolchain_errors() -> None:
+    """The hierarchy fix itself: both error types the CLI must catch belong
+    to the same family `olf.commands.toolchain` actually catches."""
+    from olf.toolchain.errors import ToolchainError
+
+    assert isinstance(UnsupportedPlatformError("Windows", "x86_64"), ToolchainError)
+    assert isinstance(ToolchainCatalogError("bad catalog"), ToolchainError)

--- a/tools/olf/tests/test_contracts_toolchain.py
+++ b/tools/olf/tests/test_contracts_toolchain.py
@@ -1,0 +1,40 @@
+"""`load_provider_contracts`'s managed-toolchain resolution behaviour (#127).
+
+Split from `test_contracts.py`, which covers `build_contract_env`/
+`render_shell_exports` against fixture contracts and never touches
+executable resolution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from olf.contracts import load_provider_contracts
+from olf.deployment.errors import ExecutableNotFoundError, ToolchainError
+
+
+def test_missing_terraform_executable_is_treated_as_not_applied_yet(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Resolver:
+        def resolve(self, tool: str):  # noqa: ANN001, ANN202
+            raise ExecutableNotFoundError(tool, searched="PATH")
+
+    monkeypatch.setattr("olf.tooling.resolver.build_resolver", lambda: _Resolver())
+
+    assert load_provider_contracts("some/terraform/dir") is None
+
+
+def test_a_real_toolchain_failure_propagates_instead_of_being_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A digest mismatch, broken download, or malformed catalog is a real
+    operational failure, not an "unapplied" signal - a caller that treated
+    it as unapplied would silently fall back to defaults (e.g. enabling
+    governance/analytics for what should be a slim deployment) instead of
+    failing closed."""
+
+    class _Resolver:
+        def resolve(self, tool: str):  # noqa: ANN001, ANN202
+            raise ToolchainError(tool, reason="digest mismatch")
+
+    monkeypatch.setattr("olf.tooling.resolver.build_resolver", lambda: _Resolver())
+
+    with pytest.raises(ToolchainError):
+        load_provider_contracts("some/terraform/dir")

--- a/tools/olf/tests/test_deployment_engine.py
+++ b/tools/olf/tests/test_deployment_engine.py
@@ -133,7 +133,10 @@ def test_build_provider_returns_cloud_provider_for_aws_and_azure(tmp_path) -> No
 
 
 def test_toolkit_default_includes_aws_and_azure_adapters() -> None:
-    toolkit = Toolkit.default()
+    # aws/az are not managed tools (#127), so host mode is enough here and
+    # keeps this test independent of the managed-toolchain resolution path,
+    # which is covered by tests/test_toolchain_resolver.py.
+    toolkit = Toolkit.default(environ={"OLF_TOOLCHAIN_MODE": "host"})
 
     assert isinstance(toolkit.aws, AwsCli)
     assert isinstance(toolkit.azure, AzureCli)

--- a/tools/olf/tests/test_e2e_runner.py
+++ b/tools/olf/tests/test_e2e_runner.py
@@ -338,3 +338,23 @@ def test_run_retry_transient_kubectl_does_not_retry_query_errors(
     with pytest.raises(E2EError, match="TABLE_NOT_FOUND"):
         _shell._run_retry_transient_kubectl(["kubectl", "exec"], attempts=3)
     assert attempts == 1
+
+
+def test_check_commands_translates_a_toolchain_error_into_an_e2e_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A managed tool that fails to provision (bad digest, broken download,
+    unwritable cache) must surface as E2EError - the only exception type
+    `olf e2e run` catches - not escape as a raw ToolchainError traceback."""
+    from olf.deployment.errors import ToolchainError
+
+    class _FailingResolver:
+        def resolve(self, tool: str) -> Path:
+            if tool == "terraform":
+                raise ToolchainError(tool, reason="digest mismatch")
+            return Path(f"/usr/bin/{tool}")
+
+    monkeypatch.setattr("olf.tooling.resolver.build_resolver", lambda: _FailingResolver())
+
+    with pytest.raises(E2EError, match="digest mismatch"):
+        _runner.check_commands(e2e_cfg(tmp_path))

--- a/tools/olf/tests/test_e2e_runner.py
+++ b/tools/olf/tests/test_e2e_runner.py
@@ -283,6 +283,7 @@ def test_terraform_output_json_reads_location_list(monkeypatch: pytest.MonkeyPat
 
 def test_terraform_output_json_rejects_invalid_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(_shell, "_run", lambda *_args, **_kwargs: "not-json")
+    monkeypatch.setattr(_shell, "_terraform_executable", lambda: "terraform")
 
     with pytest.raises(E2EError, match="not valid JSON"):
         _shell.terraform_output_json(tmp_path / "contract", "dagster_code_location_names")

--- a/tools/olf/tests/test_e2e_runner.py
+++ b/tools/olf/tests/test_e2e_runner.py
@@ -131,6 +131,7 @@ def test_prepare_kube_context_refreshes_existing_aws_context(monkeypatch: pytest
     # both bindings need the same fake to capture every command.
     monkeypatch.setattr(_runner, "_run", run)
     monkeypatch.setattr(_shell, "_run", run)
+    monkeypatch.setattr(_runner, "_kubectl_executable", lambda: "kubectl")
     monkeypatch.setattr(
         _runner,
         "terraform_output",
@@ -186,6 +187,7 @@ def test_prepare_kube_context_uses_provider_default_for_direct_cloud_runs(
     run = lambda args, capture=False: commands.append(args) or ""  # noqa: E731
     monkeypatch.setattr(_runner, "_run", run)
     monkeypatch.setattr(_shell, "_run", run)
+    monkeypatch.setattr(_runner, "_kubectl_executable", lambda: "kubectl")
     monkeypatch.setattr(_runner, "terraform_output", lambda _dir, name: terraform_outputs[name])
 
     _runner.prepare_kube_context(e2e_cfg(tmp_path, env=env, suite="smoke"))
@@ -205,6 +207,7 @@ def test_prepare_kube_context_selects_existing_local_context(monkeypatch: pytest
         return ""
 
     monkeypatch.setattr(_runner, "_run", run)
+    monkeypatch.setattr(_runner, "_kubectl_executable", lambda: "kubectl")
 
     _runner.prepare_kube_context(e2e_cfg(tmp_path))
 
@@ -228,6 +231,7 @@ def test_prepare_kube_context_updates_aws_context_when_existing_context_is_unusa
     monkeypatch.setattr(_runner, "_run", run)
     monkeypatch.setattr(_shell, "_run", run)
     monkeypatch.setattr(_shell.time, "sleep", lambda _delay: None)
+    monkeypatch.setattr(_runner, "_kubectl_executable", lambda: "kubectl")
     monkeypatch.setattr(
         _runner,
         "terraform_output",
@@ -261,6 +265,7 @@ def test_terraform_output_json_reads_location_list(monkeypatch: pytest.MonkeyPat
         "_run",
         lambda args, *, capture=False: commands.append(args) or '["openlakeforge-dagster"]',
     )
+    monkeypatch.setattr(_shell, "_terraform_executable", lambda: "terraform")
 
     assert _shell.terraform_output_json(tmp_path / "contract", "dagster_code_location_names") == [
         "openlakeforge-dagster"

--- a/tools/olf/tests/test_k8s.py
+++ b/tools/olf/tests/test_k8s.py
@@ -66,6 +66,9 @@ def test_port_forward_uses_explicit_kube_context(monkeypatch: pytest.MonkeyPatch
     popen = Mock(return_value=process)
     monkeypatch.setattr(k8s.subprocess, "Popen", popen)
     monkeypatch.setattr(k8s, "_wait_for_port_forward", Mock())
+    # Executable resolution (#127) is covered by test_toolchain_resolver.py;
+    # here only the argv shape matters.
+    monkeypatch.setattr(k8s, "_kubectl_executable", lambda: "kubectl")
 
     with k8s.port_forward(
         "superset",
@@ -140,6 +143,7 @@ def test_port_forward_cleans_up_after_readiness_failure(monkeypatch: pytest.Monk
     process.poll.return_value = 0
     monkeypatch.setattr(k8s.subprocess, "Popen", Mock(return_value=process))
     monkeypatch.setattr(k8s, "_wait_for_port_forward", Mock(side_effect=k8s.KubectlError("not ready")))
+    monkeypatch.setattr(k8s, "_kubectl_executable", lambda: "kubectl")
 
     with pytest.raises(k8s.KubectlError, match="not ready"):
         with k8s.port_forward(

--- a/tools/olf/tests/test_local_foundation.py
+++ b/tools/olf/tests/test_local_foundation.py
@@ -73,8 +73,9 @@ class _ScriptedRunner(RecordingRunner):
 
 def test_foundation_apply_variables_exact_order_and_content(tmp_path: Path) -> None:
     config = _config(tmp_path)
+    tools = _toolkit_with_runner(RecordingRunner())
 
-    variables = foundation.foundation_apply_variables(config)
+    variables = foundation.foundation_apply_variables(config, tools)
 
     assert list(variables.keys()) == [
         "cluster_name",
@@ -82,17 +83,23 @@ def test_foundation_apply_variables_exact_order_and_content(tmp_path: Path) -> N
         "kubeconfig_path",
         "kind_wait_timeout",
         "reset_existing_cluster",
+        "kind_executable_path",
+        "kubectl_executable_path",
     ]
     assert variables["cluster_name"] == "openlakeforge-local"
     assert variables["reset_existing_cluster"] == "false"
+    assert variables["kind_executable_path"] == "kind"
+    assert variables["kubectl_executable_path"] == "kubectl"
 
 
-def test_foundation_destroy_variables_are_the_three_var_subset(tmp_path: Path) -> None:
+def test_foundation_destroy_variables_are_the_four_var_subset(tmp_path: Path) -> None:
     config = _config(tmp_path)
+    tools = _toolkit_with_runner(RecordingRunner())
 
-    variables = foundation.foundation_destroy_variables(config)
+    variables = foundation.foundation_destroy_variables(config, tools)
 
-    assert list(variables.keys()) == ["cluster_name", "cluster_config_path", "kubeconfig_path"]
+    assert list(variables.keys()) == ["cluster_name", "cluster_config_path", "kubeconfig_path", "kind_executable_path"]
+    assert variables["kind_executable_path"] == "kind"
 
 
 def test_foundation_up_applies_exports_kubeconfig_and_checks_reachability(tmp_path: Path) -> None:

--- a/tools/olf/tests/test_release_readiness.py
+++ b/tools/olf/tests/test_release_readiness.py
@@ -15,6 +15,73 @@ def test_check_images_digest_pinned_flags_missing_digest() -> None:
     assert "bad" in result.detail
 
 
+_VALID_TOOLCHAIN_ENTRY = {
+    "version": "1.2.3",
+    "platforms": {
+        "darwin-amd64": "sha256:" + "a" * 64,
+        "darwin-arm64": "sha256:" + "b" * 64,
+        "linux-amd64": "sha256:" + "c" * 64,
+        "linux-arm64": "sha256:" + "d" * 64,
+    },
+}
+
+
+def _valid_toolchain_catalog() -> dict:
+    return {
+        "components": {
+            "toolchain": {
+                tool: dict(_VALID_TOOLCHAIN_ENTRY) for tool in ("terraform", "helm", "kubectl", "kind")
+            }
+        }
+    }
+
+
+def test_check_toolchain_pinned_passes_on_real_repo_catalog() -> None:
+    catalog = load_catalog(ROOT / "release/component-catalog.yaml")
+    result = _readiness._check_toolchain_pinned(catalog)
+    assert result.ok, result.detail
+
+
+def test_check_toolchain_pinned_flags_missing_components_block() -> None:
+    result = _readiness._check_toolchain_pinned({"components": {}})
+    assert not result.ok
+    assert "missing" in result.detail
+
+
+def test_check_toolchain_pinned_flags_missing_tool() -> None:
+    catalog = _valid_toolchain_catalog()
+    del catalog["components"]["toolchain"]["kind"]
+    result = _readiness._check_toolchain_pinned(catalog)
+    assert not result.ok
+    assert "kind" in result.detail
+
+
+def test_check_toolchain_pinned_rejects_latest_version() -> None:
+    catalog = _valid_toolchain_catalog()
+    catalog["components"]["toolchain"]["terraform"]["version"] = "latest"
+    result = _readiness._check_toolchain_pinned(catalog)
+    assert not result.ok
+    assert "terraform" in result.detail
+
+
+def test_check_toolchain_pinned_flags_missing_platform() -> None:
+    catalog = _valid_toolchain_catalog()
+    del catalog["components"]["toolchain"]["helm"]["platforms"]["linux-arm64"]
+    result = _readiness._check_toolchain_pinned(catalog)
+    assert not result.ok
+    assert "helm" in result.detail
+    assert "linux-arm64" in result.detail
+
+
+def test_check_toolchain_pinned_flags_malformed_digest() -> None:
+    catalog = _valid_toolchain_catalog()
+    catalog["components"]["toolchain"]["kubectl"]["platforms"]["linux-amd64"] = "not-a-digest"
+    result = _readiness._check_toolchain_pinned(catalog)
+    assert not result.ok
+    assert "kubectl" in result.detail
+    assert "linux-amd64" in result.detail
+
+
 def test_check_images_match_deployment_sources_passes_on_real_repo_catalog() -> None:
     catalog = load_catalog(ROOT / "release/component-catalog.yaml")
     result = _readiness._check_images_match_deployment_sources(ROOT, catalog)

--- a/tools/olf/tests/test_release_readiness.py
+++ b/tools/olf/tests/test_release_readiness.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import yaml
 
 from olf.release import _readiness
@@ -54,6 +55,18 @@ def test_check_toolchain_pinned_flags_missing_tool() -> None:
     result = _readiness._check_toolchain_pinned(catalog)
     assert not result.ok
     assert "kind" in result.detail
+
+
+@pytest.mark.parametrize("malformed", [None, "1.0.0", 42, ["not", "a", "mapping"]])
+def test_check_toolchain_pinned_flags_a_non_mapping_entry(malformed: object) -> None:
+    """A present-but-malformed entry (e.g. `terraform: null`) must be
+    flagged, not silently skipped - `build_spec()` would otherwise crash on
+    `entry.get()` at runtime for a catalog this check already approved."""
+    catalog = _valid_toolchain_catalog()
+    catalog["components"]["toolchain"]["terraform"] = malformed
+    result = _readiness._check_toolchain_pinned(catalog)
+    assert not result.ok
+    assert "terraform" in result.detail
 
 
 def test_check_toolchain_pinned_rejects_latest_version() -> None:

--- a/tools/olf/tests/test_smoke.py
+++ b/tools/olf/tests/test_smoke.py
@@ -17,7 +17,14 @@ def test_run_uses_deployment_engine_and_e2e_without_make(monkeypatch: pytest.Mon
 
     smoke.run(
         timeout_seconds=2700,
-        environ={"CLUSTER_NAME": "openlakeforge-pr-123", "LOCAL_KUBECONFIG_PATH": str(tmp_path / "ci.yaml")},
+        environ={
+            "CLUSTER_NAME": "openlakeforge-pr-123",
+            "LOCAL_KUBECONFIG_PATH": str(tmp_path / "ci.yaml"),
+            # tmp_path has no release/component-catalog.yaml; managed
+            # toolchain resolution is exercised separately in
+            # tests/test_toolchain_resolver.py.
+            "OLF_TOOLCHAIN_MODE": "host",
+        },
         monotonic=iter((0.0, 1.0, 2.0, 3.0)).__next__,
     )
 
@@ -37,7 +44,7 @@ def test_run_honors_namespace_from_the_supplied_environment(monkeypatch: pytest.
 
     smoke.run(
         timeout_seconds=2700,
-        environ={"OPENLAKEFORGE_KUBE_NAMESPACE": "custom-lakehouse"},
+        environ={"OPENLAKEFORGE_KUBE_NAMESPACE": "custom-lakehouse", "OLF_TOOLCHAIN_MODE": "host"},
         monotonic=iter((0.0, 1.0, 2.0, 3.0)).__next__,
     )
 

--- a/tools/olf/tests/test_superset.py
+++ b/tools/olf/tests/test_superset.py
@@ -3,7 +3,7 @@ from zipfile import ZipFile
 
 import pytest
 
-from olf import superset
+from olf import k8s, superset
 
 
 def test_bundle_identity_from_source_dir() -> None:
@@ -61,3 +61,28 @@ def test_unpack_export_bundle_replaces_managed_assets(tmp_path: Path) -> None:
     assert (target / "metadata.yaml").read_text() == "type: assets\n"
     assert (target / "dashboards" / "d.yaml").exists()
     assert not (target / "dashboards" / "stale.yaml").exists()
+
+
+def test_exec_pod_python_resolves_kubectl_through_the_managed_toolchain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_exec_pod_python` (and the other kubectl exec/copy call sites in
+    this module) must resolve the executable the same way `k8s._kubectl`
+    does - a bare `["kubectl", ...]` argv would fail on a clean machine
+    with no host kubectl, even though the managed toolchain provisioned
+    one (#127)."""
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ANN001, ANN202
+        calls.append(argv)
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr(superset.subprocess, "run", fake_run)
+    monkeypatch.setattr(k8s, "_kubectl_executable", lambda: "/managed/bin/kubectl")
+    monkeypatch.setenv("KUBE_CONTEXT", "kind-openlakeforge-local")
+
+    superset._exec_pod_python("superset-pod", "lakehouse", "print('hi')", [])
+
+    assert calls[0][0] == "/managed/bin/kubectl"

--- a/tools/olf/tests/test_toolchain_download.py
+++ b/tools/olf/tests/test_toolchain_download.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from olf.toolchain.download import cache_path, fetch_verified
+from olf.toolchain.errors import ToolchainVerificationError
+from olf.toolchain.platform import Platform
+from olf.toolchain.spec import ToolSpec
+
+_CONTENT = b"fake-tool-binary-content"
+_DIGEST = hashlib.sha256(_CONTENT).hexdigest()
+
+
+def _spec(sha256: str = f"sha256:{_DIGEST}") -> ToolSpec:
+    return ToolSpec(
+        name="kind",
+        version="1.0.0",
+        platform=Platform(os="linux", arch="amd64"),
+        sha256=sha256,
+        url="https://example.invalid/kind",
+        archive="raw",
+    )
+
+
+class _FakeDownloader:
+    def __init__(self, content: bytes = _CONTENT) -> None:
+        self.content = content
+        self.calls: list[str] = []
+
+    def fetch(self, url: str, *, destination: Path) -> None:
+        self.calls.append(url)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(self.content)
+
+
+class _FailingDownloader:
+    def fetch(self, url: str, *, destination: Path) -> None:
+        raise RuntimeError("network is unreachable")
+
+
+def test_fetch_verified_downloads_and_verifies(tmp_path: Path) -> None:
+    downloader = _FakeDownloader()
+    spec = _spec()
+
+    result = fetch_verified(downloader, spec, cache_root=tmp_path)
+
+    assert downloader.calls == [spec.url]
+    assert result == cache_path(tmp_path, spec)
+    assert result.read_bytes() == _CONTENT
+
+
+def test_fetch_verified_reuses_a_valid_cache_entry_without_downloading(tmp_path: Path) -> None:
+    downloader = _FakeDownloader()
+    spec = _spec()
+    fetch_verified(downloader, spec, cache_root=tmp_path)
+
+    fetch_verified(downloader, spec, cache_root=tmp_path)
+
+    assert downloader.calls == [spec.url]  # only the first call touched the network
+
+
+def test_fetch_verified_rejects_a_digest_mismatch_and_leaves_no_file(tmp_path: Path) -> None:
+    downloader = _FakeDownloader(content=b"wrong content entirely")
+    spec = _spec()
+
+    with pytest.raises(ToolchainVerificationError):
+        fetch_verified(downloader, spec, cache_root=tmp_path)
+
+    assert not cache_path(tmp_path, spec).exists()
+
+
+def test_fetch_verified_redownloads_a_stale_cache_entry(tmp_path: Path) -> None:
+    spec = _spec()
+    destination = cache_path(tmp_path, spec)
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"corrupted leftover from a prior run")
+    downloader = _FakeDownloader()
+
+    result = fetch_verified(downloader, spec, cache_root=tmp_path)
+
+    assert downloader.calls == [spec.url]
+    assert result.read_bytes() == _CONTENT
+
+
+def test_fetch_verified_propagates_download_failures(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="unreachable"):
+        fetch_verified(_FailingDownloader(), _spec(), cache_root=tmp_path)

--- a/tools/olf/tests/test_toolchain_download.py
+++ b/tools/olf/tests/test_toolchain_download.py
@@ -88,3 +88,64 @@ def test_fetch_verified_redownloads_a_stale_cache_entry(tmp_path: Path) -> None:
 def test_fetch_verified_propagates_download_failures(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="unreachable"):
         fetch_verified(_FailingDownloader(), _spec(), cache_root=tmp_path)
+
+
+def test_fetch_verified_serializes_concurrent_stale_cache_replacement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Two managers sharing a digest (e.g. two distribution versions pinning
+    the same tool version) that both find a corrupted cache entry at the
+    same time must not race each other's unlink - the loser must not crash
+    with FileNotFoundError, and the cache must end up correctly repaired.
+
+    A real `Path.unlink()` is fast enough that plain GIL scheduling rarely
+    reproduces the race deterministically, so a small sleep is injected
+    around every unlink of the contested `destination` path to widen the
+    window - real time, not an artificial synchronization point, so a
+    correctly-locked implementation (whose second caller never even reaches
+    its own unlink because the earlier one already repaired the cache
+    under the lock) is unaffected rather than deadlocking on a barrier that
+    only one side reaches.
+    """
+    import threading
+    import time
+
+    spec = _spec()
+    destination = cache_path(tmp_path, spec)
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"corrupted leftover from a prior run")
+
+    real_unlink = Path.unlink
+
+    def _slow_unlink(self: Path, *args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        if self == destination:
+            time.sleep(0.05)
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _slow_unlink)
+
+    start_barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+    results: list[Path] = []
+    results_lock = threading.Lock()
+
+    def _fetch() -> None:
+        start_barrier.wait(timeout=5)
+        try:
+            result = fetch_verified(_FakeDownloader(), spec, cache_root=tmp_path)
+        except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+            errors.append(exc)
+        else:
+            with results_lock:
+                results.append(result)
+
+    threads = [threading.Thread(target=_fetch) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors, errors
+    assert len(results) == 2
+    assert results[0] == results[1] == destination
+    assert destination.read_bytes() == _CONTENT

--- a/tools/olf/tests/test_toolchain_install.py
+++ b/tools/olf/tests/test_toolchain_install.py
@@ -9,7 +9,7 @@ import pytest
 
 from olf.toolchain.install import install
 from olf.toolchain.platform import Platform
-from olf.toolchain.spec import ToolSpec
+from olf.toolchain.spec import ToolSpec, activated_filename
 
 _PLATFORM = Platform(os="linux", arch="amd64")
 
@@ -35,7 +35,7 @@ def test_install_activates_a_raw_binary(tmp_path: Path) -> None:
 
     activated = install(archive, spec, bin_dir=tmp_path / "bin")
 
-    assert activated == tmp_path / "bin" / "kind"
+    assert activated == tmp_path / "bin" / activated_filename("kind", spec.sha256)
     assert activated.read_bytes() == b"#!/bin/sh\necho hi\n"
     assert activated.stat().st_mode & stat.S_IXUSR
 
@@ -49,7 +49,7 @@ def test_install_extracts_a_zip_member(tmp_path: Path) -> None:
 
     activated = install(archive, spec, bin_dir=tmp_path / "bin")
 
-    assert activated == tmp_path / "bin" / "terraform"
+    assert activated == tmp_path / "bin" / activated_filename("terraform", spec.sha256)
     assert activated.read_bytes() == b"pretend terraform binary"
 
 
@@ -82,11 +82,12 @@ def test_install_leaves_no_staging_directory_behind_on_success(tmp_path: Path) -
     archive = tmp_path / "downloaded"
     archive.write_bytes(b"binary")
     bin_dir = tmp_path / "bin"
+    spec = _spec(name="kind")
 
-    install(archive, _spec(name="kind"), bin_dir=bin_dir)
+    install(archive, spec, bin_dir=bin_dir)
 
     remaining = list(bin_dir.iterdir())
-    assert remaining == [bin_dir / "kind"]
+    assert remaining == [bin_dir / activated_filename("kind", spec.sha256)]
 
 
 def test_install_leaves_no_staging_directory_or_active_binary_on_failure(tmp_path: Path) -> None:
@@ -103,13 +104,34 @@ def test_install_leaves_no_staging_directory_or_active_binary_on_failure(tmp_pat
     assert list(bin_dir.iterdir()) == []
 
 
-def test_install_replaces_a_previously_activated_binary(tmp_path: Path) -> None:
+def test_install_never_touches_a_different_digest_of_the_same_tool(tmp_path: Path) -> None:
+    """Two different pins of the same tool must activate at two distinct,
+    immutable paths - never share one mutable `<tool>` path a later install
+    could swap out from under an in-flight resolution of the other pin."""
     bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    (bin_dir / "kind").write_bytes(b"old version")
+    old_spec = _spec(name="kind", sha256="sha256:" + "a" * 64)
+    old_archive = tmp_path / "old"
+    old_archive.write_bytes(b"old version")
+    old_activated = install(old_archive, old_spec, bin_dir=bin_dir)
 
+    new_spec = _spec(name="kind", sha256="sha256:" + "b" * 64)
+    new_archive = tmp_path / "new"
+    new_archive.write_bytes(b"new version")
+    new_activated = install(new_archive, new_spec, bin_dir=bin_dir)
+
+    assert old_activated != new_activated
+    assert old_activated.read_bytes() == b"old version"
+    assert new_activated.read_bytes() == b"new version"
+
+
+def test_install_of_the_same_digest_twice_is_idempotent(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    spec = _spec(name="kind")
     archive = tmp_path / "downloaded"
-    archive.write_bytes(b"new version")
-    install(archive, _spec(name="kind"), bin_dir=bin_dir)
+    archive.write_bytes(b"same content")
 
-    assert (bin_dir / "kind").read_bytes() == b"new version"
+    first = install(archive, spec, bin_dir=bin_dir)
+    second = install(archive, spec, bin_dir=bin_dir)
+
+    assert first == second
+    assert second.read_bytes() == b"same content"

--- a/tools/olf/tests/test_toolchain_install.py
+++ b/tools/olf/tests/test_toolchain_install.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import stat
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from olf.toolchain.install import install
+from olf.toolchain.platform import Platform
+from olf.toolchain.spec import ToolSpec
+
+_PLATFORM = Platform(os="linux", arch="amd64")
+
+
+def _spec(**overrides: object) -> ToolSpec:
+    defaults = dict(
+        name="tool",
+        version="1.0.0",
+        platform=_PLATFORM,
+        sha256="sha256:" + "a" * 64,
+        url="https://example.invalid/tool",
+        archive="raw",
+        member=None,
+    )
+    defaults.update(overrides)
+    return ToolSpec(**defaults)  # type: ignore[arg-type]
+
+
+def test_install_activates_a_raw_binary(tmp_path: Path) -> None:
+    archive = tmp_path / "downloaded"
+    archive.write_bytes(b"#!/bin/sh\necho hi\n")
+    spec = _spec(name="kind", archive="raw")
+
+    activated = install(archive, spec, bin_dir=tmp_path / "bin")
+
+    assert activated == tmp_path / "bin" / "kind"
+    assert activated.read_bytes() == b"#!/bin/sh\necho hi\n"
+    assert activated.stat().st_mode & stat.S_IXUSR
+
+
+def test_install_extracts_a_zip_member(tmp_path: Path) -> None:
+    archive = tmp_path / "downloaded.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("terraform", b"pretend terraform binary")
+        zf.writestr("LICENSE.txt", b"license text")
+    spec = _spec(name="terraform", archive="zip", member="terraform")
+
+    activated = install(archive, spec, bin_dir=tmp_path / "bin")
+
+    assert activated == tmp_path / "bin" / "terraform"
+    assert activated.read_bytes() == b"pretend terraform binary"
+
+
+def test_install_extracts_a_nested_targz_member(tmp_path: Path) -> None:
+    archive = tmp_path / "downloaded.tar.gz"
+    inner_dir = tmp_path / "helm-src"
+    inner_dir.mkdir()
+    (inner_dir / "helm").write_bytes(b"pretend helm binary")
+    (inner_dir / "README.md").write_text("readme")
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(inner_dir, arcname="linux-amd64")
+    spec = _spec(name="helm", archive="tar.gz", member="linux-amd64/helm")
+
+    activated = install(archive, spec, bin_dir=tmp_path / "bin")
+
+    assert activated.read_bytes() == b"pretend helm binary"
+
+
+def test_install_raises_when_the_expected_member_is_absent(tmp_path: Path) -> None:
+    archive = tmp_path / "downloaded.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("unexpected-name", b"data")
+    spec = _spec(name="terraform", archive="zip", member="terraform")
+
+    with pytest.raises(ValueError, match="did not contain"):
+        install(archive, spec, bin_dir=tmp_path / "bin")
+
+
+def test_install_leaves_no_staging_directory_behind_on_success(tmp_path: Path) -> None:
+    archive = tmp_path / "downloaded"
+    archive.write_bytes(b"binary")
+    bin_dir = tmp_path / "bin"
+
+    install(archive, _spec(name="kind"), bin_dir=bin_dir)
+
+    remaining = list(bin_dir.iterdir())
+    assert remaining == [bin_dir / "kind"]
+
+
+def test_install_leaves_no_staging_directory_or_active_binary_on_failure(tmp_path: Path) -> None:
+    archive = tmp_path / "downloaded.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("unexpected-name", b"data")
+    bin_dir = tmp_path / "bin"
+    spec = _spec(name="terraform", archive="zip", member="terraform")
+
+    with pytest.raises(ValueError):
+        install(archive, spec, bin_dir=bin_dir)
+
+    assert not (bin_dir / "terraform").exists()
+    assert list(bin_dir.iterdir()) == []
+
+
+def test_install_replaces_a_previously_activated_binary(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "kind").write_bytes(b"old version")
+
+    archive = tmp_path / "downloaded"
+    archive.write_bytes(b"new version")
+    install(archive, _spec(name="kind"), bin_dir=bin_dir)
+
+    assert (bin_dir / "kind").read_bytes() == b"new version"

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -280,3 +280,87 @@ def test_concurrent_resolves_of_different_tools_do_not_clobber_each_others_recei
     assert not errors, errors
     receipt = json.loads(manager.receipt_path.read_text())
     assert set(receipt) == {"terraform", "helm"}
+
+
+class _TimingDownloader:
+    """Wraps a real fake downloader but records the wall-clock interval
+    each `fetch()` call spans, in a shared list guarded by a lock. A short
+    sleep widens the window so two racing threads are very likely to
+    overlap unless something outside `fetch()` itself already serializes
+    them - i.e. this observes whether the *caller's* critical section
+    (installed-state check through receipt write) is exclusive, not just
+    whether `fetch()` calls happen to interleave.
+    """
+
+    def __init__(self, inner: _FakeDownloader, intervals: list, lock) -> None:  # noqa: ANN001
+        self._inner = inner
+        self._intervals = intervals
+        self._lock = lock
+        self.calls = inner.calls
+
+    def fetch(self, url: str, *, destination: Path) -> None:
+        import time
+
+        start = time.monotonic()
+        time.sleep(0.05)
+        self._inner.fetch(url, destination=destination)
+        end = time.monotonic()
+        with self._lock:
+            self._intervals.append((start, end))
+
+
+def _intervals_overlap(intervals: list[tuple[float, float]]) -> bool:
+    ordered = sorted(intervals)
+    return any(a_end > b_start for (_, a_end), (b_start, _) in zip(ordered, ordered[1:], strict=False))
+
+
+def test_concurrent_resolves_of_different_versions_never_leave_a_binary_receipt_mismatch(tmp_path: Path) -> None:
+    """Two `olf` processes pinning different versions of the same tool
+    (e.g. two checkouts sharing OLF_HOME) must never end up with a receipt
+    that claims one version while the activated binary is actually the
+    other - each racing writer must see the other's outcome atomically,
+    which requires their entire provision-and-record sequences to never
+    overlap in wall-clock time.
+    """
+    import threading
+
+    home = tmp_path / "home"
+    catalog_a, _ = _catalog_and_digests(version="1.0.0")
+    catalog_b, _ = _catalog_and_digests(version="2.0.0")
+    manager_a, downloader_a = _manager(tmp_path, catalog=catalog_a, home=home)
+    manager_b, downloader_b = _manager(tmp_path, catalog=catalog_b, home=home)
+
+    intervals: list[tuple[float, float]] = []
+    intervals_lock = threading.Lock()
+    manager_a.downloader = _TimingDownloader(downloader_a, intervals, intervals_lock)
+    manager_b.downloader = _TimingDownloader(downloader_b, intervals, intervals_lock)
+
+    errors: list[BaseException] = []
+    start_barrier = threading.Barrier(2)
+
+    def _resolve(manager: ToolchainManager) -> None:
+        start_barrier.wait(timeout=5)
+        try:
+            manager.resolve("kubectl")
+        except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_resolve, args=(m,)) for m in (manager_a, manager_b)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors, errors
+    assert len(intervals) == 2  # both threads actually downloaded, so overlap would have been possible
+    assert not _intervals_overlap(intervals), (
+        "the two provisioning sequences overlapped - the lock did not serialize them"
+    )
+
+    receipt = json.loads(manager_a.receipt_path.read_text())
+    recorded_version = receipt["kubectl"]["version"]
+    activated_bytes = (manager_a.bin_dir / "kubectl").read_bytes()
+    expected_bytes = f"pretend kubectl binary v{recorded_version}".encode()
+    assert activated_bytes == expected_bytes, (
+        f"receipt says {recorded_version!r} but the activated binary does not match it"
+    )

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -512,3 +512,28 @@ def test_resolve_reinstalls_from_the_verified_cache_when_the_executable_bit_is_l
     assert second_path == first_path
     assert os.access(second_path, os.X_OK)
     assert len(downloader.calls) == 1  # reused the cached archive, no re-download
+
+
+def test_from_catalog_path_raises_a_typed_error_for_invalid_yaml(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "component-catalog.yaml"
+    catalog_path.write_text("distribution: [unterminated\n  - broken")
+
+    with pytest.raises(ToolchainCatalogError):
+        ToolchainManager.from_catalog_path(catalog_path, home=tmp_path / "home", platform=_PLATFORM)
+
+
+@pytest.mark.parametrize("malformed_root", [["a", "list"], "a scalar string", 42, None])
+def test_from_catalog_raises_a_typed_error_for_a_non_mapping_root(malformed_root: object, tmp_path: Path) -> None:
+    with pytest.raises(ToolchainCatalogError):
+        ToolchainManager.from_catalog(malformed_root, home=tmp_path / "home", platform=_PLATFORM)
+
+
+@pytest.mark.parametrize("malformed_distribution", [["a", "list"], "a scalar string", 42])
+def test_from_catalog_raises_a_typed_error_for_a_non_mapping_distribution(
+    malformed_distribution: object, tmp_path: Path
+) -> None:
+    catalog, _ = _catalog_and_digests()
+    catalog["distribution"] = malformed_distribution
+
+    with pytest.raises(ToolchainCatalogError):
+        ToolchainManager.from_catalog(catalog, home=tmp_path / "home", platform=_PLATFORM)

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from olf.toolchain.manager import ToolchainManager
+from olf.toolchain.platform import Platform
+from olf.toolchain.spec import ToolchainCatalogError, load_specs
+
+_PLATFORM = Platform(os="linux", arch="amd64")
+_TOOLS = ("terraform", "helm", "kubectl", "kind")
+
+
+def _archive_bytes(tool: str, spec) -> bytes:  # noqa: ANN001
+    """Build a real zip/tar.gz/raw payload matching `spec`'s own archive
+    layout, so the fake downloader exercises the same extraction code path
+    a real download would.
+    """
+    # Version is embedded in the payload, matching a real release: a
+    # version bump always changes the binary's bytes/digest too, so a fake
+    # digest collision across versions (which would mask a version-bump
+    # re-provisioning bug behind cache reuse) can't happen here.
+    payload = f"pretend {tool} binary v{spec.version}".encode()
+    if spec.archive == "raw":
+        return payload
+    if spec.archive == "zip":
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as zf:
+            zf.writestr(spec.member, payload)
+        return buffer.getvalue()
+    if spec.archive == "tar.gz":
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w:gz") as tf:
+            info = tarfile.TarInfo(name=spec.member)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+        return buffer.getvalue()
+    raise AssertionError(spec.archive)
+
+
+def _catalog_and_digests(version: str = "1.0.0") -> tuple[dict, dict[str, str]]:
+    """A catalog with placeholder digests, plus the real digests for the
+    fake archives that will actually be served - computed by round-tripping
+    through the real `load_specs` so archive kind/member always matches
+    what `ToolchainManager` will really request.
+    """
+    placeholder = "sha256:" + "0" * 64
+    draft_catalog = {
+        "components": {
+            "toolchain": {tool: {"version": version, "platforms": {_PLATFORM.key: placeholder}} for tool in _TOOLS}
+        }
+    }
+    specs = load_specs(draft_catalog, platform=_PLATFORM)
+    digests = {tool: "sha256:" + hashlib.sha256(_archive_bytes(tool, spec)).hexdigest() for tool, spec in specs.items()}
+    catalog = {
+        "distribution": {"version": "0.1.0-alpha.1"},
+        "components": {
+            "toolchain": {
+                tool: {"version": version, "platforms": {_PLATFORM.key: digests[tool]}} for tool in _TOOLS
+            }
+        },
+    }
+    return catalog, digests
+
+
+class _FakeDownloader:
+    def __init__(self, specs: dict) -> None:
+        self._specs = specs
+        self.calls: list[str] = []
+
+    def fetch(self, url: str, *, destination: Path) -> None:
+        self.calls.append(url)
+        tool = next(name for name, spec in self._specs.items() if spec.url == url)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(_archive_bytes(tool, self._specs[tool]))
+
+
+def _manager(
+    tmp_path: Path, *, catalog: dict | None = None, home: Path | None = None
+) -> tuple[ToolchainManager, _FakeDownloader]:
+    resolved_catalog = catalog or _catalog_and_digests()[0]
+    specs = load_specs(resolved_catalog, platform=_PLATFORM)
+    downloader = _FakeDownloader(specs)
+    manager = ToolchainManager(
+        home=home or (tmp_path / "home"),
+        distribution_version=str(resolved_catalog["distribution"]["version"]),
+        platform=_PLATFORM,
+        specs=specs,
+        downloader=downloader,
+    )
+    return manager, downloader
+
+
+def test_resolve_provisions_a_managed_tool_on_first_use(tmp_path: Path) -> None:
+    manager, downloader = _manager(tmp_path)
+
+    path = manager.resolve("kind")
+
+    assert path.is_file()
+    assert path.read_bytes() == b"pretend kind binary v1.0.0"
+    assert len(downloader.calls) == 1
+
+
+def test_resolve_is_idempotent_and_touches_the_network_only_once(tmp_path: Path) -> None:
+    manager, downloader = _manager(tmp_path)
+
+    first = manager.resolve("terraform")
+    second = manager.resolve("terraform")
+
+    assert first == second
+    assert first.read_bytes() == b"pretend terraform binary v1.0.0"
+    assert len(downloader.calls) == 1
+
+
+def test_resolve_writes_a_receipt_recording_version_and_digest(tmp_path: Path) -> None:
+    manager, _ = _manager(tmp_path)
+
+    manager.resolve("helm")
+
+    receipt = json.loads(manager.receipt_path.read_text())
+    assert receipt["helm"]["version"] == manager.specs["helm"].version
+    assert receipt["helm"]["sha256"] == manager.specs["helm"].sha256
+
+
+def test_resolve_reprovisions_when_the_catalog_bumps_the_version(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    manager_v1, _ = _manager(tmp_path, home=home)
+    manager_v1.resolve("kubectl")
+
+    catalog_v2, _ = _catalog_and_digests(version="2.0.0")
+    manager_v2, downloader_v2 = _manager(tmp_path, catalog=catalog_v2, home=home)
+    # Same distribution version (receipts are per version_dir) but a bumped
+    # tool version - the receipt no longer matches the catalog's spec.
+    manager_v2 = ToolchainManager(
+        home=home,
+        distribution_version=manager_v1.distribution_version,
+        platform=_PLATFORM,
+        specs=manager_v2.specs,
+        downloader=downloader_v2,
+    )
+
+    manager_v2.resolve("kubectl")
+
+    assert len(downloader_v2.calls) == 1  # version differs from the receipt, so it re-provisions
+
+
+def test_resolve_raises_for_an_unmanaged_tool_name(tmp_path: Path) -> None:
+    manager, _ = _manager(tmp_path)
+    with pytest.raises(KeyError):
+        manager.resolve("docker")
+
+
+def test_ensure_all_provisions_every_managed_tool(tmp_path: Path) -> None:
+    manager, downloader = _manager(tmp_path)
+
+    paths = manager.ensure_all()
+
+    assert set(paths) == set(_TOOLS)
+    assert len(downloader.calls) == len(_TOOLS)
+    assert all(path.is_file() for path in paths.values())
+
+
+def test_two_distribution_versions_keep_independent_toolchains(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    catalog_a, _ = _catalog_and_digests()
+    catalog_a["distribution"]["version"] = "0.1.0-alpha.1"
+    catalog_b, _ = _catalog_and_digests()
+    catalog_b["distribution"]["version"] = "0.2.0-alpha.1"
+
+    manager_a, _ = _manager(tmp_path, catalog=catalog_a, home=home)
+    manager_b, _ = _manager(tmp_path, catalog=catalog_b, home=home)
+
+    path_a = manager_a.resolve("kind")
+    path_b = manager_b.resolve("kind")
+
+    assert path_a != path_b
+    assert path_a.is_file()
+    assert path_b.is_file()
+    assert manager_a.version_dir != manager_b.version_dir
+
+
+def test_from_catalog_path_raises_a_typed_error_for_a_missing_catalog(tmp_path: Path) -> None:
+    with pytest.raises(ToolchainCatalogError):
+        ToolchainManager.from_catalog_path(tmp_path / "missing.yaml", home=tmp_path / "home", platform=_PLATFORM)
+
+
+def test_prune_requires_exactly_one_selector(tmp_path: Path) -> None:
+    manager, _ = _manager(tmp_path)
+    with pytest.raises(ValueError):
+        manager.prune()
+    with pytest.raises(ValueError):
+        manager.prune(version="1.0.0", remove_all=True)
+
+
+def test_prune_all_removes_every_installed_version(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    catalog_a, _ = _catalog_and_digests()
+    catalog_a["distribution"]["version"] = "0.1.0-alpha.1"
+    catalog_b, _ = _catalog_and_digests()
+    catalog_b["distribution"]["version"] = "0.2.0-alpha.1"
+    manager_a, _ = _manager(tmp_path, catalog=catalog_a, home=home)
+    manager_b, _ = _manager(tmp_path, catalog=catalog_b, home=home)
+    manager_a.resolve("kind")
+    manager_b.resolve("kind")
+
+    removed = manager_a.prune(remove_all=True)
+
+    assert sorted(p.name for p in removed) == ["0.1.0-alpha.1", "0.2.0-alpha.1"]
+    assert not manager_a.version_dir.exists()
+    assert not manager_b.version_dir.exists()
+
+
+def test_prune_keep_current_preserves_only_the_active_distribution(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    catalog_a, _ = _catalog_and_digests()
+    catalog_a["distribution"]["version"] = "0.1.0-alpha.1"
+    catalog_b, _ = _catalog_and_digests()
+    catalog_b["distribution"]["version"] = "0.2.0-alpha.1"
+    manager_a, _ = _manager(tmp_path, catalog=catalog_a, home=home)
+    manager_b, _ = _manager(tmp_path, catalog=catalog_b, home=home)
+    manager_a.resolve("kind")
+    manager_b.resolve("kind")
+
+    removed = manager_b.prune(keep_current=True)
+
+    assert [p.name for p in removed] == ["0.1.0-alpha.1"]
+    assert not manager_a.version_dir.exists()
+    assert manager_b.version_dir.exists()
+
+
+def test_prune_never_removes_anything_outside_olf_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    outside = tmp_path / "definitely-not-olf-home"
+    outside.mkdir()
+    (outside / "marker.txt").write_text("do not touch")
+    (home / "toolchains").mkdir(parents=True)
+    escape_link = home / "toolchains" / "escaped-version"
+    escape_link.symlink_to(outside)
+
+    manager, _ = _manager(tmp_path, home=home)
+
+    manager.prune(remove_all=True)
+
+    assert outside.is_dir()
+    assert (outside / "marker.txt").is_file()

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -410,3 +410,37 @@ def test_prune_refuses_a_symlinked_toolchains_root(tmp_path: Path) -> None:
     assert removed == []
     assert (outside / "some-version").is_dir()
     assert (outside / "some-version" / "marker.txt").is_file()
+
+
+@pytest.mark.parametrize("malformed_document", [None, [], 42, "not-a-dict"])
+def test_installed_treats_a_malformed_receipt_document_as_absent(tmp_path: Path, malformed_document: object) -> None:
+    """A receipt.json containing valid JSON in the wrong shape (null, a
+    list, a scalar) must be treated the same as an absent receipt - it's a
+    disposable cache of what's installed, not a source of truth, so
+    resolve() should repair it by reprovisioning rather than crash the
+    whole command."""
+    manager, _ = _manager(tmp_path)
+    manager.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    manager.receipt_path.write_text(json.dumps(malformed_document))
+
+    assert manager.installed("terraform") is None
+
+
+@pytest.mark.parametrize("malformed_entry", [None, [], 42, "not-a-dict"])
+def test_installed_treats_a_malformed_per_tool_entry_as_absent(tmp_path: Path, malformed_entry: object) -> None:
+    manager, _ = _manager(tmp_path)
+    manager.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    manager.receipt_path.write_text(json.dumps({"terraform": malformed_entry}))
+
+    assert manager.installed("terraform") is None
+
+
+def test_resolve_repairs_a_malformed_receipt_instead_of_crashing(tmp_path: Path) -> None:
+    manager, downloader = _manager(tmp_path)
+    manager.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    manager.receipt_path.write_text("null")
+
+    path = manager.resolve("kind")
+
+    assert path.is_file()
+    assert len(downloader.calls) == 1

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -444,3 +444,39 @@ def test_resolve_repairs_a_malformed_receipt_instead_of_crashing(tmp_path: Path)
 
     assert path.is_file()
     assert len(downloader.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "malformed_fields",
+    [
+        {"version": "1.8.5", "sha256": None},
+        {"version": "1.8.5", "sha256": 42},
+        {"version": "1.8.5", "sha256": "not-a-digest"},
+        {"version": None, "sha256": "sha256:" + "a" * 64},
+        {"version": 42, "sha256": "sha256:" + "a" * 64},
+        {"version": "", "sha256": "sha256:" + "a" * 64},
+    ],
+)
+def test_installed_treats_a_receipt_with_a_malformed_field_as_absent(
+    tmp_path: Path, malformed_fields: dict
+) -> None:
+    """A structurally valid dict entry can still carry a malformed field
+    (e.g. `sha256: null`) - activated_filename() would otherwise crash on
+    a None/non-digest value instead of this disposable cache entry being
+    treated as absent and reprovisioned."""
+    manager, _ = _manager(tmp_path)
+    manager.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    manager.receipt_path.write_text(json.dumps({"terraform": malformed_fields}))
+
+    assert manager.installed("terraform") is None
+
+
+def test_resolve_repairs_a_receipt_with_a_null_sha256_instead_of_crashing(tmp_path: Path) -> None:
+    manager, downloader = _manager(tmp_path)
+    manager.receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    manager.receipt_path.write_text(json.dumps({"kind": {"version": "0.26.0", "sha256": None}}))
+
+    path = manager.resolve("kind")
+
+    assert path.is_file()
+    assert len(downloader.calls) == 1

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -11,7 +11,7 @@ import pytest
 
 from olf.toolchain.manager import ToolchainManager
 from olf.toolchain.platform import Platform
-from olf.toolchain.spec import ToolchainCatalogError, load_specs
+from olf.toolchain.spec import ToolchainCatalogError, activated_filename, load_specs
 
 _PLATFORM = Platform(os="linux", arch="amd64")
 _TOOLS = ("terraform", "helm", "kubectl", "kind")
@@ -359,8 +359,30 @@ def test_concurrent_resolves_of_different_versions_never_leave_a_binary_receipt_
 
     receipt = json.loads(manager_a.receipt_path.read_text())
     recorded_version = receipt["kubectl"]["version"]
-    activated_bytes = (manager_a.bin_dir / "kubectl").read_bytes()
+    recorded_sha256 = receipt["kubectl"]["sha256"]
+    activated_path = manager_a.bin_dir / activated_filename("kubectl", recorded_sha256)
     expected_bytes = f"pretend kubectl binary v{recorded_version}".encode()
-    assert activated_bytes == expected_bytes, (
-        f"receipt says {recorded_version!r} but the activated binary does not match it"
+    assert activated_path.read_bytes() == expected_bytes, (
+        f"receipt says {recorded_version!r} but the digest-named activated binary does not match it"
     )
+
+
+def test_a_resolved_path_survives_a_later_resolve_of_a_different_pin(tmp_path: Path) -> None:
+    """The core TOCTOU scenario: checkout A resolves a path, then (after A's
+    `resolve()` call has already returned) checkout B resolves a different
+    pin of the same tool under the same OLF_HOME/version_dir. A's path must
+    still contain exactly what A resolved - a content-addressed path can
+    never be mutated by someone else's install."""
+    home = tmp_path / "home"
+    catalog_a, _ = _catalog_and_digests(version="1.0.0")
+    catalog_b, _ = _catalog_and_digests(version="2.0.0")
+    manager_a, _ = _manager(tmp_path, catalog=catalog_a, home=home)
+    manager_b, _ = _manager(tmp_path, catalog=catalog_b, home=home)
+
+    path_a = manager_a.resolve("terraform")
+    content_when_a_resolved = path_a.read_bytes()
+
+    manager_b.resolve("terraform")  # a different pin, well after A's call returned
+
+    assert path_a.read_bytes() == content_when_a_resolved
+    assert path_a != manager_b.installed("terraform").path

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -249,3 +249,34 @@ def test_prune_never_removes_anything_outside_olf_home(tmp_path: Path) -> None:
 
     assert outside.is_dir()
     assert (outside / "marker.txt").is_file()
+
+
+def test_concurrent_resolves_of_different_tools_do_not_clobber_each_others_receipt(tmp_path: Path) -> None:
+    """Two `olf` processes (simulated here as threads sharing one manager,
+    which is the realistic shape of the race - independent `ToolchainManager`
+    instances pointed at the same `OLF_HOME`) provisioning different tools at
+    the same time must not lose either receipt entry, and must never crash
+    on the temp-file rename `_write_receipt` performs.
+    """
+    import threading
+
+    manager, _ = _manager(tmp_path)
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(2)
+
+    def _resolve(tool: str) -> None:
+        barrier.wait(timeout=5)
+        try:
+            manager.resolve(tool)
+        except BaseException as exc:  # noqa: BLE001 - captured for the assertion below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_resolve, args=(tool,)) for tool in ("terraform", "helm")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors, errors
+    receipt = json.loads(manager.receipt_path.read_text())
+    assert set(receipt) == {"terraform", "helm"}

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import os
 import tarfile
 import zipfile
 from pathlib import Path
@@ -480,3 +481,34 @@ def test_resolve_repairs_a_receipt_with_a_null_sha256_instead_of_crashing(tmp_pa
 
     assert path.is_file()
     assert len(downloader.calls) == 1
+
+
+def test_installed_refuses_an_activated_file_that_lost_its_executable_bit(tmp_path: Path) -> None:
+    """A digest-named activated file with a valid receipt but no execute
+    permission (e.g. a partial restore of a damaged OLF_HOME) must not be
+    trusted as installed - the next command would otherwise fail with a
+    permission error instead of resolve() repairing it."""
+    manager, downloader = _manager(tmp_path)
+    path = manager.resolve("kind")
+    assert manager.installed("kind") is not None
+
+    path.chmod(0o644)  # drop the executable bit, keep the content intact
+
+    assert manager.installed("kind") is None
+
+
+def test_resolve_reinstalls_from_the_verified_cache_when_the_executable_bit_is_lost(tmp_path: Path) -> None:
+    """The repair path must reuse the already-verified download cache
+    entry rather than re-downloading - resolve() should not need the
+    network just because a local file lost a permission bit."""
+    manager, downloader = _manager(tmp_path)
+    first_path = manager.resolve("kind")
+    assert len(downloader.calls) == 1
+
+    first_path.chmod(0o644)
+
+    second_path = manager.resolve("kind")
+
+    assert second_path == first_path
+    assert os.access(second_path, os.X_OK)
+    assert len(downloader.calls) == 1  # reused the cached archive, no re-download

--- a/tools/olf/tests/test_toolchain_manager.py
+++ b/tools/olf/tests/test_toolchain_manager.py
@@ -386,3 +386,27 @@ def test_a_resolved_path_survives_a_later_resolve_of_a_different_pin(tmp_path: P
 
     assert path_a.read_bytes() == content_when_a_resolved
     assert path_a != manager_b.installed("terraform").path
+
+
+def test_prune_refuses_a_symlinked_toolchains_root(tmp_path: Path) -> None:
+    """If `<OLF_HOME>/toolchains` itself is a symlink to an external
+    directory, `prune` must not trust that directory as its root at all -
+    otherwise every real child of the external directory satisfies the
+    per-entry `resolved.parent == toolchains_root` check and gets deleted,
+    defeating the "never remove anything outside OLF_HOME" guarantee.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    outside = tmp_path / "definitely-not-olf-home"
+    outside.mkdir()
+    (outside / "some-version").mkdir()
+    (outside / "some-version" / "marker.txt").write_text("do not touch")
+    (home / "toolchains").symlink_to(outside)
+
+    manager, _ = _manager(tmp_path, home=home)
+
+    removed = manager.prune(remove_all=True)
+
+    assert removed == []
+    assert (outside / "some-version").is_dir()
+    assert (outside / "some-version" / "marker.txt").is_file()

--- a/tools/olf/tests/test_toolchain_platform.py
+++ b/tools/olf/tests/test_toolchain_platform.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from olf.toolchain.platform import Platform, UnsupportedPlatformError
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "expected"),
+    [
+        ("Darwin", "arm64", "darwin-arm64"),
+        ("Darwin", "x86_64", "darwin-amd64"),
+        ("Linux", "x86_64", "linux-amd64"),
+        ("Linux", "aarch64", "linux-arm64"),
+        ("linux", "amd64", "linux-amd64"),
+    ],
+)
+def test_from_uname_maps_known_platforms(system: str, machine: str, expected: str) -> None:
+    platform = Platform.from_uname(system=system, machine=machine)
+    assert platform.key == expected
+    assert str(platform) == expected
+
+
+def test_from_uname_rejects_unknown_os() -> None:
+    with pytest.raises(UnsupportedPlatformError):
+        Platform.from_uname(system="Windows", machine="x86_64")
+
+
+def test_from_uname_rejects_unknown_arch() -> None:
+    with pytest.raises(UnsupportedPlatformError):
+        Platform.from_uname(system="Linux", machine="mips")
+
+
+def test_detect_returns_a_platform() -> None:
+    assert isinstance(Platform.detect(), Platform)

--- a/tools/olf/tests/test_toolchain_resolver.py
+++ b/tools/olf/tests/test_toolchain_resolver.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from olf.deployment.errors import ExecutableNotFoundError, ToolchainError
+from olf.tooling.resolver import (
+    ManagedExecutableResolver,
+    PathExecutableResolver,
+    build_resolver,
+)
+
+
+def test_path_resolver_still_resolves_from_path() -> None:
+    resolver = PathExecutableResolver(which=lambda name: f"/usr/bin/{name}" if name == "docker" else None)
+    assert resolver.resolve("docker") == Path("/usr/bin/docker")
+    with pytest.raises(ExecutableNotFoundError):
+        resolver.resolve("terraform")
+
+
+def test_path_resolver_overrides_take_precedence_over_which() -> None:
+    resolver = PathExecutableResolver(
+        overrides={"terraform": Path("/opt/pinned/terraform")}, which=lambda _name: "/usr/bin/terraform"
+    )
+    assert resolver.resolve("terraform") == Path("/opt/pinned/terraform")
+
+
+class _FakeManager:
+    def __init__(self, paths: dict[str, Path] | None = None, *, fail_with: Exception | None = None) -> None:
+        self._paths = paths or {}
+        self._fail_with = fail_with
+        self.calls: list[str] = []
+
+    def resolve(self, tool: str) -> Path:
+        self.calls.append(tool)
+        if self._fail_with is not None:
+            raise self._fail_with
+        return self._paths[tool]
+
+
+def test_managed_resolver_delegates_managed_tools_to_the_manager() -> None:
+    manager = _FakeManager({"terraform": Path("/home/.openlakeforge/toolchains/x/bin/terraform")})
+    resolver = ManagedExecutableResolver(manager, fallback=PathExecutableResolver(which=lambda _n: None))
+
+    result = resolver.resolve("terraform")
+
+    assert result == Path("/home/.openlakeforge/toolchains/x/bin/terraform")
+    assert manager.calls == ["terraform"]
+
+
+def test_managed_resolver_falls_through_unmanaged_tools_to_path() -> None:
+    manager = _FakeManager()
+    resolver = ManagedExecutableResolver(
+        manager, fallback=PathExecutableResolver(which=lambda name: f"/usr/bin/{name}" if name == "docker" else None)
+    )
+
+    result = resolver.resolve("docker")
+
+    assert result == Path("/usr/bin/docker")
+    assert manager.calls == []  # docker is not a managed tool; the manager is never consulted
+
+
+@pytest.mark.parametrize("tool", ["terraform", "helm", "kubectl", "kind"])
+def test_managed_resolver_never_falls_back_to_path_for_a_managed_tool_on_failure(tool: str) -> None:
+    manager = _FakeManager(fail_with=RuntimeError("network unreachable"))
+    fallback_calls: list[str] = []
+
+    class _RecordingFallback:
+        def resolve(self, name: str) -> Path:
+            fallback_calls.append(name)
+            return Path(f"/usr/bin/{name}")
+
+    resolver = ManagedExecutableResolver(manager, fallback=_RecordingFallback())
+
+    with pytest.raises(ToolchainError, match=tool):
+        resolver.resolve(tool)
+
+    assert fallback_calls == []  # a managed-tool failure must never silently resolve a host binary
+
+
+def test_managed_resolver_wraps_manager_failures_with_an_actionable_escape_hatch() -> None:
+    manager = _FakeManager(fail_with=RuntimeError("digest mismatch"))
+    resolver = ManagedExecutableResolver(manager, fallback=PathExecutableResolver(which=lambda _n: None))
+
+    with pytest.raises(ToolchainError, match="OLF_TOOLCHAIN_MODE=host"):
+        resolver.resolve("kind")
+
+
+def test_managed_resolver_propagates_executable_not_found_unwrapped() -> None:
+    """A plain PATH miss for a managed tool should surface the standard
+    ExecutableNotFoundError message, not be double-wrapped."""
+
+    class _NotFoundManager:
+        def resolve(self, tool: str) -> Path:
+            raise ExecutableNotFoundError(tool, searched="OLF_HOME")
+
+    resolver = ManagedExecutableResolver(_NotFoundManager(), fallback=PathExecutableResolver(which=lambda _n: None))
+
+    with pytest.raises(ExecutableNotFoundError):
+        resolver.resolve("terraform")
+
+
+def test_build_resolver_host_mode_returns_a_plain_path_resolver(tmp_path: Path) -> None:
+    resolver = build_resolver(environ={"OLF_TOOLCHAIN_MODE": "host"})
+    assert isinstance(resolver, PathExecutableResolver)
+    assert not isinstance(resolver, ManagedExecutableResolver)
+
+
+def test_build_resolver_rejects_an_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="OLF_TOOLCHAIN_MODE"):
+        build_resolver(environ={"OLF_TOOLCHAIN_MODE": "bogus"})
+
+
+def test_build_resolver_managed_mode_wires_a_managed_resolver_against_the_real_catalog(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("olf.config.repo_root", lambda: Path("."))
+    resolver = build_resolver(environ={"OLF_TOOLCHAIN_MODE": "managed", "OLF_HOME": str(tmp_path)})
+
+    assert isinstance(resolver, ManagedExecutableResolver)
+    assert resolver.manager.home == tmp_path
+    assert set(resolver.manager.specs) == {"terraform", "helm", "kubectl", "kind"}
+
+
+def test_build_resolver_overrides_win_over_managed_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("olf.config.repo_root", lambda: Path("."))
+    pinned = Path("/opt/pinned/terraform")
+    resolver = build_resolver(
+        overrides={"terraform": pinned}, environ={"OLF_TOOLCHAIN_MODE": "managed", "OLF_HOME": str(tmp_path)}
+    )
+
+    assert resolver.resolve("terraform") == pinned
+
+
+def test_build_resolver_managed_mode_fails_closed_on_a_missing_catalog(tmp_path: Path) -> None:
+    empty_repo = tmp_path / "empty-repo"
+    empty_repo.mkdir()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("olf.config.repo_root", lambda: empty_repo)
+        with pytest.raises(ToolchainError):
+            build_resolver(environ={"OLF_TOOLCHAIN_MODE": "managed", "OLF_HOME": str(tmp_path / "home")})

--- a/tools/olf/tests/test_toolchain_resolver.py
+++ b/tools/olf/tests/test_toolchain_resolver.py
@@ -108,7 +108,11 @@ def test_build_resolver_host_mode_returns_a_plain_path_resolver(tmp_path: Path) 
 
 
 def test_build_resolver_rejects_an_unknown_mode() -> None:
-    with pytest.raises(ValueError, match="OLF_TOOLCHAIN_MODE"):
+    """A misspelled OLF_TOOLCHAIN_MODE is a user configuration mistake, not
+    a provisioning failure - but every olf lifecycle command's boundary
+    only catches DeploymentError (ToolchainError's base), so this must
+    raise that family, not a plain ValueError, or it escapes uncaught."""
+    with pytest.raises(ToolchainError, match="OLF_TOOLCHAIN_MODE"):
         build_resolver(environ={"OLF_TOOLCHAIN_MODE": "bogus"})
 
 

--- a/tools/olf/tests/test_toolchain_spec.py
+++ b/tools/olf/tests/test_toolchain_spec.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+from olf.toolchain.platform import Platform
+from olf.toolchain.spec import ToolchainCatalogError, build_spec, load_specs
+
+_PLATFORM = Platform(os="linux", arch="amd64")
+_DIGEST = "sha256:" + "a" * 64
+
+
+def _entry(version: str = "1.2.3") -> dict:
+    return {"version": version, "platforms": {"linux-amd64": _DIGEST}}
+
+
+@pytest.mark.parametrize(
+    ("tool", "expected_url", "archive", "member"),
+    [
+        (
+            "terraform",
+            "https://releases.hashicorp.com/terraform/1.2.3/terraform_1.2.3_linux_amd64.zip",
+            "zip",
+            "terraform",
+        ),
+        ("helm", "https://get.helm.sh/helm-v1.2.3-linux-amd64.tar.gz", "tar.gz", "linux-amd64/helm"),
+        ("kubectl", "https://dl.k8s.io/release/v1.2.3/bin/linux/amd64/kubectl", "raw", None),
+        (
+            "kind",
+            "https://github.com/kubernetes-sigs/kind/releases/download/v1.2.3/kind-linux-amd64",
+            "raw",
+            None,
+        ),
+    ],
+)
+def test_build_spec_constructs_the_correct_url_and_archive_layout(
+    tool: str, expected_url: str, archive: str, member: str | None
+) -> None:
+    spec = build_spec(tool, _entry(), platform=_PLATFORM)
+    assert spec.url == expected_url
+    assert spec.archive == archive
+    assert spec.member == member
+    assert spec.sha256 == _DIGEST
+    assert spec.version == "1.2.3"
+
+
+def test_build_spec_rejects_unmanaged_tool() -> None:
+    with pytest.raises(ToolchainCatalogError):
+        build_spec("docker", _entry(), platform=_PLATFORM)
+
+
+def test_build_spec_requires_a_version() -> None:
+    with pytest.raises(ToolchainCatalogError):
+        build_spec("terraform", {"platforms": {"linux-amd64": _DIGEST}}, platform=_PLATFORM)
+
+
+def test_build_spec_requires_the_platform_key() -> None:
+    with pytest.raises(ToolchainCatalogError):
+        build_spec("terraform", {"version": "1.2.3", "platforms": {"darwin-arm64": _DIGEST}}, platform=_PLATFORM)
+
+
+def test_build_spec_rejects_a_malformed_digest() -> None:
+    with pytest.raises(ToolchainCatalogError):
+        build_spec("terraform", {"version": "1.2.3", "platforms": {"linux-amd64": "not-a-digest"}}, platform=_PLATFORM)
+
+
+def test_load_specs_builds_every_managed_tool() -> None:
+    catalog = {
+        "components": {
+            "toolchain": {
+                "terraform": _entry("1.0.0"),
+                "helm": _entry("2.0.0"),
+                "kubectl": _entry("3.0.0"),
+                "kind": _entry("4.0.0"),
+            }
+        }
+    }
+    specs = load_specs(catalog, platform=_PLATFORM)
+    assert set(specs) == {"terraform", "helm", "kubectl", "kind"}
+    assert specs["terraform"].version == "1.0.0"
+
+
+def test_load_specs_rejects_a_catalog_missing_the_toolchain_block() -> None:
+    with pytest.raises(ToolchainCatalogError):
+        load_specs({"components": {}}, platform=_PLATFORM)
+
+
+def test_load_specs_rejects_a_catalog_missing_one_tool() -> None:
+    catalog = {
+        "components": {
+            "toolchain": {
+                "terraform": _entry(),
+                "helm": _entry(),
+                "kubectl": _entry(),
+            }
+        }
+    }
+    with pytest.raises(ToolchainCatalogError, match="kind"):
+        load_specs(catalog, platform=_PLATFORM)

--- a/tools/olf/tests/test_toolchain_spec.py
+++ b/tools/olf/tests/test_toolchain_spec.py
@@ -84,6 +84,12 @@ def test_load_specs_rejects_a_catalog_missing_the_toolchain_block() -> None:
         load_specs({"components": {}}, platform=_PLATFORM)
 
 
+@pytest.mark.parametrize("malformed_components", [["a", "list"], "a scalar string", 42])
+def test_load_specs_rejects_a_non_mapping_components_block(malformed_components: object) -> None:
+    with pytest.raises(ToolchainCatalogError):
+        load_specs({"components": malformed_components}, platform=_PLATFORM)
+
+
 def test_load_specs_rejects_a_catalog_missing_one_tool() -> None:
     catalog = {
         "components": {

--- a/tools/olf/tests/test_toolchain_windows_compat.py
+++ b/tools/olf/tests/test_toolchain_windows_compat.py
@@ -1,0 +1,27 @@
+"""`olf.toolchain.manager`/`download` must import cleanly on a platform
+without `fcntl` (POSIX-only, e.g. Windows), so `Platform.detect()` gets the
+chance to raise its own actionable `UnsupportedPlatformError` instead of a
+raw `ModuleNotFoundError` interrupting the import before that check ever
+runs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("module_name", ["olf.toolchain.manager", "olf.toolchain.download"])
+def test_module_imports_without_fcntl_available(monkeypatch: pytest.MonkeyPatch, module_name: str) -> None:
+    monkeypatch.setitem(sys.modules, "fcntl", None)
+    for name in ("olf.toolchain.manager", "olf.toolchain.download"):
+        sys.modules.pop(name, None)
+
+    try:
+        module = importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert module is not None


### PR DESCRIPTION
## Summary

Implements [#127](https://github.com/malon64/openlakeforge/issues/127), the
distribution-foundation half of [#80](https://github.com/malon64/openlakeforge/issues/80):
`olf` now downloads, verifies, and privately invokes its own versioned
Terraform, Helm, kubectl, and kind binaries instead of requiring them
installed globally.

**This PR is stacked on [#140](https://github.com/malon64/openlakeforge/pull/140)**
(`codex/olf-remove-bash`) since #140 is still open. It builds directly on
that migration — the `ExecutableResolver` seam #123 introduced (and #140
carries forward) is the only integration point this change needs. Retarget
to `main` once #140 merges.

## What changed

- New `tools/olf/olf/toolchain/` package: platform detection, per-tool
  download specs read from `release/component-catalog.yaml`'s new
  `components.toolchain` block, atomic download/verify/install, and
  `ToolchainManager` (version-scoped receipts under `OLF_HOME`, default
  `~/.openlakeforge`).
- `olf.tooling.resolver` gains `ManagedExecutableResolver` + `build_resolver()`,
  wired into `Toolkit.default()`. `OLF_TOOLCHAIN_MODE` selects `managed`
  (default) or `host` (pre-#127 PATH behavior); explicit resolver overrides
  always win. No tool adapter changed — that's the payoff of the #123 seam.
  Managed-tool failures raise `ToolchainError` and never silently fall back
  to a host binary.
- `olf.k8s`, `olf.contracts`, and `olf.e2e` had legacy bare
  `["kubectl", ...]`/`["terraform", ...]` argv construction predating the
  #123 tooling package — converted to resolve through the same seam so CI
  dropping its setup actions doesn't silently break Phase 2 artifact
  deployment or e2e assertions.
- `olf doctor` reports toolchain mode/version/platform and per-tool
  managed-vs-host provenance, and provisions the toolchain as a side effect.
- New `olf toolchain list|install|path|clean` command group. `clean`
  resolves every target against `OLF_HOME` and refuses anything outside it.
- `olf release check` gained a pin-drift gate for `components.toolchain`
  (concrete versions, well-formed digests, every supported platform); the
  compatibility matrix gained a "Managed toolchain" table.
- CI (`checks.yml`, `local-full-e2e.yml`) replaced `hashicorp/setup-terraform`,
  `azure/setup-helm`, and `helm/kind-action` with `olf toolchain install`
  behind an `actions/cache` step, so CI itself proves the clean-machine path.
- ADR 0029 records the design, including why `terraform`/`helm`/`kind` stay
  managed binaries (no Python SDK exists; reimplementing them is an
  explicit #80 non-goal) and why `aws`/`az` are deliberately deferred rather
  than folded in here (`eks_update_kubeconfig`'s `exec:`-block auth wrinkle
  needs its own ADR).

## Out of scope (tracked separately)

- Replacing the `aws`/`az` CLI adapters with `boto3`/`azure-mgmt` SDKs —
  filing a sibling issue under #80 for this.
- Packaging `olf` without host Python and the no-clone platform payload
  ([#128](https://github.com/malon64/openlakeforge/issues/128)).

## Validation

- `uv run --project tools/olf ruff check tools/olf` — clean.
- `uv run --project tools/olf pytest tools/olf/tests` — 838 passed, 1
  skipped (64 new tests covering the toolchain package + resolver, offline
  throughout via an injected fake `Downloader`).
- `uv run --project tools/olf olf check all` (`OLF_TOOLCHAIN_MODE=host`) —
  structure/components/contracts/infra/dbt/lockfiles pass against this
  machine's own Terraform/Helm; `project-code` fails only on a pre-existing
  local Python-version mismatch (confirmed identical on the unmodified
  baseline via `git stash`), unrelated to this change.
- Manually verified the full download → sha256-verify → extract → activate
  path against real upstream artifacts for all three archive kinds
  (terraform zip, helm tar.gz, kind/kubectl raw binary) with the exact
  digests now pinned in the catalog.
- `olf toolchain list|install|path|clean` exercised end-to-end against an
  isolated `OLF_HOME`.
- Added an autouse pytest fixture (`OLF_TOOLCHAIN_MODE=host` + isolated
  `OLF_HOME`) after discovering the default managed mode could otherwise let
  an unmocked test silently download real binaries onto the network and
  into a developer's actual home directory.

## Test plan

- [x] `uv run --project tools/olf ruff check tools/olf`
- [x] `uv run --project tools/olf pytest tools/olf/tests`
- [x] `uv run --project tools/olf olf check all` (host mode; see note above)
- [ ] CI's `kind-smoke` job passing is the clean-machine proof — a runner
      with only Docker/Python/uv provisioning and using the release
      toolchain end-to-end.