### PR TITLE
fix: scope each PyPI publish job to its own GitHub Environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,8 +249,18 @@ jobs:
           path: dist/python/openlakeforge
           if-no-files-found: error
 
-  publish-pypi:
-    name: Publish Python distributions to PyPI
+  # Two separate jobs, not two steps in one job: PyPI keys a Trusted
+  # Publisher (pending or not) by (owner, repo, workflow, environment).
+  # Neither publish step used to declare a `environment:`, so both
+  # projects resolved to the identical tuple and PyPI refused to register
+  # the second pending publisher ("already been registered for a
+  # different project name"). Giving each job its own `environment:`
+  # makes the two tuples distinct, which is the only thing that changes
+  # here - the two publishes have no ordering dependency on each other
+  # (PyPI publish doesn't resolve dependencies), so running them as
+  # parallel jobs is also strictly faster than the old sequential steps.
+  publish-pypi-domain-model:
+    name: Publish openlakeforge-domain-model to PyPI
     # Every fallible release step (image build/sign/attest) must finish
     # before either package reaches PyPI: PyPI publication is irreversible
     # (no re-upload of the same filenames), while an image or bundle
@@ -260,6 +270,7 @@ jobs:
     # `[prepare, python-packages]`.
     needs: [prepare, python-packages, build]
     runs-on: ubuntu-latest
+    environment: pypi-domain-model
     steps:
       - name: Download domain-model distribution
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -267,21 +278,16 @@ jobs:
           name: domain-model-distribution-${{ needs.prepare.outputs.version }}
           path: dist/domain-model
 
-      - name: Download openlakeforge distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: openlakeforge-distribution-${{ needs.prepare.outputs.version }}
-          path: dist/openlakeforge
-
-      # PyPI Trusted Publishing must be configured for this workflow and both
-      # projects before the first tagged release. The action uses this job's
-      # short-lived GitHub OIDC identity and creates PyPI attestations.
+      # PyPI Trusted Publishing must be configured for this workflow,
+      # environment, and project before the first tagged release. The
+      # action uses this job's short-lived GitHub OIDC identity and
+      # creates PyPI attestations.
       #
-      # skip-existing makes each publish step idempotent: if this job is
-      # re-run after the domain-model package already reached PyPI (e.g. the
-      # openlakeforge upload failed, or a later job in this workflow did),
-      # PyPI's rejection of the already-published filenames is treated as
-      # success instead of failing the rerun.
+      # skip-existing makes this step idempotent: if this job is re-run
+      # after the package already reached PyPI (e.g. this job succeeded
+      # but a later job in the workflow failed), PyPI's rejection of the
+      # already-published filenames is treated as success instead of
+      # failing the rerun.
       - name: Publish openlakeforge-domain-model to PyPI
         if: needs.prepare.outputs.dry_run == 'false'
         uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
@@ -289,6 +295,18 @@ jobs:
           packages-dir: dist/domain-model
           attestations: true
           skip-existing: true
+
+  publish-pypi-openlakeforge:
+    name: Publish openlakeforge to PyPI
+    needs: [prepare, python-packages, build]
+    runs-on: ubuntu-latest
+    environment: pypi-openlakeforge
+    steps:
+      - name: Download openlakeforge distribution
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: openlakeforge-distribution-${{ needs.prepare.outputs.version }}
+          path: dist/openlakeforge
 
       - name: Publish openlakeforge to PyPI
         if: needs.prepare.outputs.dry_run == 'false'
@@ -430,7 +448,7 @@ jobs:
 
   bundle:
     name: Assemble and publish the release bundle
-    needs: [prepare, python-packages, publish-pypi, build]
+    needs: [prepare, python-packages, publish-pypi-domain-model, publish-pypi-openlakeforge, build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/release/releasing.md
+++ b/docs/release/releasing.md
@@ -52,6 +52,15 @@ See [ADR 0008](../adr/0008-olf-owns-orchestration-and-toolchain.md).
 
 ## Cutting a release
 
+0. **Before the first tagged release only**: register a PyPI [pending
+   trusted publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
+   for each of `openlakeforge-domain-model` and `openlakeforge`, pointed at
+   this repo's `release.yml`. Each must use a **distinct GitHub Environment
+   name** (`pypi-domain-model` and `pypi-openlakeforge`, matching the
+   `environment:` key on each `publish-pypi-*` job) — PyPI keys a pending
+   publisher by `(owner, repo, workflow, environment)`, and both jobs
+   sharing this repo and workflow file means an identical, un-scoped
+   environment would collide across the two project names.
 1. Update `release/component-catalog.yaml`'s `distribution.version` (and any
    changed component versions/digests/lockfiles) in the same PR as the code
    it describes. Run `uv run --project tools/olf --locked olf check all` locally.


### PR DESCRIPTION
## Summary
- PyPI keys a (pending) trusted publisher by `(owner, repo, workflow, environment)`. Both `openlakeforge-domain-model` and `openlakeforge` published as steps in one `publish-pypi` job with no `environment:` set, so both projects resolved to the identical tuple — PyPI refused to register the second pending publisher ("already been registered for a different project name").
- Splits `publish-pypi` into `publish-pypi-domain-model` and `publish-pypi-openlakeforge`, each with a distinct `environment:` key (`pypi-domain-model` / `pypi-openlakeforge`). The two publishes have no ordering dependency on each other, so this also runs them in parallel instead of sequentially.
- Documents the required two-environment pending-publisher setup as a new step 0 in `docs/release/releasing.md`.

## Test plan
- [x] `olf release check` passes on top of current `main` (12 catalog checks, all PASS)
- [x] `.github/workflows/release.yml` parses as valid YAML
- [x] Register the two PyPI pending publishers with the new environment names before the next tag push