### PR TITLE
fix: bump pypa/gh-action-pypi-publish to fix Metadata-Version 2.4 rejection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
       # failing the rerun.
       - name: Publish openlakeforge-domain-model to PyPI
         if: needs.prepare.outputs.dry_run == 'false'
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         with:
           packages-dir: dist/domain-model
           attestations: true
@@ -310,7 +310,7 @@ jobs:
 
       - name: Publish openlakeforge to PyPI
         if: needs.prepare.outputs.dry_run == 'false'
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         with:
           packages-dir: dist/openlakeforge
           attestations: true

--- a/release/component-catalog.yaml
+++ b/release/component-catalog.yaml
@@ -111,7 +111,7 @@ components:
     actions/attest-build-provenance: e8998f949152b193b063cb0ec769d69d929409be
     actions/upload-artifact: ea165f8d65b6e75b540449e92b4886f43607fa02
     actions/download-artifact: d3f86a106a0bac45b974a628896c90dbdf5c8093
-    pypa/gh-action-pypi-publish: ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
+    pypa/gh-action-pypi-publish: dc37677b2e1c63e2034f94d8a5b11f265b73ba33
     softprops/action-gh-release: fe965f7af51af5f2602596916f38a38df2e33de0
 update_process:
   owner: release-engineering


### PR DESCRIPTION
## Summary
- The v0.2.0-alpha.1 release attempt's real (non-dry-run) PyPI publish failed for both packages: `InvalidDistribution: Metadata is missing required fields: Name, Version` — https://github.com/malon64/openlakeforge/actions/runs/33070013405
- Root cause: the pinned `pypa/gh-action-pypi-publish@ec4db0b4...` SHA dates to June 2024 and bundles `twine` < 5.1, which predates PEP 639 Metadata-Version 2.4 support. `setuptools` now emits 2.4 by default (confirmed locally: `Metadata-Version: 2.4` in the built wheel's METADATA). The same old pin also silently ignores the `attestations` input (added later), confirmed by an "Unexpected input(s) 'attestations'" warning in the failed run — independent evidence the pin is stale.
- Bumps to `dc37677b...` (v1.14.2, bundles `twine==7.0.0`) in both `publish-pypi-*` jobs and in `release/component-catalog.yaml`'s action entry, keeping the SHA-pin-vs-catalog gate consistent.

## Test plan
- [x] `olf release check` passes (56 action references checked, catalog/workflow SHAs match)
- [x] `.github/workflows/release.yml` parses as valid YAML
- [x] Confirmed locally that a fresh `uv build` of `packages/domain-model` produces `Metadata-Version: 2.4`
- [x] Confirmed the new pin's `requirements/runtime.txt` bundles `twine==7.0.0` (2.4 support landed in twine 5.1.0)
- [ ] Real PyPI publish still needs to be re-attempted from a ref that has this fix — the existing `v0.2.0-alpha.1` tag is frozen at a commit predating this fix (workflow content is resolved from the triggering ref), so re-running against that tag will still hit the old pin. Needs a decision on how to get this fix onto a runnable ref (see conversation).