### PR TITLE
fix: verify every catalog Helm chart before Terraform applies it

### DIFF
--- a/infra/terraform/environments/aws-poc/main.tf
+++ b/infra/terraform/environments/aws-poc/main.tf
@@ -266,13 +266,15 @@ module "openmetadata" {
   source = "../../modules/governance/openmetadata"
   count  = var.enable_governance ? 1 : 0
 
-  namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
-  base_values_file    = "${path.root}/../../../helm/values/local/openmetadata.yaml"
-  deps_values_file    = "${path.root}/../../../helm/values/local/openmetadata-deps.yaml"
-  catalog_contract    = local.catalog_contract
-  storage_contract    = local.storage_contract
-  postgresql_contract = local.metadata_database_contract
-  postgresql_ssl_mode = "require"
+  namespace               = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  base_values_file        = "${path.root}/../../../helm/values/local/openmetadata.yaml"
+  deps_values_file        = "${path.root}/../../../helm/values/local/openmetadata-deps.yaml"
+  chart_package_path      = var.openmetadata_chart_package_path
+  deps_chart_package_path = var.openmetadata_deps_chart_package_path
+  catalog_contract        = local.catalog_contract
+  storage_contract        = local.storage_contract
+  postgresql_contract     = local.metadata_database_contract
+  postgresql_ssl_mode     = "require"
   # Empty by design: the database schemas mirror Glue databases, which now
   # come into existence in Phase 2. `olf openmetadata deploy-metadata` creates
   # each databaseSchema entity right before it seeds that schema's tables.
@@ -294,6 +296,7 @@ module "superset" {
 
   namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file    = "${path.root}/../../../helm/values/local/superset.yaml"
+  chart_package_path  = var.superset_chart_package_path
   image_repository    = var.superset_image_repository
   image_tag           = var.superset_image_tag
   image_pull_policy   = var.superset_image_pull_policy

--- a/infra/terraform/environments/aws-poc/variables.tf
+++ b/infra/terraform/environments/aws-poc/variables.tf
@@ -148,6 +148,24 @@ variable "dagster_chart_package_path" {
   default     = null
 }
 
+variable "openmetadata_chart_package_path" {
+  description = "Optional local OpenMetadata Helm chart package used by aws-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "openmetadata_deps_chart_package_path" {
+  description = "Optional local openmetadata-dependencies Helm chart package used by aws-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "superset_chart_package_path" {
+  description = "Optional local Superset Helm chart package used by aws-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
 variable "rds_instance_class" {
   description = "RDS PostgreSQL instance class for the AWS POC."
   type        = string

--- a/infra/terraform/environments/azure-poc/main.tf
+++ b/infra/terraform/environments/azure-poc/main.tf
@@ -80,8 +80,9 @@ module "postgresql" {
 module "seaweedfs" {
   source = "../../modules/storage/seaweedfs"
 
-  namespace        = kubernetes_namespace_v1.lakehouse.metadata[0].name
-  base_values_file = "${path.root}/../../../helm/values/local/seaweedfs.yaml"
+  namespace          = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  base_values_file   = "${path.root}/../../../helm/values/local/seaweedfs.yaml"
+  chart_package_path = var.seaweedfs_chart_package_path
   bucket_names = [
     var.bronze_bucket_name,
     var.silver_bucket_name,
@@ -96,6 +97,7 @@ module "polaris" {
 
   namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file    = "${path.root}/../../../helm/values/local/polaris.yaml"
+  chart_package_path  = var.polaris_chart_package_path
   catalog_name        = var.catalog_name
   principal_name      = "trino"
   principal_role      = "data-engineer"
@@ -128,12 +130,14 @@ module "openmetadata" {
   source = "../../modules/governance/openmetadata"
   count  = var.enable_governance ? 1 : 0
 
-  namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
-  base_values_file    = "${path.root}/../../../helm/values/local/openmetadata.yaml"
-  deps_values_file    = "${path.root}/../../../helm/values/local/openmetadata-deps.yaml"
-  catalog_contract    = local.catalog_contract
-  storage_contract    = local.storage_contract
-  postgresql_contract = local.metadata_database_contract
+  namespace               = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  base_values_file        = "${path.root}/../../../helm/values/local/openmetadata.yaml"
+  deps_values_file        = "${path.root}/../../../helm/values/local/openmetadata-deps.yaml"
+  chart_package_path      = var.openmetadata_chart_package_path
+  deps_chart_package_path = var.openmetadata_deps_chart_package_path
+  catalog_contract        = local.catalog_contract
+  storage_contract        = local.storage_contract
+  postgresql_contract     = local.metadata_database_contract
   # Empty by design: the database schemas mirror Polaris namespaces, which now
   # come into existence in Phase 2. `olf openmetadata deploy-metadata` creates
   # each databaseSchema entity right before it seeds that schema's tables.
@@ -152,6 +156,7 @@ module "superset" {
 
   namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file    = "${path.root}/../../../helm/values/local/superset.yaml"
+  chart_package_path  = var.superset_chart_package_path
   image_repository    = var.superset_image_repository
   image_tag           = var.superset_image_tag
   image_pull_policy   = var.superset_image_pull_policy

--- a/infra/terraform/environments/azure-poc/variables.tf
+++ b/infra/terraform/environments/azure-poc/variables.tf
@@ -135,3 +135,33 @@ variable "dagster_chart_package_path" {
   type        = string
   default     = null
 }
+
+variable "seaweedfs_chart_package_path" {
+  description = "Optional local SeaweedFS Helm chart package used by azure-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "polaris_chart_package_path" {
+  description = "Optional local Polaris Helm chart package used by azure-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "openmetadata_chart_package_path" {
+  description = "Optional local OpenMetadata Helm chart package used by azure-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "openmetadata_deps_chart_package_path" {
+  description = "Optional local openmetadata-dependencies Helm chart package used by azure-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "superset_chart_package_path" {
+  description = "Optional local Superset Helm chart package used by azure-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}

--- a/infra/terraform/environments/local/main.tf
+++ b/infra/terraform/environments/local/main.tf
@@ -80,8 +80,9 @@ module "postgresql" {
 module "seaweedfs" {
   source = "../../modules/storage/seaweedfs"
 
-  namespace        = kubernetes_namespace_v1.lakehouse.metadata[0].name
-  base_values_file = "${path.root}/../../../helm/values/local/seaweedfs.yaml"
+  namespace          = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  base_values_file   = "${path.root}/../../../helm/values/local/seaweedfs.yaml"
+  chart_package_path = var.seaweedfs_chart_package_path
   bucket_names = [
     var.bronze_bucket_name,
     var.silver_bucket_name,
@@ -96,6 +97,7 @@ module "polaris" {
 
   namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file    = "${path.root}/../../../helm/values/local/polaris.yaml"
+  chart_package_path  = var.polaris_chart_package_path
   catalog_name        = var.catalog_name
   principal_name      = "trino"
   principal_role      = "data-engineer"
@@ -128,12 +130,14 @@ module "openmetadata" {
   source = "../../modules/governance/openmetadata"
   count  = var.enable_governance ? 1 : 0
 
-  namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
-  base_values_file    = "${path.root}/../../../helm/values/local/openmetadata.yaml"
-  deps_values_file    = "${path.root}/../../../helm/values/local/openmetadata-deps.yaml"
-  catalog_contract    = local.catalog_contract
-  storage_contract    = local.storage_contract
-  postgresql_contract = local.metadata_database_contract
+  namespace               = kubernetes_namespace_v1.lakehouse.metadata[0].name
+  base_values_file        = "${path.root}/../../../helm/values/local/openmetadata.yaml"
+  deps_values_file        = "${path.root}/../../../helm/values/local/openmetadata-deps.yaml"
+  chart_package_path      = var.openmetadata_chart_package_path
+  deps_chart_package_path = var.openmetadata_deps_chart_package_path
+  catalog_contract        = local.catalog_contract
+  storage_contract        = local.storage_contract
+  postgresql_contract     = local.metadata_database_contract
   # Empty by design: the database schemas mirror Polaris namespaces, which now
   # come into existence in Phase 2. `olf openmetadata deploy-metadata` creates
   # each databaseSchema entity right before it seeds that schema's tables.
@@ -152,6 +156,7 @@ module "superset" {
 
   namespace           = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file    = "${path.root}/../../../helm/values/local/superset.yaml"
+  chart_package_path  = var.superset_chart_package_path
   image_repository    = var.superset_image_repository
   image_tag           = var.superset_image_tag
   image_pull_policy   = var.superset_image_pull_policy
@@ -177,6 +182,7 @@ module "dagster" {
 
   namespace                      = kubernetes_namespace_v1.lakehouse.metadata[0].name
   base_values_file               = "${path.root}/../../../helm/values/local/dagster.yaml"
+  chart_package_path             = var.dagster_chart_package_path
   project_code_image_repository  = var.project_code_image_repository
   project_code_image_tag         = var.project_code_image_tag
   project_code_image_pull_policy = var.project_code_image_pull_policy

--- a/infra/terraform/environments/local/variables.tf
+++ b/infra/terraform/environments/local/variables.tf
@@ -129,3 +129,39 @@ variable "trino_chart_package_path" {
   type        = string
   default     = null
 }
+
+variable "dagster_chart_package_path" {
+  description = "Optional local Dagster Helm chart package used by local-up to avoid transient GitHub chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "seaweedfs_chart_package_path" {
+  description = "Optional local SeaweedFS Helm chart package used by local-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "polaris_chart_package_path" {
+  description = "Optional local Polaris Helm chart package used by local-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "openmetadata_chart_package_path" {
+  description = "Optional local OpenMetadata Helm chart package used by local-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "openmetadata_deps_chart_package_path" {
+  description = "Optional local openmetadata-dependencies Helm chart package used by local-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}
+
+variable "superset_chart_package_path" {
+  description = "Optional local Superset Helm chart package used by local-up to avoid transient chart download failures."
+  type        = string
+  default     = null
+}

--- a/infra/terraform/modules/analytics/superset/main.tf
+++ b/infra/terraform/modules/analytics/superset/main.tf
@@ -1,3 +1,9 @@
+locals {
+  chart      = var.chart_package_path != null ? var.chart_package_path : "superset"
+  repository = var.chart_package_path != null ? null : var.chart_repository
+  version    = var.chart_package_path != null ? null : var.chart_version
+}
+
 resource "random_password" "secret_key" {
   length  = 64
   special = false
@@ -5,9 +11,9 @@ resource "random_password" "secret_key" {
 
 resource "helm_release" "superset" {
   name       = var.release_name
-  repository = var.chart_repository
-  chart      = "superset"
-  version    = var.chart_version
+  repository = local.repository
+  chart      = local.chart
+  version    = local.version
   namespace  = var.namespace
 
   # Keep Terraform aligned with the web, worker, Redis, and init hook readiness

--- a/infra/terraform/modules/analytics/superset/variables.tf
+++ b/infra/terraform/modules/analytics/superset/variables.tf
@@ -12,13 +12,19 @@ variable "release_name" {
 variable "chart_repository" {
   description = "Superset Helm chart repository."
   type        = string
-  default     = "http://apache.github.io/superset/"
+  default     = "https://apache.github.io/superset/"
 }
 
 variable "chart_version" {
   description = "Superset Helm chart version."
   type        = string
   default     = "0.15.5"
+}
+
+variable "chart_package_path" {
+  description = "Optional local Superset Helm chart package path. When set, Terraform installs this package instead of downloading from chart_repository."
+  type        = string
+  default     = null
 }
 
 variable "base_values_file" {

--- a/infra/terraform/modules/catalog/polaris/release.tf
+++ b/infra/terraform/modules/catalog/polaris/release.tf
@@ -19,11 +19,17 @@ resource "kubernetes_secret_v1" "bootstrap_credentials" {
   type = "Opaque"
 }
 
+locals {
+  chart_package = var.chart_package_path != null ? var.chart_package_path : "polaris"
+  chart_repo    = var.chart_package_path != null ? null : var.chart_repository
+  chart_ver     = var.chart_package_path != null ? null : var.chart_version
+}
+
 resource "helm_release" "polaris" {
   name       = var.release_name
-  repository = var.chart_repository
-  chart      = "polaris"
-  version    = var.chart_version
+  repository = local.chart_repo
+  chart      = local.chart_package
+  version    = local.chart_ver
   namespace  = var.namespace
 
   wait    = true

--- a/infra/terraform/modules/catalog/polaris/variables.tf
+++ b/infra/terraform/modules/catalog/polaris/variables.tf
@@ -21,6 +21,12 @@ variable "chart_version" {
   default     = "1.4.1"
 }
 
+variable "chart_package_path" {
+  description = "Optional local Polaris Helm chart package path. When set, Terraform installs this package instead of downloading from chart_repository."
+  type        = string
+  default     = null
+}
+
 variable "base_values_file" {
   description = "Path to the non-secret base Helm values file."
   type        = string

--- a/infra/terraform/modules/governance/openmetadata/releases.tf
+++ b/infra/terraform/modules/governance/openmetadata/releases.tf
@@ -1,9 +1,18 @@
+locals {
+  deps_chart      = var.deps_chart_package_path != null ? var.deps_chart_package_path : "openmetadata-dependencies"
+  deps_repository = var.deps_chart_package_path != null ? null : var.chart_repository
+  deps_version    = var.deps_chart_package_path != null ? null : var.deps_chart_version
+  chart           = var.chart_package_path != null ? var.chart_package_path : "openmetadata"
+  repository      = var.chart_package_path != null ? null : var.chart_repository
+  version         = var.chart_package_path != null ? null : var.chart_version
+}
+
 # OpenSearch via the openmetadata-dependencies chart (Airflow + MySQL disabled)
 resource "helm_release" "openmetadata_deps" {
   name       = "${var.release_name}-deps"
-  repository = var.chart_repository
-  chart      = "openmetadata-dependencies"
-  version    = var.deps_chart_version
+  repository = local.deps_repository
+  chart      = local.deps_chart
+  version    = local.deps_version
   namespace  = var.namespace
 
   wait    = true
@@ -17,9 +26,9 @@ resource "helm_release" "openmetadata_deps" {
 # Main OpenMetadata application
 resource "helm_release" "openmetadata" {
   name       = var.release_name
-  repository = var.chart_repository
-  chart      = "openmetadata"
-  version    = var.chart_version
+  repository = local.repository
+  chart      = local.chart
+  version    = local.version
   namespace  = var.namespace
 
   wait            = true

--- a/infra/terraform/modules/governance/openmetadata/variables.tf
+++ b/infra/terraform/modules/governance/openmetadata/variables.tf
@@ -21,6 +21,12 @@ variable "chart_version" {
   default     = "1.12.10"
 }
 
+variable "chart_package_path" {
+  description = "Optional local OpenMetadata Helm chart package path. When set, Terraform installs this package instead of downloading from chart_repository."
+  type        = string
+  default     = null
+}
+
 variable "base_values_file" {
   description = "Path to the non-secret base Helm values file for the openmetadata chart."
   type        = string
@@ -35,6 +41,12 @@ variable "deps_chart_version" {
   description = "openmetadata-dependencies Helm chart version. Should match chart_version."
   type        = string
   default     = "1.12.10"
+}
+
+variable "deps_chart_package_path" {
+  description = "Optional local openmetadata-dependencies Helm chart package path. When set, Terraform installs this package instead of downloading from chart_repository."
+  type        = string
+  default     = null
 }
 
 variable "postgresql_contract" {

--- a/infra/terraform/modules/storage/seaweedfs/main.tf
+++ b/infra/terraform/modules/storage/seaweedfs/main.tf
@@ -5,6 +5,10 @@ locals {
     "openlakeforge.io/component"   = "storage"
   }
 
+  chart      = var.chart_package_path != null ? var.chart_package_path : "seaweedfs"
+  repository = var.chart_package_path != null ? null : var.chart_repository
+  version    = var.chart_package_path != null ? null : var.chart_version
+
   s3_service_name     = "${var.release_name}-s3"
   master_service_name = "${var.release_name}-master"
   filer_service_name  = "${var.release_name}-filer-client"
@@ -40,9 +44,9 @@ resource "kubernetes_secret_v1" "s3_credentials" {
 
 resource "helm_release" "seaweedfs" {
   name       = var.release_name
-  repository = var.chart_repository
-  chart      = "seaweedfs"
-  version    = var.chart_version
+  repository = local.repository
+  chart      = local.chart
+  version    = local.version
   namespace  = var.namespace
 
   wait    = true

--- a/infra/terraform/modules/storage/seaweedfs/variables.tf
+++ b/infra/terraform/modules/storage/seaweedfs/variables.tf
@@ -21,6 +21,12 @@ variable "chart_version" {
   default     = "4.23.0"
 }
 
+variable "chart_package_path" {
+  description = "Optional local SeaweedFS Helm chart package path. When set, Terraform installs this package instead of downloading from chart_repository."
+  type        = string
+  default     = null
+}
+
 variable "base_values_file" {
   description = "Path to the non-secret base Helm values file."
   type        = string

--- a/tools/olf/olf/deployment/charts.py
+++ b/tools/olf/olf/deployment/charts.py
@@ -15,7 +15,7 @@ import hashlib
 import os
 import tarfile
 import tempfile
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -23,6 +23,7 @@ import yaml
 
 from olf import log
 from olf.deployment.context import DeploymentPaths
+from olf.deployment.env_settings import env as _env_lookup
 from olf.deployment.retry import RetryPolicy
 from olf.tooling.helm import Helm
 
@@ -318,3 +319,180 @@ def _prepare_cached_dagster_chart_no_schema(
             digest_sidecar.write_text(_digest(request.package_path) + "\n")
 
     return request.package_path
+@dataclass(frozen=True)
+class ChartDefault:
+    """A catalog chart's source-mode fallback (no catalog entry, or a
+    non-installed run) plus how it must be prepared.
+
+    `chart_ref` is the repo-relative reference Helm resolves once the repo
+    named `name.split("/", 1)[0]`-equivalent is added (`<repo>/<chart>`,
+    matching `CatalogChart.reference`); `repository`/`version` are the
+    literal defaults every provider config used to hardcode per chart before
+    this table existed.
+    """
+
+    chart_ref: str
+    repository: str
+    version: str
+    repack: bool = False
+    variant: str | None = None
+
+
+CHART_DEFAULTS: Mapping[str, ChartDefault] = {
+    "trino": ChartDefault(chart_ref="trino/trino", repository="https://trinodb.github.io/charts", version="1.42.2"),
+    "dagster": ChartDefault(
+        chart_ref="dagster/dagster",
+        repository="https://dagster-io.github.io/helm",
+        version="1.13.6",
+        repack=True,
+        variant="no-schema",
+    ),
+    "seaweedfs": ChartDefault(
+        chart_ref="seaweedfs/seaweedfs",
+        repository="https://seaweedfs.github.io/seaweedfs/helm",
+        version="4.23.0",
+    ),
+    "polaris": ChartDefault(
+        chart_ref="polaris/polaris",
+        repository="https://downloads.apache.org/polaris/helm-chart",
+        version="1.4.1",
+    ),
+    "openmetadata": ChartDefault(
+        chart_ref="open-metadata/openmetadata",
+        repository="https://helm.open-metadata.org",
+        version="1.12.10",
+    ),
+    "openmetadata-dependencies": ChartDefault(
+        chart_ref="open-metadata/openmetadata-dependencies",
+        repository="https://helm.open-metadata.org",
+        version="1.12.10",
+    ),
+    "superset": ChartDefault(
+        chart_ref="superset/superset",
+        repository="https://apache.github.io/superset/",
+        version="0.15.5",
+    ),
+}
+
+
+def _env_slug(name: str) -> str:
+    return name.upper().replace("-", "_")
+
+
+TERRAFORM_VARIABLE_KEY: Mapping[str, str] = {
+    "trino": "trino_chart_package_path",
+    "dagster": "dagster_chart_package_path",
+    "seaweedfs": "seaweedfs_chart_package_path",
+    "polaris": "polaris_chart_package_path",
+    "openmetadata": "openmetadata_chart_package_path",
+    "openmetadata-dependencies": "openmetadata_deps_chart_package_path",
+    "superset": "superset_chart_package_path",
+}
+"""Maps a catalog chart name to the Terraform variable each environment root
+declares for it. `openmetadata-dependencies` breaks the `<name>_chart_package_path`
+pattern because its Terraform module variable is `deps_chart_package_path`
+(paired with the module's existing `deps_chart_version`, see
+`modules/governance/openmetadata/variables.tf`), not a name derived from the
+catalog key.
+"""
+
+
+@dataclass(frozen=True)
+class ChartSetting:
+    """A resolved, provider-agnostic chart ready for `prepare_chart`."""
+
+    name: str
+    repository_url: str
+    chart_ref: str
+    version: str
+    package_path: Path
+    sha256: str | None
+    repack: bool
+    variant: str | None
+
+    def request(self) -> ChartRequest:
+        return ChartRequest(
+            display_name=self.name,
+            repo_name=self.chart_ref.split("/", 1)[0],
+            repo_url=self.repository_url,
+            chart_ref=self.chart_ref,
+            version=self.version,
+            package_path=self.package_path,
+            sha256=self.sha256,
+        )
+
+
+def resolve_chart_setting(
+    name: str,
+    environ: Mapping[str, str],
+    *,
+    helm_cache_dir: Path,
+    cache_root: Path,
+    catalog_path: Path,
+    installed: bool,
+) -> ChartSetting:
+    """Resolve one catalog chart's settings, mirroring the `${VAR:-default}`
+    fallback chain `local.config.ChartSettings`/`cloud.config.CloudChartSettings`
+    each duplicated per chart before this helper existed.
+    """
+    default = CHART_DEFAULTS[name]
+    slug = _env_slug(name)
+    catalog_chart = CatalogChart.load(catalog_path, name) if catalog_path.is_file() else None
+    version = _env_lookup(environ, f"{slug}_CHART_VERSION", catalog_chart.version if catalog_chart else default.version)
+    fallback_filename = f"{name}-{version}-{default.variant}.tgz" if default.variant else f"{name}-{version}.tgz"
+    default_package_path = (
+        catalog_chart.request(cache_root=cache_root, variant=default.variant).package_path
+        if installed and catalog_chart is not None
+        else helm_cache_dir / fallback_filename
+    )
+    fallback_repository = catalog_chart.repository if catalog_chart is not None else default.repository
+    return ChartSetting(
+        name=name,
+        repository_url=_env_lookup(environ, f"{slug}_CHART_REPOSITORY", fallback_repository),
+        chart_ref=default.chart_ref,
+        version=version,
+        package_path=Path(_env_lookup(environ, f"{slug}_CHART_PACKAGE_PATH", str(default_package_path))),
+        sha256=catalog_chart.sha256 if installed and catalog_chart is not None else None,
+        repack=default.repack,
+        variant=default.variant,
+    )
+
+
+def resolve_chart_settings(
+    names: Iterable[str],
+    environ: Mapping[str, str],
+    *,
+    helm_cache_dir: Path,
+    cache_root: Path,
+    catalog_path: Path,
+    installed: bool,
+) -> dict[str, ChartSetting]:
+    return {
+        name: resolve_chart_setting(
+            name,
+            environ,
+            helm_cache_dir=helm_cache_dir,
+            cache_root=cache_root,
+            catalog_path=catalog_path,
+            installed=installed,
+        )
+        for name in names
+    }
+
+
+def prepare_chart(
+    setting: ChartSetting,
+    *,
+    helm: Helm,
+    paths: DeploymentPaths,
+    env: Mapping[str, str],
+    retry_policy: RetryPolicy,
+) -> Path:
+    """Cache and verify one resolved chart, dispatching to the schema-stripping
+    repack only for charts that declare it (currently Dagster alone)."""
+    request = setting.request()
+    if setting.repack:
+        return prepare_cached_dagster_chart_no_schema(
+            request, helm=helm, paths=paths, env=env, retry_policy=retry_policy
+        )
+    return prepare_cached_chart(request, helm=helm, paths=paths, env=env, retry_policy=retry_policy)

--- a/tools/olf/olf/deployment/cloud/aws.py
+++ b/tools/olf/olf/deployment/cloud/aws.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from olf import log
+from olf.deployment.charts import TERRAFORM_VARIABLE_KEY
 from olf.deployment.cloud.backend import FoundationFacts, output_raw_or_empty
 from olf.deployment.cloud.config import CloudDeploymentConfig
 from olf.deployment.engine import Toolkit
@@ -159,9 +160,7 @@ class AwsBackend:
             "superset_image_repository": images.superset_repository,
             "superset_image_tag": images.superset_tag,
             "superset_image_pull_policy": images.superset_pull_policy,
-            "trino_chart_package_path": str(config.charts.trino_package_path),
-            "dagster_chart_package_path": str(config.charts.dagster_package_path),
-        }
+        } | {TERRAFORM_VARIABLE_KEY[setting.name]: str(setting.package_path) for setting in config.charts.values()}
 
     def platform_destroy_variables(self, config: CloudDeploymentConfig, facts: FoundationFacts) -> dict[str, str]:
         return {

--- a/tools/olf/olf/deployment/cloud/azure.py
+++ b/tools/olf/olf/deployment/cloud/azure.py
@@ -12,6 +12,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from olf import log
+from olf.deployment.charts import TERRAFORM_VARIABLE_KEY
 from olf.deployment.cloud.backend import FoundationFacts, output_raw_or_empty
 from olf.deployment.cloud.config import CloudDeploymentConfig
 from olf.deployment.engine import Toolkit
@@ -167,9 +168,7 @@ class AzureBackend:
             "superset_image_repository": images.superset_repository,
             "superset_image_tag": images.superset_tag,
             "superset_image_pull_policy": images.superset_pull_policy,
-            "trino_chart_package_path": str(config.charts.trino_package_path),
-            "dagster_chart_package_path": str(config.charts.dagster_package_path),
-        }
+        } | {TERRAFORM_VARIABLE_KEY[setting.name]: str(setting.package_path) for setting in config.charts.values()}
 
     def platform_destroy_variables(self, config: CloudDeploymentConfig, facts: FoundationFacts) -> dict[str, str]:
         return {

--- a/tools/olf/olf/deployment/cloud/config.py
+++ b/tools/olf/olf/deployment/cloud/config.py
@@ -18,13 +18,13 @@ precedent ADR 0025 set for the local provider.
 from __future__ import annotations
 
 import subprocess
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from olf.deployment.charts import CatalogChart
-from olf.deployment.context import DeploymentContext
+from olf.deployment.charts import ChartSetting, resolve_chart_settings
+from olf.deployment.context import DeploymentContext, DeploymentFeatures
 from olf.deployment.env_settings import env as _env
 from olf.deployment.env_settings import retry_policy as _retry_policy
 from olf.deployment.env_settings import truthy as _truthy
@@ -176,18 +176,49 @@ class CloudImageSettings:
         )
 
 
+_CLOUD_ALWAYS_CHARTS = ("trino", "dagster")
+_CLOUD_IN_CLUSTER_STORAGE_CHARTS = ("seaweedfs", "polaris")
+_CLOUD_GOVERNANCE_CHARTS = ("openmetadata", "openmetadata-dependencies")
+_CLOUD_ANALYTICS_CHARTS = ("superset",)
+
+
+def _cloud_chart_names(scope: str, features: DeploymentFeatures) -> tuple[str, ...]:
+    """Every chart a given cloud scope deploys.
+
+    AWS replaces SeaweedFS/Polaris with S3/Glue, so it never installs those
+    two charts at all - unlike Azure, which (like local) runs both
+    in-cluster. Governance/analytics follow the same optional-layer gating
+    as the local provider.
+    """
+    names = list(_CLOUD_ALWAYS_CHARTS)
+    if scope != "aws":
+        names.extend(_CLOUD_IN_CLUSTER_STORAGE_CHARTS)
+    if features.governance_enabled:
+        names.extend(_CLOUD_GOVERNANCE_CHARTS)
+    if features.analytics_enabled:
+        names.extend(_CLOUD_ANALYTICS_CHARTS)
+    return tuple(names)
+
+
 @dataclass(frozen=True)
 class CloudChartSettings:
-    trino_repository_url: str
-    trino_chart_ref: str
-    trino_version: str
-    trino_package_path: Path
-    trino_sha256: str | None
-    dagster_repository_url: str
-    dagster_chart_ref: str
-    dagster_version: str
-    dagster_package_path: Path
-    dagster_sha256: str | None
+    """A resolved `ChartSetting` per chart a given cloud scope deploys.
+
+    Generalizes what used to be ten Trino/Dagster-only fields on this class -
+    see `olf.deployment.charts.resolve_chart_settings`, which both this and
+    `local.config.ChartSettings` now share.
+    """
+
+    settings: Mapping[str, ChartSetting]
+
+    def __getitem__(self, name: str) -> ChartSetting:
+        return self.settings[name]
+
+    def get(self, name: str) -> ChartSetting | None:
+        return self.settings.get(name)
+
+    def values(self) -> Iterable[ChartSetting]:
+        return self.settings.values()
 
     @classmethod
     def from_environment(
@@ -198,54 +229,25 @@ class CloudChartSettings:
         cache_root: Path,
         catalog_path: Path,
         installed: bool,
+        scope: str,
+        features: DeploymentFeatures,
     ) -> CloudChartSettings:
-        """Mirrors `olf.deployment.local.config.ChartSettings.from_environment`:
-        an installed distribution pins each chart's digest from the
-        component catalog, so a downloaded Trino/Dagster archive is verified
-        before use exactly as the local provider's Trino chart already is
+        """An installed distribution pins each chart's digest from the
+        component catalog, so a downloaded archive is verified before use
+        exactly as the local provider's charts already are
         (`prepare_cached_chart`/`prepare_cached_dagster_chart_no_schema`).
-        Source-mode runs (`installed=False`) keep resolving purely from
-        `TRINO_CHART_VERSION`/`DAGSTER_CHART_VERSION`, with `sha256=None`.
+        Source-mode runs (`installed=False`) keep resolving purely from each
+        chart's `<SLUG>_CHART_VERSION` override, with `sha256=None`.
         """
-        trino_catalog_chart = CatalogChart.load(catalog_path, "trino") if catalog_path.is_file() else None
-        dagster_catalog_chart = CatalogChart.load(catalog_path, "dagster") if catalog_path.is_file() else None
-        trino_version = _env(environ, "TRINO_CHART_VERSION", "1.42.2")
-        dagster_version = _env(environ, "DAGSTER_CHART_VERSION", "1.13.6")
-        default_trino_package_path = (
-            trino_catalog_chart.request(cache_root=cache_root).package_path
-            if installed and trino_catalog_chart is not None
-            else helm_cache_dir / f"trino-{trino_version}.tgz"
-        )
-        default_dagster_package_path = (
-            dagster_catalog_chart.request(cache_root=cache_root, variant="no-schema").package_path
-            if installed and dagster_catalog_chart is not None
-            else helm_cache_dir / f"dagster-{dagster_version}-no-schema.tgz"
-        )
         return cls(
-            trino_repository_url=_env(
+            settings=resolve_chart_settings(
+                _cloud_chart_names(scope, features),
                 environ,
-                "TRINO_CHART_REPOSITORY",
-                trino_catalog_chart.repository if trino_catalog_chart is not None else "https://trinodb.github.io/charts",
-            ),
-            trino_chart_ref="trino/trino",
-            trino_version=_env(
-                environ, "TRINO_CHART_VERSION", trino_catalog_chart.version if trino_catalog_chart else "1.42.2"
-            ),
-            trino_package_path=Path(_env(environ, "TRINO_CHART_PACKAGE_PATH", str(default_trino_package_path))),
-            trino_sha256=trino_catalog_chart.sha256 if installed and trino_catalog_chart is not None else None,
-            dagster_repository_url=_env(
-                environ,
-                "DAGSTER_CHART_REPOSITORY",
-                dagster_catalog_chart.repository if dagster_catalog_chart is not None else "https://dagster-io.github.io/helm",
-            ),
-            dagster_chart_ref="dagster/dagster",
-            dagster_version=_env(
-                environ, "DAGSTER_CHART_VERSION", dagster_catalog_chart.version if dagster_catalog_chart else "1.13.6"
-            ),
-            dagster_package_path=Path(
-                _env(environ, "DAGSTER_CHART_PACKAGE_PATH", str(default_dagster_package_path))
-            ),
-            dagster_sha256=dagster_catalog_chart.sha256 if installed and dagster_catalog_chart is not None else None,
+                helm_cache_dir=helm_cache_dir,
+                cache_root=cache_root,
+                catalog_path=catalog_path,
+                installed=installed,
+            )
         )
 
 
@@ -379,6 +381,8 @@ class CloudDeploymentConfig:
                 cache_root=context.paths.cache_root,
                 catalog_path=context.paths.distribution_root / "release/component-catalog.yaml",
                 installed=context.paths.installed,
+                scope=scope,
+                features=context.features,
             ),
             terraform=terraform,
             floe=FloeManifestSettings.from_environment(environ, work_root=context.paths.work_root, scope=scope),

--- a/tools/olf/olf/deployment/cloud/platform.py
+++ b/tools/olf/olf/deployment/cloud/platform.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping
 
 from olf import log
 from olf.deployment import kube_ops
-from olf.deployment.charts import ChartRequest, prepare_cached_chart, prepare_cached_dagster_chart_no_schema
+from olf.deployment.charts import prepare_chart
 from olf.deployment.cloud.backend import CloudBackend, FoundationFacts
 from olf.deployment.cloud.config import CloudDeploymentConfig
 from olf.deployment.engine import Toolkit
@@ -37,36 +37,14 @@ def _retry_if_logging(description: str, policy: RetryPolicy):  # noqa: ANN202
 
 
 def prepare_charts(config: CloudDeploymentConfig, tools: Toolkit, *, env: Mapping[str, str]) -> None:
-    prepare_cached_chart(
-        ChartRequest(
-            display_name="Trino",
-            repo_name="trino",
-            repo_url=config.charts.trino_repository_url,
-            chart_ref=config.charts.trino_chart_ref,
-            version=config.charts.trino_version,
-            package_path=config.charts.trino_package_path,
-            sha256=config.charts.trino_sha256,
-        ),
-        helm=tools.helm,
-        paths=config.paths,
-        env=env,
-        retry_policy=config.terraform.apply_retry,
-    )
-    prepare_cached_dagster_chart_no_schema(
-        ChartRequest(
-            display_name="Dagster",
-            repo_name="dagster",
-            repo_url=config.charts.dagster_repository_url,
-            chart_ref=config.charts.dagster_chart_ref,
-            version=config.charts.dagster_version,
-            package_path=config.charts.dagster_package_path,
-            sha256=config.charts.dagster_sha256,
-        ),
-        helm=tools.helm,
-        paths=config.paths,
-        env=env,
-        retry_policy=config.terraform.apply_retry,
-    )
+    for setting in config.charts.values():
+        prepare_chart(
+            setting,
+            helm=tools.helm,
+            paths=config.paths,
+            env=env,
+            retry_policy=config.terraform.apply_retry,
+        )
 
 
 def platform_up(

--- a/tools/olf/olf/deployment/local/config.py
+++ b/tools/olf/olf/deployment/local/config.py
@@ -8,12 +8,12 @@ corresponding shell script's `${VAR:-default}` fallback chain.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from olf.deployment.charts import CatalogChart
-from olf.deployment.context import DeploymentContext, Profile
+from olf.deployment.charts import ChartSetting, resolve_chart_settings
+from olf.deployment.context import DeploymentContext, DeploymentFeatures, Profile
 from olf.deployment.env_settings import env as _env
 from olf.deployment.env_settings import float_env as _float_env
 from olf.deployment.env_settings import int_env as _int_env
@@ -96,13 +96,43 @@ class ImageSettings:
         )
 
 
+_ALWAYS_CHARTS = ("trino", "dagster", "seaweedfs", "polaris")
+_GOVERNANCE_CHARTS = ("openmetadata", "openmetadata-dependencies")
+_ANALYTICS_CHARTS = ("superset",)
+
+
+def _local_chart_names(features: DeploymentFeatures) -> tuple[str, ...]:
+    """Every chart the local provider ever deploys, minus the ones a
+    disabled optional layer will never install - a slim-profile run must
+    not spend time downloading and verifying charts it cannot use.
+    """
+    names = list(_ALWAYS_CHARTS)
+    if features.governance_enabled:
+        names.extend(_GOVERNANCE_CHARTS)
+    if features.analytics_enabled:
+        names.extend(_ANALYTICS_CHARTS)
+    return tuple(names)
+
+
 @dataclass(frozen=True)
 class ChartSettings:
-    trino_repository_url: str
-    trino_chart_ref: str
-    trino_version: str
-    trino_package_path: Path
-    trino_sha256: str | None
+    """A resolved `ChartSetting` per chart the local provider deploys.
+
+    Generalizes what used to be five Trino-only fields on this class - see
+    `olf.deployment.charts.resolve_chart_settings`, which both this and
+    `cloud.config.CloudChartSettings` now share.
+    """
+
+    settings: Mapping[str, ChartSetting]
+
+    def __getitem__(self, name: str) -> ChartSetting:
+        return self.settings[name]
+
+    def get(self, name: str) -> ChartSetting | None:
+        return self.settings.get(name)
+
+    def values(self) -> Iterable[ChartSetting]:
+        return self.settings.values()
 
     @classmethod
     def from_environment(
@@ -113,24 +143,17 @@ class ChartSettings:
         cache_root: Path,
         catalog_path: Path,
         installed: bool,
+        features: DeploymentFeatures,
     ) -> ChartSettings:
-        catalog_chart = CatalogChart.load(catalog_path, "trino") if catalog_path.is_file() else None
-        version = _env(environ, "TRINO_CHART_VERSION", "1.42.2")
-        default_package_path = (
-            cache_root / "helm" / f"{catalog_chart.sha256}.tgz"
-            if installed and catalog_chart is not None
-            else helm_cache_dir / f"trino-{version}.tgz"
-        )
         return cls(
-            trino_repository_url=_env(
+            settings=resolve_chart_settings(
+                _local_chart_names(features),
                 environ,
-                "TRINO_CHART_REPOSITORY",
-                catalog_chart.repository if catalog_chart is not None else "https://trinodb.github.io/charts",
-            ),
-            trino_chart_ref="trino/trino",
-            trino_version=_env(environ, "TRINO_CHART_VERSION", catalog_chart.version if catalog_chart else "1.42.2"),
-            trino_package_path=Path(_env(environ, "TRINO_CHART_PACKAGE_PATH", str(default_package_path))),
-            trino_sha256=catalog_chart.sha256 if installed and catalog_chart is not None else None,
+                helm_cache_dir=helm_cache_dir,
+                cache_root=cache_root,
+                catalog_path=catalog_path,
+                installed=installed,
+            )
         )
 
 
@@ -238,6 +261,7 @@ class LocalDeploymentConfig:
                 cache_root=context.paths.cache_root,
                 catalog_path=context.paths.distribution_root / "release/component-catalog.yaml",
                 installed=context.paths.installed,
+                features=context.features,
             ),
             terraform=TerraformSettings.from_environment(
                 environ,

--- a/tools/olf/olf/deployment/local/platform.py
+++ b/tools/olf/olf/deployment/local/platform.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping
 
 from olf import log
 from olf.deployment import kube_ops
-from olf.deployment.charts import ChartRequest, prepare_cached_chart
+from olf.deployment.charts import TERRAFORM_VARIABLE_KEY, prepare_chart
 from olf.deployment.engine import Toolkit
 from olf.deployment.errors import CommandExecutionError, DeploymentPreconditionError
 from olf.deployment.local.config import LocalDeploymentConfig
@@ -28,23 +28,16 @@ def platform_var_files(config: LocalDeploymentConfig) -> tuple[str, ...]:
 
 
 def prepare_charts(config: LocalDeploymentConfig, tools: Toolkit, *, env: Mapping[str, str]) -> None:
-    """Ensure Terraform's locally referenced Trino chart archive is available."""
+    """Ensure every Terraform-referenced chart archive is cached and digest-verified."""
     config.context.prepare_directories()
-    prepare_cached_chart(
-        ChartRequest(
-            display_name="Trino",
-            repo_name="trino",
-            repo_url=config.charts.trino_repository_url,
-            chart_ref=config.charts.trino_chart_ref,
-            version=config.charts.trino_version,
-            package_path=config.charts.trino_package_path,
-            sha256=config.charts.trino_sha256,
-        ),
-        helm=tools.helm,
-        paths=config.paths,
-        env=env,
-        retry_policy=config.terraform.apply_retry,
-    )
+    for setting in config.charts.values():
+        prepare_chart(
+            setting,
+            helm=tools.helm,
+            paths=config.paths,
+            env=env,
+            retry_policy=config.terraform.apply_retry,
+        )
 
 
 def platform_apply_variables(config: LocalDeploymentConfig) -> dict[str, str]:
@@ -70,8 +63,7 @@ def platform_apply_variables(config: LocalDeploymentConfig) -> dict[str, str]:
         "superset_image_repository": images.superset_repository,
         "superset_image_tag": images.superset_tag,
         "superset_image_pull_policy": images.superset_pull_policy,
-        "trino_chart_package_path": str(config.charts.trino_package_path),
-    }
+    } | {TERRAFORM_VARIABLE_KEY[setting.name]: str(setting.package_path) for setting in config.charts.values()}
 
 
 def platform_destroy_variables(config: LocalDeploymentConfig) -> dict[str, str]:

--- a/tools/olf/olf/release/_readiness.py
+++ b/tools/olf/olf/release/_readiness.py
@@ -427,69 +427,44 @@ def _check_dockerfiles_pinned(repo_root: Path) -> CheckResult:
     return CheckResult("Dockerfile base images are digest-pinned", True)
 
 
-@dataclass(frozen=True)
-class _DeploymentWrapperChartVersion:
-    """Chart version exported by a supported platform deployment wrapper."""
-
-    path: str
-    chart: str
-    variable: str
-
-
-_DEPLOYMENT_WRAPPER_CHART_VERSIONS = (
-    _DeploymentWrapperChartVersion("tools/olf/olf/deployment/local/config.py", "trino", "TRINO_CHART_VERSION"),
-    _DeploymentWrapperChartVersion("tools/olf/olf/deployment/cloud/config.py", "trino", "TRINO_CHART_VERSION"),
-    _DeploymentWrapperChartVersion("tools/olf/olf/deployment/cloud/config.py", "dagster", "DAGSTER_CHART_VERSION"),
-)
-
-
-def _wrapper_chart_version_default(source_path: Path, variable: str) -> str | None:
-    """Read a provider config's chart-version default.
-
-    Every deployment provider (local since #124, AWS/Azure since #125) reads
-    its chart-version default through ``_env(environ, "VAR", "version")``.
-    """
-    text = source_path.read_text()
-    pattern = re.compile(rf'_env\(\s*environ,\s*"{re.escape(variable)}",\s*"(?P<version>[^"]+)"\s*\)')
-    match = pattern.search(text)
-    return match.group("version") if match else None
-
-
 def _check_chart_versions_match_deployment_wrappers(repo_root: Path) -> CheckResult:
-    """Ensure cached chart packages and Terraform module defaults stay aligned.
+    """Ensure every catalog-routed chart's fallback default and Terraform
+    module default stay aligned, and that the two chart sets match exactly.
 
-    The platform wrappers pass chart package paths to Terraform for Trino and
-    Dagster, which bypasses each module's ``helm_release.version`` argument.
-    The compatibility matrix is still sourced from the module defaults, so
-    every wrapper default must match that matrix value.
+    Every deployment provider (#124 local, #125 AWS/Azure) now resolves
+    every deployed chart through `olf.deployment.charts.CHART_DEFAULTS`
+    rather than a Trino/Dagster-only pair of hardcoded fields (#147) - a
+    chart added to a Terraform module without a matching `CHART_DEFAULTS`
+    entry would otherwise fetch straight from its upstream repository,
+    unverified against the component catalog, and go unnoticed exactly as
+    5 of the 7 catalog charts did before this check existed.
     """
+    from olf.deployment.charts import CHART_DEFAULTS
+
     module_versions = _helm_chart_versions_from_terraform_modules(repo_root)
+    module_charts = frozenset(module_versions)
+    default_charts = frozenset(CHART_DEFAULTS)
+
     problems: list[str] = []
+    only_in_terraform = sorted(module_charts - default_charts)
+    if only_in_terraform:
+        problems.append(f"Terraform module chart(s) with no CHART_DEFAULTS entry: {', '.join(only_in_terraform)}")
+    only_in_defaults = sorted(default_charts - module_charts)
+    if only_in_defaults:
+        problems.append(f"CHART_DEFAULTS entry with no Terraform module: {', '.join(only_in_defaults)}")
+
     checked = 0
-    for source in _DEPLOYMENT_WRAPPER_CHART_VERSIONS:
-        source_path = repo_root / source.path
-        if not source_path.is_file():
-            problems.append(f"{source.path}: deployment wrapper does not exist")
-            continue
-        wrapper_version = _wrapper_chart_version_default(source_path, source.variable)
-        if wrapper_version is None:
-            problems.append(f"{source.path}: missing {source.variable} default")
-            continue
-        module_version = module_versions.get(source.chart)
-        if module_version is None:
-            problems.append(f"{source.path}: no Terraform chart_version default for {source.chart}")
-            continue
+    for name in sorted(module_charts & default_charts):
         checked += 1
-        if wrapper_version != module_version:
+        default_version = CHART_DEFAULTS[name].version
+        module_version = module_versions[name]
+        if default_version != module_version:
             problems.append(
-                f"{source.path}: {source.variable}={wrapper_version!r} but "
-                f"Terraform {source.chart} chart_version={module_version!r}"
+                f"{name}: CHART_DEFAULTS version={default_version!r} but Terraform chart_version={module_version!r}"
             )
     if problems:
-        return CheckResult(
-            "Helm chart versions match deployment wrappers", False, "; ".join(problems)
-        )
-    return CheckResult("Helm chart versions match deployment wrappers", True, f"{checked} wrapper value(s) checked")
+        return CheckResult("Helm chart versions match deployment wrappers", False, "; ".join(problems))
+    return CheckResult("Helm chart versions match deployment wrappers", True, f"{checked} chart(s) checked")
 
 
 def run_release_check(

--- a/tools/olf/tests/test_cloud_aws.py
+++ b/tools/olf/tests/test_cloud_aws.py
@@ -294,6 +294,9 @@ def test_platform_apply_variables_include_aws_region_and_resolved_repository(tmp
         "superset_image_pull_policy",
         "trino_chart_package_path",
         "dagster_chart_package_path",
+        "openmetadata_chart_package_path",
+        "openmetadata_deps_chart_package_path",
+        "superset_chart_package_path",
     }
 
 

--- a/tools/olf/tests/test_cloud_azure.py
+++ b/tools/olf/tests/test_cloud_azure.py
@@ -343,6 +343,11 @@ def test_platform_apply_variables_have_no_aws_region(tmp_path: Path) -> None:
         "superset_image_pull_policy",
         "trino_chart_package_path",
         "dagster_chart_package_path",
+        "seaweedfs_chart_package_path",
+        "polaris_chart_package_path",
+        "openmetadata_chart_package_path",
+        "openmetadata_deps_chart_package_path",
+        "superset_chart_package_path",
     }
 
 

--- a/tools/olf/tests/test_cloud_config.py
+++ b/tools/olf/tests/test_cloud_config.py
@@ -10,7 +10,7 @@ from olf.deployment.cloud.config import (
     CloudTerraformSettings,
     default_image_tag,
 )
-from olf.deployment.context import DeploymentContext
+from olf.deployment.context import DeploymentContext, DeploymentFeatures
 
 
 def test_aws_image_settings_defaults_to_ecr_public_python_base_image() -> None:
@@ -76,32 +76,42 @@ def test_provider_prefixed_image_aliases_are_honored_after_generic_overrides() -
         assert generic_wins.project_code_tag == "generic"
 
 
+_FULL_FEATURES = DeploymentFeatures(governance_enabled=True, analytics_enabled=True)
+
+
 def _no_catalog_kwargs(tmp_path: Path) -> dict:
     return {
         "cache_root": tmp_path / "cache",
         "catalog_path": tmp_path / "no-such-catalog.yaml",
         "installed": False,
+        "scope": "aws",
+        "features": _FULL_FEATURES,
     }
 
 
 def _write_catalog(tmp_path: Path, *, trino_sha256: str, dagster_sha256: str) -> Path:
+    """A catalog covering every chart `CloudChartSettings` might resolve -
+    a real `component-catalog.yaml` always declares all of them, so a
+    partial fixture would make `CatalogChart.load` raise for any chart
+    beyond the two this fixture used to focus on."""
+    from olf.deployment.charts import CHART_DEFAULTS
+
+    overrides = {"trino": trino_sha256, "dagster": dagster_sha256}
+    lines = ["components:", "  helm:", "    charts:"]
+    for index, (name, default) in enumerate(CHART_DEFAULTS.items()):
+        sha256 = overrides.get(name, f"{index:0>2}" * 32)
+        lines.extend(
+            [
+                f"      {name}:",
+                f"        repository: {default.repository}",
+                f"        reference: {default.chart_ref}",
+                f"        version: {default.version}",
+                f'        sha256: "{sha256}"',
+            ]
+        )
     catalog_path = tmp_path / "release/component-catalog.yaml"
     catalog_path.parent.mkdir(parents=True, exist_ok=True)
-    catalog_path.write_text(
-        "components:\n"
-        "  helm:\n"
-        "    charts:\n"
-        "      trino:\n"
-        "        repository: https://trinodb.github.io/charts\n"
-        "        reference: trino/trino\n"
-        "        version: 1.42.2\n"
-        f"        sha256: {trino_sha256}\n"
-        "      dagster:\n"
-        "        repository: https://dagster-io.github.io/helm\n"
-        "        reference: dagster/dagster\n"
-        "        version: 1.13.6\n"
-        f"        sha256: {dagster_sha256}\n"
-    )
+    catalog_path.write_text("\n".join(lines) + "\n")
     return catalog_path
 
 
@@ -112,12 +122,50 @@ def test_chart_settings_defaults_trino_and_dagster_package_paths(tmp_path: Path)
         {}, helm_cache_dir=helm_cache_dir, **_no_catalog_kwargs(tmp_path)
     )
 
-    assert settings.trino_package_path == helm_cache_dir / "trino-1.42.2.tgz"
-    assert settings.dagster_package_path == helm_cache_dir / "dagster-1.13.6-no-schema.tgz"
-    assert settings.trino_chart_ref == "trino/trino"
-    assert settings.dagster_chart_ref == "dagster/dagster"
-    assert settings.trino_sha256 is None
-    assert settings.dagster_sha256 is None
+    assert settings["trino"].package_path == helm_cache_dir / "trino-1.42.2.tgz"
+    assert settings["dagster"].package_path == helm_cache_dir / "dagster-1.13.6-no-schema.tgz"
+    assert settings["trino"].chart_ref == "trino/trino"
+    assert settings["dagster"].chart_ref == "dagster/dagster"
+    assert settings["trino"].sha256 is None
+    assert settings["dagster"].sha256 is None
+
+
+def test_chart_settings_scope_excludes_seaweedfs_and_polaris_for_aws(tmp_path: Path) -> None:
+    settings = CloudChartSettings.from_environment(
+        {}, helm_cache_dir=tmp_path / "helm/aws/charts", **_no_catalog_kwargs(tmp_path)
+    )
+
+    assert set(settings.settings) == {
+        "trino",
+        "dagster",
+        "openmetadata",
+        "openmetadata-dependencies",
+        "superset",
+    }
+
+
+def test_chart_settings_scope_includes_seaweedfs_and_polaris_for_azure(tmp_path: Path) -> None:
+    kwargs = _no_catalog_kwargs(tmp_path)
+    kwargs["scope"] = "azure"
+    settings = CloudChartSettings.from_environment({}, helm_cache_dir=tmp_path / "helm/azure/charts", **kwargs)
+
+    assert set(settings.settings) == {
+        "trino",
+        "dagster",
+        "seaweedfs",
+        "polaris",
+        "openmetadata",
+        "openmetadata-dependencies",
+        "superset",
+    }
+
+
+def test_chart_settings_slim_profile_excludes_governance_and_analytics_charts(tmp_path: Path) -> None:
+    kwargs = _no_catalog_kwargs(tmp_path)
+    kwargs["features"] = DeploymentFeatures(governance_enabled=False, analytics_enabled=False)
+    settings = CloudChartSettings.from_environment({}, helm_cache_dir=tmp_path / "helm/aws/charts", **kwargs)
+
+    assert set(settings.settings) == {"trino", "dagster"}
 
 
 def test_chart_settings_honors_explicit_package_path_overrides(tmp_path: Path) -> None:
@@ -133,8 +181,8 @@ def test_chart_settings_honors_explicit_package_path_overrides(tmp_path: Path) -
         **_no_catalog_kwargs(tmp_path),
     )
 
-    assert settings.trino_package_path == trino_override
-    assert settings.dagster_package_path == dagster_override
+    assert settings["trino"].package_path == trino_override
+    assert settings["dagster"].package_path == dagster_override
 
 
 def test_chart_settings_pins_digests_from_catalog_when_installed(tmp_path: Path) -> None:
@@ -153,14 +201,16 @@ def test_chart_settings_pins_digests_from_catalog_when_installed(tmp_path: Path)
         cache_root=cache_root,
         catalog_path=catalog_path,
         installed=True,
+        scope="aws",
+        features=_FULL_FEATURES,
     )
 
-    assert settings.trino_sha256 == trino_sha256
-    assert settings.dagster_sha256 == dagster_sha256
-    assert settings.trino_package_path == cache_root / "helm" / f"{trino_sha256}.tgz"
-    assert settings.dagster_package_path == cache_root / "helm" / f"{dagster_sha256}-no-schema.tgz"
-    assert settings.trino_version == "1.42.2"
-    assert settings.dagster_version == "1.13.6"
+    assert settings["trino"].sha256 == trino_sha256
+    assert settings["dagster"].sha256 == dagster_sha256
+    assert settings["trino"].package_path == cache_root / "helm" / f"{trino_sha256}.tgz"
+    assert settings["dagster"].package_path == cache_root / "helm" / f"{dagster_sha256}-no-schema.tgz"
+    assert settings["trino"].version == "1.42.2"
+    assert settings["dagster"].version == "1.13.6"
 
 
 def test_chart_settings_does_not_pin_digests_in_source_mode_even_with_a_catalog(tmp_path: Path) -> None:
@@ -172,10 +222,12 @@ def test_chart_settings_does_not_pin_digests_in_source_mode_even_with_a_catalog(
         cache_root=tmp_path / "cache",
         catalog_path=catalog_path,
         installed=False,
+        scope="aws",
+        features=_FULL_FEATURES,
     )
 
-    assert settings.trino_sha256 is None
-    assert settings.dagster_sha256 is None
+    assert settings["trino"].sha256 is None
+    assert settings["dagster"].sha256 is None
 
 
 def test_aws_terraform_settings_uses_default_tfvars_only_if_it_exists(tmp_path: Path) -> None:

--- a/tools/olf/tests/test_cloud_platform.py
+++ b/tools/olf/tests/test_cloud_platform.py
@@ -82,8 +82,8 @@ class _PlatformScriptedRunner(RecordingRunner):
 def test_platform_up_skips_superset_build_when_analytics_disabled(tmp_path: Path) -> None:
     config = _config(tmp_path, enable_analytics="false")
     config.paths.helm_cache_dir.mkdir(parents=True, exist_ok=True)
-    config.charts.trino_package_path.write_text("cached")
-    config.charts.dagster_package_path.write_text("cached")
+    config.charts["trino"].package_path.write_text("cached")
+    config.charts["dagster"].package_path.write_text("cached")
     backend = FakeCloudBackend(scope="aws")
     tools = _toolkit(_PlatformScriptedRunner())
 
@@ -95,8 +95,8 @@ def test_platform_up_skips_superset_build_when_analytics_disabled(tmp_path: Path
 def test_platform_up_builds_superset_when_analytics_enabled(tmp_path: Path) -> None:
     config = _config(tmp_path, enable_analytics="true")
     config.paths.helm_cache_dir.mkdir(parents=True, exist_ok=True)
-    config.charts.trino_package_path.write_text("cached")
-    config.charts.dagster_package_path.write_text("cached")
+    config.charts["trino"].package_path.write_text("cached")
+    config.charts["dagster"].package_path.write_text("cached")
     backend = FakeCloudBackend(scope="aws")
     tools = _toolkit(_PlatformScriptedRunner())
 
@@ -108,8 +108,8 @@ def test_platform_up_builds_superset_when_analytics_enabled(tmp_path: Path) -> N
 def test_platform_up_uses_backend_apply_variables_and_var_file(tmp_path: Path) -> None:
     config = _config(tmp_path, enable_analytics="false")
     config.paths.helm_cache_dir.mkdir(parents=True, exist_ok=True)
-    config.charts.trino_package_path.write_text("cached")
-    config.charts.dagster_package_path.write_text("cached")
+    config.charts["trino"].package_path.write_text("cached")
+    config.charts["dagster"].package_path.write_text("cached")
     backend = FakeCloudBackend(scope="aws")
     runner = _PlatformScriptedRunner()
     tools = _toolkit(runner)
@@ -134,8 +134,8 @@ def test_platform_up_never_passes_var_file_to_azure_apply_even_with_explicit_ove
     context = DeploymentContext.azure(repo_root=tmp_path, profile=Profile.SLIM)
     config = CloudDeploymentConfig.from_environment({}, context=context, var_file=explicit)
     config.paths.helm_cache_dir.mkdir(parents=True, exist_ok=True)
-    config.charts.trino_package_path.write_text("cached")
-    config.charts.dagster_package_path.write_text("cached")
+    config.charts["trino"].package_path.write_text("cached")
+    config.charts["dagster"].package_path.write_text("cached")
     backend = FakeCloudBackend(scope="azure")
     runner = _PlatformScriptedRunner()
     tools = _toolkit(runner)
@@ -149,8 +149,8 @@ def test_platform_up_never_passes_var_file_to_azure_apply_even_with_explicit_ove
 def test_platform_up_cleans_up_polaris_jobs_only_when_backend_requests_it(tmp_path: Path) -> None:
     config = _config(tmp_path, enable_analytics="false")
     config.paths.helm_cache_dir.mkdir(parents=True, exist_ok=True)
-    config.charts.trino_package_path.write_text("cached")
-    config.charts.dagster_package_path.write_text("cached")
+    config.charts["trino"].package_path.write_text("cached")
+    config.charts["dagster"].package_path.write_text("cached")
 
     backend_no_cleanup = FakeCloudBackend(scope="aws", cleanup_polaris=False)
     tools = _toolkit(_PlatformScriptedRunner())

--- a/tools/olf/tests/test_local_config.py
+++ b/tools/olf/tests/test_local_config.py
@@ -6,6 +6,32 @@ from olf.deployment.context import DeploymentContext, Profile
 from olf.deployment.local.config import LocalDeploymentConfig
 
 
+def _write_full_catalog(repo_root: Path, *, overrides: dict[str, str] | None = None) -> Path:
+    """A catalog covering every chart the local provider might resolve - a
+    real `component-catalog.yaml` always declares all of them, so a partial
+    fixture would make `CatalogChart.load` raise for any chart beyond the
+    one(s) a given test focuses on."""
+    from olf.deployment.charts import CHART_DEFAULTS
+
+    overrides = overrides or {}
+    lines = ["components:", "  helm:", "    charts:"]
+    for index, (name, default) in enumerate(CHART_DEFAULTS.items()):
+        sha256 = overrides.get(name, f"{index:0>2}" * 32)
+        lines.extend(
+            [
+                f"      {name}:",
+                f"        repository: {default.repository}",
+                f"        reference: {default.chart_ref}",
+                f"        version: {default.version}",
+                f'        sha256: "{sha256}"',
+            ]
+        )
+    catalog_path = repo_root / "release/component-catalog.yaml"
+    catalog_path.parent.mkdir(parents=True, exist_ok=True)
+    catalog_path.write_text("\n".join(lines) + "\n")
+    return catalog_path
+
+
 def test_full_profile_defaults(tmp_path: Path) -> None:
     context = DeploymentContext.local(repo_root=tmp_path, profile=Profile.FULL)
 
@@ -18,8 +44,17 @@ def test_full_profile_defaults(tmp_path: Path) -> None:
     assert config.images.project_code_image == "ghcr.io/openlakeforge/project-code:local"
     assert config.images.superset_image == "ghcr.io/openlakeforge/superset:local"
     assert config.images.project_code_pull_policy == "Never"
-    assert config.charts.trino_version == "1.42.2"
-    assert config.charts.trino_package_path == context.paths.helm_cache_dir / "trino-1.42.2.tgz"
+    assert config.charts["trino"].version == "1.42.2"
+    assert config.charts["trino"].package_path == context.paths.helm_cache_dir / "trino-1.42.2.tgz"
+    assert set(config.charts.settings) == {
+        "trino",
+        "dagster",
+        "seaweedfs",
+        "polaris",
+        "openmetadata",
+        "openmetadata-dependencies",
+        "superset",
+    }
     assert config.terraform.var_file is None
     assert config.terraform.apply_retry.max_attempts == 4
     assert config.terraform.apply_retry.delay_seconds == 20.0
@@ -99,19 +134,8 @@ def test_installed_default_project_still_pins_the_catalog_chart_digest(tmp_path:
     Trino chart Helm downloaded instead of verifying the catalog digest.
     """
     payload = tmp_path / "payload"
-    catalog = payload / "release/component-catalog.yaml"
-    catalog.parent.mkdir(parents=True)
     digest = "a" * 64
-    catalog.write_text(
-        "components:\n"
-        "  helm:\n"
-        "    charts:\n"
-        "      trino:\n"
-        "        repository: https://trinodb.github.io/charts\n"
-        "        reference: trino/trino\n"
-        "        version: 1.42.2\n"
-        f"        sha256: {digest}\n"
-    )
+    _write_full_catalog(payload, overrides={"trino": digest})
     context = DeploymentContext.local(
         repo_root=payload,
         distribution_root=payload,
@@ -122,28 +146,17 @@ def test_installed_default_project_still_pins_the_catalog_chart_digest(tmp_path:
 
     config = LocalDeploymentConfig.from_environment({}, context=context)
 
-    assert config.charts.trino_sha256 == digest
-    assert config.charts.trino_package_path == tmp_path / "cache/helm" / f"{digest}.tgz"
+    assert config.charts["trino"].sha256 == digest
+    assert config.charts["trino"].package_path == tmp_path / "cache/helm" / f"{digest}.tgz"
 
 
 def test_source_checkout_does_not_pin_chart_digests(tmp_path: Path) -> None:
-    catalog = tmp_path / "release/component-catalog.yaml"
-    catalog.parent.mkdir(parents=True)
-    catalog.write_text(
-        "components:\n"
-        "  helm:\n"
-        "    charts:\n"
-        "      trino:\n"
-        "        repository: https://trinodb.github.io/charts\n"
-        "        reference: trino/trino\n"
-        "        version: 1.42.2\n"
-        f"        sha256: {'a' * 64}\n"
-    )
+    _write_full_catalog(tmp_path, overrides={"trino": "a" * 64})
     context = DeploymentContext.local(repo_root=tmp_path)
 
     config = LocalDeploymentConfig.from_environment({}, context=context)
 
-    assert config.charts.trino_sha256 is None
+    assert config.charts["trino"].sha256 is None
 
 
 def test_relative_local_var_file_resolves_against_the_writable_project(tmp_path: Path) -> None:

--- a/tools/olf/tests/test_local_platform.py
+++ b/tools/olf/tests/test_local_platform.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -52,6 +54,23 @@ def _fail() -> CommandResult:
     return CommandResult(argv=(), returncode=1, stdout="", stderr="", duration_seconds=0.0)
 
 
+def _fake_dagster_archive_bytes() -> bytes:
+    """A minimal real gzip tarball shaped like `helm pull`'s Dagster output -
+    see `test_deployment_charts.py`'s identical helper for why the schema-
+    stripping repack needs a real archive rather than a `RecordingRunner`
+    stub, even for a chart source mode never digest-verifies."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as bundle:
+        for name, content in (
+            (b"dagster/Chart.yaml", b"name: dagster\n"),
+            (b"dagster/values.schema.json", b"{}"),
+        ):
+            info = tarfile.TarInfo(name.decode())
+            info.size = len(content)
+            bundle.addfile(info, io.BytesIO(content))
+    return buffer.getvalue()
+
+
 def test_platform_apply_variables_exact_order(tmp_path: Path) -> None:
     config = _config(tmp_path)
 
@@ -74,9 +93,29 @@ def test_platform_apply_variables_exact_order(tmp_path: Path) -> None:
         "superset_image_tag",
         "superset_image_pull_policy",
         "trino_chart_package_path",
+        "dagster_chart_package_path",
+        "seaweedfs_chart_package_path",
+        "polaris_chart_package_path",
+        "openmetadata_chart_package_path",
+        "openmetadata_deps_chart_package_path",
+        "superset_chart_package_path",
     ]
     assert variables["enable_governance"] == "true"
     assert variables["enable_analytics"] == "true"
+
+
+def test_platform_apply_variables_slim_profile_omits_disabled_layer_charts(tmp_path: Path) -> None:
+    config = _config(tmp_path, profile=Profile.SLIM)
+
+    variables = platform.platform_apply_variables(config)
+
+    assert "openmetadata_chart_package_path" not in variables
+    assert "openmetadata_deps_chart_package_path" not in variables
+    assert "superset_chart_package_path" not in variables
+    assert "trino_chart_package_path" in variables
+    assert "dagster_chart_package_path" in variables
+    assert "seaweedfs_chart_package_path" in variables
+    assert "polaris_chart_package_path" in variables
 
 
 def test_platform_destroy_variables_are_the_four_var_subset(tmp_path: Path) -> None:
@@ -143,6 +182,15 @@ class _PlatformScriptedRunner(RecordingRunner):
             return _ok()
         if argv[0] == "helm" and "show" in argv:
             return CommandResult(argv=(), returncode=1, stdout="", stderr="", duration_seconds=0.0)
+        if argv[0] == "helm" and "pull" in argv and "dagster/dagster" in argv:
+            destination = Path(argv[argv.index("--destination") + 1])
+            version = argv[argv.index("--version") + 1]
+            destination.mkdir(parents=True, exist_ok=True)
+            (destination / f"dagster-{version}.tgz").write_bytes(_fake_dagster_archive_bytes())
+        if argv[0] == "helm" and "package" in argv:
+            destination = Path(argv[argv.index("--destination") + 1])
+            destination.mkdir(parents=True, exist_ok=True)
+            (destination / "dagster-1.13.6.tgz").write_bytes(b"fake-repacked-chart")
         return _ok()
 
 

--- a/tools/olf/tests/test_release_readiness.py
+++ b/tools/olf/tests/test_release_readiness.py
@@ -330,32 +330,34 @@ def test_check_images_match_deployment_sources_requires_every_registered_image_i
     assert "trino: registered deployment image is missing from the component catalog" in result.detail
 
 
-def test_chart_versions_match_deployment_wrappers_flags_cached_chart_drift(tmp_path: Path) -> None:
-    trino_module = tmp_path / "infra/terraform/modules/query/trino"
-    dagster_module = tmp_path / "infra/terraform/modules/orchestration/dagster"
-    trino_module.mkdir(parents=True)
-    dagster_module.mkdir(parents=True)
-    (trino_module / "variables.tf").write_text(
-        'variable "chart_version" {\n  default = "1.42.2"\n}\n'
-    )
-    (dagster_module / "variables.tf").write_text(
-        'variable "chart_version" {\n  default = "1.13.6"\n}\n'
-    )
-    for path, contents in {
-        "tools/olf/olf/deployment/local/config.py": '_env(environ, "TRINO_CHART_VERSION", "9.9.9")\n',
-        "tools/olf/olf/deployment/cloud/config.py": (
-            '_env(environ, "TRINO_CHART_VERSION", "1.42.2")\n'
-            '_env(environ, "DAGSTER_CHART_VERSION", "1.13.6")\n'
-        ),
-    }.items():
-        wrapper_path = tmp_path / path
-        wrapper_path.parent.mkdir(parents=True, exist_ok=True)
-        wrapper_path.write_text(contents)
+def _write_chart_module(tmp_path: Path, module_path: str, *, version: str, deps_version: str | None = None) -> None:
+    module_dir = tmp_path / "infra/terraform/modules" / module_path
+    module_dir.mkdir(parents=True)
+    body = f'variable "chart_version" {{\n  default = "{version}"\n}}\n'
+    if deps_version is not None:
+        body += f'variable "deps_chart_version" {{\n  default = "{deps_version}"\n}}\n'
+    (module_dir / "variables.tf").write_text(body)
+
+
+def test_chart_versions_match_deployment_wrappers_flags_version_drift(tmp_path: Path) -> None:
+    _write_chart_module(tmp_path, "query/trino", version="9.9.9")
 
     result = _readiness._check_chart_versions_match_deployment_wrappers(tmp_path)
 
     assert not result.ok
-    assert "TRINO_CHART_VERSION='9.9.9'" in result.detail
+    assert "trino: CHART_DEFAULTS version=" in result.detail
+    assert "9.9.9" in result.detail
+
+
+def test_chart_versions_match_deployment_wrappers_flags_terraform_only_chart(tmp_path: Path) -> None:
+    _write_chart_module(tmp_path, "query/trino", version="1.42.2")
+    _write_chart_module(tmp_path, "storage/not-a-catalog-chart", version="1.0.0")
+
+    result = _readiness._check_chart_versions_match_deployment_wrappers(tmp_path)
+
+    assert not result.ok
+    assert "not-a-catalog-chart" in result.detail
+    assert "no CHART_DEFAULTS entry" in result.detail
 
 
 def test_chart_versions_match_deployment_wrappers_passes_on_real_repo() -> None:


### PR DESCRIPTION
## Summary

Fixes #147.

Only Trino (all providers) and Dagster (cloud only) were routed through the digest-verified chart cache (`olf.deployment.charts.prepare_cached_chart`/`prepare_cached_dagster_chart_no_schema`) before their Terraform module consumed a pre-verified local `.tgz`. SeaweedFS, Polaris, OpenMetadata, OpenMetadata-dependencies, and Superset all fetched straight from their upstream `repository` + `version` at `terraform apply` time — so `olf check components`'s "catalog Helm charts are immutable" check could report all 7 charts pinned while 5 of them were never actually verified against that pin, and a compromised or altered chart repository could serve different content under the pinned version undetected.

- Generalized the Trino/Dagster-only chart plumbing in [`charts.py`](tools/olf/olf/deployment/charts.py) into a shared `CHART_DEFAULTS` table plus `resolve_chart_settings`/`prepare_chart` helpers both providers now use for every catalog chart.
- `local.config.ChartSettings` / `cloud.config.CloudChartSettings` are now mapping-based (`config.charts["trino"].package_path`), gated by profile (slim skips governance/analytics charts) and cloud scope (AWS skips SeaweedFS/Polaris — S3/Glue instead).
- Added `chart_package_path` Terraform variables to `storage/seaweedfs`, `catalog/polaris`, `governance/openmetadata` (plus `deps_chart_package_path`), and `analytics/superset`, following the existing Trino/Dagster pattern exactly. Wired all three environment roots (`local`, `aws-poc`, `azure-poc`) — **local now also verifies Dagster**, which it never did before (only cloud had it).
- Replaced the release-readiness check's source-text regex scraping (`_check_chart_versions_match_deployment_wrappers`) with one that imports `CHART_DEFAULTS` directly and asserts the chart sets match exactly. A chart added to a Terraform module without a matching entry now fails `olf check all` instead of silently reporting "N chart(s) checked".
- Small fix in an already-touched file: Superset's `chart_repository` default was `http://apache.github.io/superset/`; flipped to `https://` to match the catalog pin.

## Test plan

- [x] `uv run --project tools/olf pytest tools/olf/tests` — 1055 passed
- [x] `uv run --project tools/olf ruff check tools/olf` — clean
- [x] `uv run --project tools/olf olf check all` — all checks pass, including `catalog Helm charts are immutable: 7 chart(s) checked` and `Helm chart versions match deployment wrappers: 7 chart(s) checked`. The one failure in this run (`project-code check requires Python >=3.12,<3.13; found 3.14`) is a pre-existing local-environment Python version mismatch, unrelated to this change.
- [x] `terraform validate` on every touched module (`storage/seaweedfs`, `catalog/polaris`, `governance/openmetadata`, `analytics/superset`, `query/trino`, `orchestration/dagster`) and all three environment roots (`local`, `aws-poc`, `azure-poc`)
- [ ] A real `olf deploy --provider local` / `olf e2e run --env local` run — **not done**. There's already a running `openlakeforge-local` kind cluster on the machine this PR was authored on (from unrelated work), and this repo's Terraform/OLF state can be shared across worktrees, so a real deploy risked conflicting with it. This should be run once that cluster is free, since chart-wiring bugs won't reliably surface from unit tests alone.