### PR TITLE
feat: define the external data-project contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ labels expressing intended sequence within a milestone.
 | `lakehouse_code/dashboards/superset/<dashboard>/` | Consumption-owned: Superset reports |
 | `lakehouse_code/pipelines/dagster/` | User-maintained Dagster orchestration code |
 | `lakehouse_code/lakehouse.yaml` | Canonical domain/product business metadata descriptor |
+| `openlakeforge.yaml` | Project-root profile marker; semantic profile resolution is pending |
 | `libs/` | Shared runtime Python imported by the project-code image |
 | `packages/domain-model/` | Canonical provider-neutral descriptor and inventory package |
 | `tools/olf/` | The `olf` CLI — uv-managed deploy tooling, contracts, artifacts, scaffolding, e2e |

--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ olf init
 is not a prerequisite.
 
 `olf init` verifies the packaged platform payload, provisions or reuses the
-pinned toolchain, checks that Docker is reachable, and copies the demo
-`lakehouse_code/` into the current directory as your own writable code. Use
-`olf init --empty` to start from a bare project instead — it has no source or
-product yet, so scaffold both with `olf source new` and `olf product new`
-before deploying.
+pinned toolchain, checks that Docker is reachable, and creates the writable
+project files `openlakeforge.yaml` and `lakehouse_code/`. The profile is
+included now as a structural project marker; profile interpretation follows in
+the next milestone slice. Validate the project boundary with
+`olf project validate --project .`. Use `olf init --empty` to start from a
+bare project instead — it has no source or product yet, so scaffold both with
+`olf source new` and `olf product new` before deploying.
 
 Start the **Slim** profile:
 

--- a/docs/adr/0009-distribution.md
+++ b/docs/adr/0009-distribution.md
@@ -47,13 +47,20 @@ checked, not that the bytes ship in the wheel.
 | Root | Holds | Mutability |
 | --- | --- | --- |
 | `distribution_root` | Terraform, Helm values, schemas, Dockerfiles, `libs/`, release catalog | Immutable, shared between projects |
-| `project_root` | `lakehouse_code/` — descriptors, Floe contracts, dashboards, pipelines | The user's, writable |
+| `project_root` | `openlakeforge.yaml` and `lakehouse_code/` — descriptors, Floe contracts, dashboards, pipelines | The user's, writable |
 | state / work / cache roots | Terraform state and data, generated artifacts, Docker staging, Helm downloads | Derived |
 
 An installed `olf` resolves `project_root` to the **current working directory**.
 `OPENLAKEFORGE_PROJECT_ROOT` and `--project-root`/`--repo-root` override it. A
 source checkout keeps the checkout as the contributor default; the two modes stay
 distinct rather than one emulating the other.
+
+`ProjectSpec` is the typed project/distribution boundary for project
+consumers. It supplies canonical paths for the profile, descriptors, Bronze,
+Silver, Gold, dashboard, and Dagster directories. `olf project validate
+--project PATH` emits a JSON report for the structural layout, descriptors,
+inventory, and declared assets. The profile is structurally required but its
+contents are not parsed or resolved yet.
 
 The consequence worth naming: scaffolding validates user descriptors against
 schemas that live outside the project, because the schema is platform material
@@ -62,15 +69,17 @@ and the descriptor is not.
 ### `olf init` makes a directory into a project
 
 It verifies the payload, provisions or reuses the pinned toolchain, checks
-Docker, and copies the packaged demo `lakehouse_code/` into the current
-directory — or writes a transitional skeleton under `--empty` (ADR 0005).
+Docker, and copies the packaged demo `lakehouse_code/` and
+`openlakeforge.yaml` into the current directory — or writes a transitional
+skeleton with the same profile under `--empty` (ADR 0005).
 
 It stages into a sibling directory and renames atomically, and refuses to
-overwrite an existing `lakehouse_code/`. It never installs Docker or uses Git.
-Within the project directory it touches only `lakehouse_code/`; the toolchain
-and payload verification steps write outside it, to the shared, immutable
-`OLF_HOME` (ADR 0008) — never to the project itself, and never requiring the
-user to know that boundary exists to run `olf init` successfully.
+overwrite either existing project path. It never installs Docker or uses Git.
+Within the project directory it touches only `openlakeforge.yaml` and
+`lakehouse_code/`; the toolchain and payload verification steps write outside
+it, to the shared, immutable `OLF_HOME` (ADR 0008) — never to the project
+itself, and never requiring the user to know that boundary exists to run
+`olf init` successfully.
 
 ## Consequences
 
@@ -93,3 +102,6 @@ alpha. Upgrading is documented per release, not automated.
 Merges the decisions previously recorded as ADR 0031 (the PyPI embedded platform
 payload) and 0032 (the installed project root). ADR 0032's transitional-project
 rule is recorded in ADR 0005 alongside the descriptor model it waives.
+Updated for the v0.3 external project contract: `ProjectSpec` makes the
+project/distribution split explicit, and `openlakeforge.yaml` is the required
+project-root profile marker pending its semantic resolver.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -52,6 +52,16 @@ Bronze is an immutable landing zone owned by ingestion. Silver is owned by Floe 
 
 dbt does not own a Silver staging layer in v1. Floe writes Silver Iceberg tables directly through the Polaris REST catalog. dbt consumes those Silver tables and builds Gold models.
 
+## Project Boundary
+
+A writable data project contains `openlakeforge.yaml` and `lakehouse_code/`.
+The latter holds the provider-neutral descriptors, Bronze sources, Silver
+contracts, Gold dbt projects, Superset bundles, and Dagster pipeline modules.
+Terraform, Helm values, image definitions, schemas, and shared libraries stay
+in the immutable OpenLakeForge distribution. Builds combine those platform
+assets with the selected project's `lakehouse_code/`; they do not copy platform
+files into the project.
+
 ## Execution Model
 
 OpenLakeForge v1 uses one custom runtime image:

--- a/docs/setup/local.md
+++ b/docs/setup/local.md
@@ -70,10 +70,11 @@ olf init
 
 `olf init` verifies the packaged platform payload, installs or reuses the
 release-pinned Terraform, Helm, kubectl, and kind toolchain under
-`~/.openlakeforge`, checks Docker, and creates a writable `lakehouse_code/`
-directory copied from the demo. Set `OLF_TOOLCHAIN_MODE=host` to use your own
-host-installed Terraform, Helm, kubectl, and kind instead of the managed
-toolchain.
+`~/.openlakeforge`, checks Docker, and creates the writable project files
+`openlakeforge.yaml` and `lakehouse_code/` from the demo. Validate the
+resulting project boundary with `olf project validate --project .`. Set
+`OLF_TOOLCHAIN_MODE=host` to use your own host-installed Terraform, Helm,
+kubectl, and kind instead of the managed toolchain.
 
 `olf init --empty` creates a transitional project with no source, domain, or
 product. Scaffold its first source and product before deploying:

--- a/openlakeforge.yaml
+++ b/openlakeforge.yaml
@@ -1,0 +1,13 @@
+apiVersion: openlakeforge.io/v1alpha1
+kind: DeploymentProfile
+
+metadata:
+  name: openlakeforge
+
+spec:
+  provider:
+    type: local
+  preset: slim
+  stages:
+    dev:
+      enabled: true

--- a/tools/olf/olf/cli.py
+++ b/tools/olf/olf/cli.py
@@ -30,6 +30,7 @@ from olf.commands import (
     layers,
     openmetadata,
     product,
+    project,
     release,
     revision,
     smoke,
@@ -66,6 +67,7 @@ app.add_typer(release.app, name="release")
 app.add_typer(source.app, name="source")
 app.add_typer(domain.app, name="domain")
 app.add_typer(product.app, name="product")
+app.add_typer(project.app, name="project")
 app.add_typer(toolchain.app, name="toolchain")
 
 app.command("deploy")(deployment.deploy)

--- a/tools/olf/olf/commands/artifacts.py
+++ b/tools/olf/olf/commands/artifacts.py
@@ -76,7 +76,7 @@ def upload_manifests(
     """Publish domain Floe runtime artifacts to the operational artifact bucket."""
     from olf import s3
 
-    repo_root = config.repo_root()
+    project = config.project_spec()
     namespace = config.namespace()
     bucket = config.env("OPENLAKEFORGE_OPS_BUCKET_NAME") or config.env("OPENLAKEFORGE_ARTIFACT_BUCKET_NAME")
     if not bucket:
@@ -86,17 +86,17 @@ def upload_manifests(
         if runtime_root:
             uploads = s3.discover_runtime_artifacts(Path(runtime_root))
         else:
-            root = Path(manifest_root) if manifest_root else repo_root / ".tmp/floe-runtime/aws/manifests"
+            root = Path(manifest_root) if manifest_root else project.root / ".tmp/floe-runtime/aws/manifests"
             uploads = s3.discover_runtime_manifests(root)
         if not uploads:
-            root = runtime_root or manifest_root or str(repo_root / ".tmp/floe-runtime/aws/manifests")
+            root = runtime_root or manifest_root or str(project.root / ".tmp/floe-runtime/aws/manifests")
             raise typer.Exit(code=fail(f"no rendered Floe artifacts found under {root}."))
         s3.upload_direct(bucket, uploads, region=config.env("OPENLAKEFORGE_STORAGE_REGION"))
     elif via == "port-forward":
         if runtime_root:
             uploads = s3.discover_runtime_artifacts(Path(runtime_root))
         else:
-            uploads = s3.discover_tracked_manifests(repo_root)
+            uploads = s3.discover_tracked_manifests(project.root)
         if not uploads:
             raise typer.Exit(
                 code=fail("no generated domain Floe artifacts found. Run 'olf floe generate-manifests' first.")

--- a/tools/olf/olf/commands/catalog.py
+++ b/tools/olf/olf/commands/catalog.py
@@ -109,7 +109,7 @@ def sync_namespaces(*, dry_run: bool, prune: bool | None) -> None:
     if prune is None:
         prune = config.truthy(config.env("OPENLAKEFORGE_CATALOG_PRUNE_NAMESPACES", "false"))
     desired = catalog_module.desired_namespaces(
-        config.repo_root(),
+        config.project_spec().root,
         bronze_bucket=config.env("OPENLAKEFORGE_STORAGE_BRONZE_BUCKET", "lakehouse-bronze"),
         silver_bucket=config.env("OPENLAKEFORGE_STORAGE_SILVER_BUCKET", "lakehouse-silver"),
         gold_bucket=config.env("OPENLAKEFORGE_STORAGE_GOLD_BUCKET", "lakehouse-gold"),

--- a/tools/olf/olf/commands/checks.py
+++ b/tools/olf/olf/commands/checks.py
@@ -26,6 +26,7 @@ REQUIRED_PATHS: tuple[str, ...] = (
     "README.md",
     "AGENTS.md",
     "CLAUDE.md",
+    "openlakeforge.yaml",
     "Makefile",
     ".gitignore",
     ".github/workflows/checks.yml",
@@ -147,6 +148,8 @@ REQUIRED_PATHS: tuple[str, ...] = (
     "tools/olf/pyproject.toml",
     "tools/olf/uv.lock",
     "tools/olf/olf/cli.py",
+    "tools/olf/olf/project.py",
+    "tools/olf/olf/commands/project.py",
     "tools/olf/olf/initialization.py",
     "tools/olf/olf/contracts.py",
     "tools/olf/olf/contracts_check.py",
@@ -252,6 +255,16 @@ def _distribution_root_for(root: Path) -> Path:
     return runtime_layout().distribution_root
 
 
+def _check_cache_root(project_root: Path, distribution_root: Path) -> Path:
+    """Keep check caches outside a selected external data project."""
+    if project_root == distribution_root:
+        return project_root / ".cache"
+    from olf.distribution import runtime_layout
+
+    project_key = hashlib.sha256(str(project_root).encode()).hexdigest()[:12]
+    return runtime_layout().cache_root / "checks" / project_key
+
+
 @app.command("structure")
 def structure(repo_root: str = typer.Option("", "--repo-root", help="Checkout root to validate.")) -> None:
     """Validate the essential repository skeleton and prohibit shell scripts."""
@@ -341,9 +354,11 @@ def _option_value(argv: list[str], option: str) -> str | None:
 def contracts(repo_root: str = typer.Option("", "--repo-root", help="Checkout or project root to validate.")) -> None:
     """Run the existing parsed provider-contract validation."""
     from olf import contracts_check
+    from olf.project import ProjectSpec
 
     root = _root(repo_root)
-    report = contracts_check.run_contracts_check(root, distribution_root=_distribution_root_for(root))
+    project = ProjectSpec(root=root, distribution_root=_distribution_root_for(root))
+    report = contracts_check.run_contracts_check(project.root, distribution_root=project.distribution_root)
     typer.echo(report.render())
     if not report.ok:
         raise typer.Exit(code=1)
@@ -534,7 +549,10 @@ def _check_compiled_lock(path: Path, *, uv: str, root: Path) -> None:
 @app.command("project-code")
 def project_code(repo_root: str = typer.Option("", "--repo-root", help="Checkout root to validate.")) -> None:
     """Load the merged Dagster definitions in the project-code dependency set."""
+    from olf.project import ProjectSpec
+
     root = _root(repo_root)
+    project = ProjectSpec(root=root, distribution_root=_distribution_root_for(root))
     if sys.version_info[:2] != (3, 12):
         raise typer.Exit(
             code=fail(
@@ -542,19 +560,25 @@ def project_code(repo_root: str = typer.Option("", "--repo-root", help="Checkout
                 f"found {sys.version_info[0]}.{sys.version_info[1]}"
             )
         )
-    cache = root / ".cache/project-code-check"
-    project_digest = hashlib.sha256((root / "images/project-code/pyproject.toml").read_bytes()).hexdigest()[:16]
-    domain_digest = _source_tree_digest(root / "packages/domain-model")
+    cache = _check_cache_root(project.root, project.distribution_root) / "project-code"
+    project_digest = hashlib.sha256(
+        (project.distribution_root / "images/project-code/pyproject.toml").read_bytes()
+    ).hexdigest()[:16]
+    domain_digest = _source_tree_digest(project.distribution_root / "packages/domain-model")
     site = cache / f"py{sys.version_info.major}{sys.version_info.minor}-{project_digest}-{domain_digest}" / "site"
     if not (site / ".complete").is_file():
         site.mkdir(parents=True, exist_ok=True)
-        pyproject = tomllib.loads((root / "images/project-code/pyproject.toml").read_text())
-        _uv_pip_install(target=site, requirements=pyproject["project"]["dependencies"], cwd=root)
-        _uv_pip_install(target=site, requirements=[str(root / "packages/domain-model")], cwd=root)
+        pyproject = tomllib.loads((project.distribution_root / "images/project-code/pyproject.toml").read_text())
+        _uv_pip_install(target=site, requirements=pyproject["project"]["dependencies"], cwd=project.root)
+        _uv_pip_install(
+            target=site,
+            requirements=[str(project.distribution_root / "packages/domain-model")],
+            cwd=project.root,
+        )
         (site / ".complete").touch()
     env = {
         "PATH": f"{site / 'bin'}{os.pathsep}{os.environ.get('PATH', '')}",
-        "PYTHONPATH": f"{site}{os.pathsep}{root}",
+        "PYTHONPATH": f"{site}{os.pathsep}{project.root}{os.pathsep}{project.distribution_root}",
         "OPENLAKEFORGE_FLOE_MANIFEST_ACCESS_MODE": "remote",
         "OPENLAKEFORGE_OPS_BUCKET_NAME": "openlakeforge-ops",
         "OPENLAKEFORGE_ARTIFACT_BUCKET_NAME": "openlakeforge-ops",
@@ -564,7 +588,7 @@ def project_code(repo_root: str = typer.Option("", "--repo-root", help="Checkout
         "OPENLAKEFORGE_LOG_BASE_URI": "s3://openlakeforge-ops/logs",
         "OPENLAKEFORGE_RUN_ARTIFACT_BASE_URI": "s3://openlakeforge-ops/runs",
     }
-    _run([sys.executable, "-m", "olf.project_code_check", str(root)], cwd=root, env=env)
+    _run([sys.executable, "-m", "olf.project_code_check", str(project.root)], cwd=project.root, env=env)
 
 
 def _source_tree_digest(directory: Path) -> str:
@@ -579,6 +603,8 @@ def _source_tree_digest(directory: Path) -> str:
 @app.command("dbt")
 def dbt(repo_root: str = typer.Option("", "--repo-root", help="Checkout or project root to validate.")) -> None:
     """Render, resolve, parse, and compile every discovered dbt product."""
+    from olf.project import ProjectSpec
+
     root = _root(repo_root)
     # `libs` is distribution-owned, not project-owned (ADR 0009): an
     # installed project's root has only `lakehouse_code/`, so the
@@ -586,16 +612,16 @@ def dbt(repo_root: str = typer.Option("", "--repo-root", help="Checkout or proje
     # Mirrors `olf dbt parse`'s identical fix. `_distribution_root_for`
     # prefers `root` itself when `--repo-root` selects a complete, separate
     # checkout, so that checkout's own `libs/dbt/render_profiles` wins.
-    distribution_root = _distribution_root_for(root)
-    for path in (str(root), str(distribution_root)):
+    project_spec = ProjectSpec(root=root, distribution_root=_distribution_root_for(root))
+    for path in (str(project_spec.root), str(project_spec.distribution_root)):
         if path not in sys.path:
             sys.path.insert(0, path)
     from libs.dbt.render_profiles import discover_project_dirs, write_profile
 
-    projects = discover_project_dirs(root / "lakehouse_code/gold")
+    projects = discover_project_dirs(project_spec.gold_root)
     if not projects:
         raise typer.Exit(code=fail("no product dbt projects found"))
-    cache = root / ".cache/dbt-check"
+    cache = _check_cache_root(project_spec.root, project_spec.distribution_root) / "dbt"
     dependency_key = hashlib.sha256(b"dbt-trino==1.10.2\nopenlineage-dbt==1.45.0").hexdigest()[:16]
     site = cache / f"py{sys.version_info.major}{sys.version_info.minor}-{dependency_key}" / "site"
     if not (site / ".complete").is_file():
@@ -603,7 +629,7 @@ def dbt(repo_root: str = typer.Option("", "--repo-root", help="Checkout or proje
         _uv_pip_install(
             target=site,
             requirements=["dbt-trino==1.10.2", "openlineage-dbt==1.45.0"],
-            cwd=root,
+            cwd=project_spec.root,
         )
         (site / ".complete").touch()
     dbt_bin = str(site / "bin/dbt")
@@ -622,10 +648,10 @@ def dbt(repo_root: str = typer.Option("", "--repo-root", help="Checkout or proje
     }
     for project in projects:
         write_profile(project, environment="local")
-        _run([dbt_bin, "deps", "--project-dir", str(project)], cwd=root, env=env)
+        _run([dbt_bin, "deps", "--project-dir", str(project)], cwd=project_spec.root, env=env)
         _run(
             [dbt_bin, "parse", "--project-dir", str(project), "--profiles-dir", str(project), "--target", "local"],
-            cwd=root,
+            cwd=project_spec.root,
             env=env,
         )
         _run(
@@ -641,10 +667,10 @@ def dbt(repo_root: str = typer.Option("", "--repo-root", help="Checkout or proje
                 "--no-introspect",
                 "--no-populate-cache",
             ],
-            cwd=root,
+            cwd=project_spec.root,
             env=env,
         )
-        _validate_dbt_relation_contract(project, root=root, catalog=env["OPENLAKEFORGE_CATALOG_NAME"])
+        _validate_dbt_relation_contract(project, root=project_spec.root, catalog=env["OPENLAKEFORGE_CATALOG_NAME"])
     typer.echo("dbt projects compiled and relation contracts are valid.")
 
 

--- a/tools/olf/olf/commands/dbt.py
+++ b/tools/olf/olf/commands/dbt.py
@@ -48,15 +48,14 @@ def parse(
             # (per the image-build contract) has no `libs` of its own, so
             # the distribution root must be on sys.path too, not just the
             # project root.
-            root = config.repo_root()
-            distribution_root = config.distribution_root()
-            for path in (str(root), str(distribution_root)):
+            project_spec = config.project_spec()
+            for path in (str(project_spec.root), str(project_spec.distribution_root)):
                 if path not in sys.path:
                     sys.path.insert(0, path)
             from libs.dbt.render_profiles import discover_project_dirs, write_profile
 
             projects = (
-                [Path(project_dir).resolve()] if project_dir else discover_project_dirs(root / "lakehouse_code/gold")
+                [Path(project_dir).resolve()] if project_dir else discover_project_dirs(project_spec.gold_root)
             )
             if not projects:
                 raise typer.Exit(code=fail("no product dbt projects found"))
@@ -68,7 +67,7 @@ def parse(
                     args = [dbt, command, "--project-dir", str(project)]
                     if command == "parse":
                         args += ["--profiles-dir", str(project), "--target", _target_for_provider(provider)]
-                    tools.runner.run(args, cwd=root, stream_output=True)
+                    tools.runner.run(args, cwd=project_spec.root, stream_output=True)
     except DeploymentError as exc:
         raise typer.Exit(code=fail(str(exc))) from exc
 

--- a/tools/olf/olf/commands/domain.py
+++ b/tools/olf/olf/commands/domain.py
@@ -28,11 +28,11 @@ def domain_new(
     validated before any product consumes its Silver tables."""
     try:
         layout = writable_project_layout(repo_root)
-        root = layout.project_root
+        project = layout.project
         inputs = tuple(parse_source_resource(value) for value in input_)
-        plan = plan_domain_new(root, domain=domain, display_name=display_name, inputs=inputs)
+        plan = plan_domain_new(project.root, domain=domain, display_name=display_name, inputs=inputs)
         commit_plan(
-            root, plan, schema_root=layout.distribution_root / "docs" / "schema", allow_transitional=True
+            project.root, plan, schema_root=project.schema_root, allow_transitional=True
         )
     except (RuntimeError, ScaffoldError) as exc:
         raise typer.Exit(code=fail(str(exc))) from exc

--- a/tools/olf/olf/commands/images.py
+++ b/tools/olf/olf/commands/images.py
@@ -19,14 +19,23 @@ app = typer.Typer(help="Build and load local runtime images.")
 
 
 def _local_config(
-    cluster_name: str, *, environ: Mapping[str, str] | None = None
+    cluster_name: str, *, project_root: str = "", environ: Mapping[str, str] | None = None
 ) -> tuple[LocalDeploymentConfig, Toolkit]:
+    from olf.distribution import runtime_layout
+
+    layout_env = dict(os.environ if environ is None else environ)
+    if project_root:
+        layout_env["OPENLAKEFORGE_PROJECT_ROOT"] = project_root
+    layout = runtime_layout(layout_env)
     context = DeploymentContext.for_provider(
         "local",
-        repo_root=config.repo_root(),
+        repo_root=layout.project.root,
+        distribution_root=layout.project.distribution_root,
+        state_root=None if layout.is_source else layout.state_root,
+        work_root=None if layout.is_source else layout.work_root,
+        cache_root=None if layout.is_source else layout.cache_root,
         namespace=config.namespace(),
         cluster_name=cluster_name,
-        kubeconfig_path=config.repo_root() / ".tmp/kubeconfigs/local.yaml",
         profile=Profile.FULL,
     )
     resolved_environ = os.environ if environ is None else environ
@@ -37,9 +46,12 @@ def _local_config(
 def build(
     image: str = typer.Argument(..., metavar="IMAGE", help="project-code or superset."),
     cluster_name: str = typer.Option("openlakeforge-local", "--cluster-name"),
+    project_root: str = typer.Option(
+        "", "--project-root", help="Writable project root; defaults to the current directory."
+    ),
 ) -> None:
     """Build one locally pinned runtime image with Docker retry policy."""
-    settings, tools = _local_config(cluster_name)
+    settings, tools = _local_config(cluster_name, project_root=project_root)
     try:
         if image == "project-code":
             build_project_code_image(
@@ -60,9 +72,12 @@ def build(
 def load(
     image: str = typer.Argument(..., metavar="IMAGE", help="project-code or superset."),
     cluster_name: str = typer.Option("openlakeforge-local", "--cluster-name"),
+    project_root: str = typer.Option(
+        "", "--project-root", help="Writable project root; defaults to the current directory."
+    ),
 ) -> None:
     """Load a built runtime image into the required Kind cluster."""
-    settings, tools = _local_config(cluster_name)
+    settings, tools = _local_config(cluster_name, project_root=project_root)
     try:
         if image == "project-code":
             reference = settings.images.project_code_image

--- a/tools/olf/olf/commands/openmetadata.py
+++ b/tools/olf/olf/commands/openmetadata.py
@@ -8,6 +8,7 @@ import typer
 
 from olf import config
 from olf.commands._shared import fail, log_step
+from olf.project import ProjectSpec
 
 app = typer.Typer(help="OpenMetadata governance metadata helpers.")
 
@@ -42,6 +43,7 @@ def deploy_openmetadata_metadata() -> None:
     from olf import k8s
     from olf import openmetadata as om
 
+    project = ProjectSpec(root=config.project_root(), distribution_root=config.distribution_root())
     namespace = config.namespace()
     service = config.env("OPENMETADATA_SERVICE", "openmetadata")
     remote_port = int(config.env("OPENMETADATA_SERVICE_PORT", "8585"))
@@ -57,7 +59,7 @@ def deploy_openmetadata_metadata() -> None:
             base_url=f"http://127.0.0.1:{local_port}",
             admin_email=config.env("OPENMETADATA_ADMIN_EMAIL", "admin@open-metadata.org"),
             admin_password=config.env("OPENMETADATA_ADMIN_PASSWORD", "admin"),
-            metadata_root=config.env("OPENMETADATA_METADATA_ROOT", "lakehouse_code"),
+            metadata_root=config.env("OPENMETADATA_METADATA_ROOT", str(project.code_root)),
             metadata_source_dir=os.environ.get("OPENMETADATA_METADATA_SOURCE_DIR", ""),
             allow_missing_assets=config.truthy(config.env("OPENMETADATA_ALLOW_MISSING_ASSETS", "false")),
             catalog_service=config.env("OPENMETADATA_CATALOG_SERVICE") or config.env("OPENLAKEFORGE_CATALOG_PROVIDER"),

--- a/tools/olf/olf/commands/product.py
+++ b/tools/olf/olf/commands/product.py
@@ -36,10 +36,10 @@ def product_new(
     domain inline (via --input) when DOMAIN is not declared yet."""
     try:
         layout = writable_project_layout(repo_root)
-        root = layout.project_root
+        project = layout.project
         inputs = tuple(parse_source_resource(value) for value in input_)
         plan = plan_product_new(
-            root,
+            project.root,
             target=target,
             display_name=display_name,
             silver_inputs=tuple(silver_input),
@@ -47,7 +47,7 @@ def product_new(
             gold_tables=tuple(gold_table),
             with_report=with_report,
         )
-        commit_plan(root, plan, schema_root=layout.distribution_root / "docs" / "schema")
+        commit_plan(project.root, plan, schema_root=project.schema_root)
     except (RuntimeError, ScaffoldError) as exc:
         raise typer.Exit(code=fail(str(exc))) from exc
     for line in plan.summary:

--- a/tools/olf/olf/commands/project.py
+++ b/tools/olf/olf/commands/project.py
@@ -1,0 +1,25 @@
+"""Commands for validating a writable OpenLakeForge data project."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from olf.project import ProjectSpec, validate_project
+
+app = typer.Typer(help="Validate and build writable OpenLakeForge data projects.")
+
+
+@app.command("validate")
+def validate(
+    project: str = typer.Option(..., "--project", help="Explicit writable project root."),
+) -> None:
+    """Emit a machine-readable report for one project root."""
+    from olf.distribution import runtime_layout
+
+    layout = runtime_layout()
+    report = validate_project(ProjectSpec(root=Path(project), distribution_root=layout.distribution_root))
+    typer.echo(report.render_json())
+    if not report.ok:
+        raise typer.Exit(code=1)

--- a/tools/olf/olf/commands/source.py
+++ b/tools/olf/olf/commands/source.py
@@ -24,10 +24,10 @@ def source_new(
     example CSV per --resource. Adds SOURCE to lakehouse.yaml's `sources:`."""
     try:
         layout = writable_project_layout(repo_root)
-        root = layout.project_root
-        plan = plan_source_new(root, source=source, display_name=display_name, resources=tuple(resource))
+        project = layout.project
+        plan = plan_source_new(project.root, source=source, display_name=display_name, resources=tuple(resource))
         commit_plan(
-            root, plan, schema_root=layout.distribution_root / "docs" / "schema", allow_transitional=True
+            project.root, plan, schema_root=project.schema_root, allow_transitional=True
         )
     except (RuntimeError, ScaffoldError) as exc:
         raise typer.Exit(code=fail(str(exc))) from exc

--- a/tools/olf/olf/commands/superset.py
+++ b/tools/olf/olf/commands/superset.py
@@ -42,13 +42,14 @@ def deploy_superset_reports() -> None:
     """Build and import source-controlled Superset report bundles."""
     from olf import superset
 
-    inventory = inventory_for(config.repo_root())
+    project = config.project_spec()
+    inventory = inventory_for(project.root)
     declared_report_dirs = tuple(dashboard.report_source_dir for dashboard in inventory.dashboards)
     override = os.environ.get("SUPERSET_REPORT_SOURCE_DIR") or None
     if override is not None and override not in declared_report_dirs:
         raise typer.BadParameter(f"SUPERSET_REPORT_SOURCE_DIR {override!r} is not declared in lakehouse.yaml")
     superset.deploy_reports(
-        config.repo_root(),
+        project.root,
         config.namespace(),
         config.env("OPENLAKEFORGE_QUERY_SQLALCHEMY_URI"),
         report_source_dir=override,
@@ -90,8 +91,8 @@ def export_superset_reports() -> None:
 
     from olf import superset
 
-    repo_root = config.repo_root()
-    inventory = inventory_for(repo_root)
+    project = config.project_spec()
+    inventory = inventory_for(project.root)
     if not inventory.dashboards:
         raise typer.BadParameter("lakehouse.yaml declares no dashboard to export")
     default_dashboard = inventory.dashboards[0]
@@ -104,7 +105,7 @@ def export_superset_reports() -> None:
         # e2e.discovered_dashboards) — prefer the checked-in bundle's own
         # title so a re-export finds the same dashboard it last exported.
         # Falls back to displayName only when no bundle exists yet to read.
-        for dashboard_file in superset.discover_dashboard_files(repo_root / report_source_dir):
+        for dashboard_file in superset.discover_dashboard_files(project.root / report_source_dir):
             document = yaml.safe_load(dashboard_file.read_text())
             title = document.get("dashboard_title") if isinstance(document, dict) else None
             if title:
@@ -112,7 +113,7 @@ def export_superset_reports() -> None:
         return default_product.display_name
 
     superset.export_report(
-        repo_root,
+        project.root,
         config.namespace(),
         report_source_dir=report_source_dir,
         bundle_name=config.env(

--- a/tools/olf/olf/config.py
+++ b/tools/olf/olf/config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from olf.project import ProjectSpec
+
 
 def namespace() -> str:
     return os.environ.get("NAMESPACE") or os.environ.get("OPENLAKEFORGE_KUBE_NAMESPACE") or "lakehouse"
@@ -27,6 +29,11 @@ def distribution_root() -> Path:
 def project_root() -> Path:
     """Return the user-project root, defaulting to the active source root."""
     return Path(os.environ.get("OPENLAKEFORGE_PROJECT_ROOT", repo_root())).resolve()
+
+
+def project_spec() -> ProjectSpec:
+    """Resolve the selected writable project and its platform payload."""
+    return ProjectSpec(root=project_root(), distribution_root=distribution_root())
 
 
 def truthy(value: str) -> bool:

--- a/tools/olf/olf/deployment/context.py
+++ b/tools/olf/olf/deployment/context.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
 
+from olf.project import ProjectSpec
+
 DEFAULT_NAMESPACE = "lakehouse"
 DEFAULT_LOCAL_CLUSTER_NAME = "openlakeforge-local"
 
@@ -50,6 +52,7 @@ class Profile(StrEnum):
 class DeploymentPaths:
     repo_root: Path
     distribution_root: Path
+    project: ProjectSpec
     state_root: Path
     work_root: Path
     cache_root: Path
@@ -264,6 +267,7 @@ class DeploymentContext:
         paths = DeploymentPaths(
             repo_root=resolved_repo_root,
             distribution_root=resolved_distribution_root,
+            project=ProjectSpec(root=resolved_repo_root, distribution_root=resolved_distribution_root),
             state_root=resolved_state_root,
             work_root=resolved_work_root,
             cache_root=resolved_cache_root,
@@ -323,6 +327,9 @@ class DeploymentContext:
         # Fresh contract readers create their own managed-tool resolver. Keep
         # them anchored to the same verified distribution as the Toolkit.
         env["OLF_DISTRIBUTION_ROOT"] = str(self.paths.distribution_root)
+        env["OPENLAKEFORGE_PROJECT_ROOT"] = str(self.paths.project.root)
+        # The legacy name remains for contributor/release compatibility.
+        env["OPENLAKEFORGE_REPO_ROOT"] = str(self.paths.project.root)
         # Gate on `installed`, never on `distribution_root != repo_root`: the
         # documented quick start (`uv tool install` then `olf deploy` with no
         # --project-root) deploys the bundled demo, so both roots are the same

--- a/tools/olf/olf/deployment/contract_env.py
+++ b/tools/olf/olf/deployment/contract_env.py
@@ -47,6 +47,7 @@ def applied_contract_environment(
 
     extra = {
         "OPENLAKEFORGE_REPO_ROOT": str(repo_root),
+        "OPENLAKEFORGE_PROJECT_ROOT": str(repo_root),
         "NAMESPACE": namespace,
         "KUBE_CONTEXT": kube_context,
         "KUBECONFIG": str(kubeconfig_path),

--- a/tools/olf/olf/deployment/project_code.py
+++ b/tools/olf/olf/deployment/project_code.py
@@ -20,7 +20,7 @@ def project_code_build_context(paths: DeploymentPaths) -> Iterator[Path]:
     code, so its ``lakehouse_code`` must replace the bundled demo before the
     image is built.  Source mode has one tree already and needs no staging.
     """
-    if paths.repo_root == paths.distribution_root:
+    if paths.project.root == paths.project.distribution_root:
         yield paths.distribution_root
         return
 
@@ -29,5 +29,5 @@ def project_code_build_context(paths: DeploymentPaths) -> Iterator[Path]:
         root = Path(temporary)
         for relative in ("images/project-code", "packages/domain-model", "libs"):
             shutil.copytree(paths.distribution_root / relative, root / relative)
-        shutil.copytree(paths.repo_root / "lakehouse_code", root / "lakehouse_code")
+        shutil.copytree(paths.project.code_root, root / "lakehouse_code")
         yield root

--- a/tools/olf/olf/distribution.py
+++ b/tools/olf/olf/distribution.py
@@ -22,6 +22,10 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from olf.project import ProjectSpec
 
 _PAYLOAD_ROOTS = (
     "infra/terraform",
@@ -33,7 +37,7 @@ _PAYLOAD_ROOTS = (
     "docs/schema",
     "lakehouse_code",
 )
-_PAYLOAD_FILES = ("release/component-catalog.yaml",)
+_PAYLOAD_FILES = ("openlakeforge.yaml", "release/component-catalog.yaml")
 _EXCLUDED_PARTS = frozenset({".terraform", ".tmp", "__pycache__", ".pytest_cache", ".venv", "dist", "build"})
 _CATALOG_VERSION = re.compile(r"^distribution:\s*$.*?^\s+version:\s*['\"]?([^'\"\s#]+)", re.MULTILINE | re.DOTALL)
 _ALPHA_VERSION = re.compile(r"^(\d+\.\d+\.\d+)-alpha\.(\d+)$")
@@ -159,6 +163,13 @@ class RuntimeLayout:
     @property
     def is_source(self) -> bool:
         return self.mode == "source"
+
+    @property
+    def project(self) -> ProjectSpec:
+        """Resolve this layout's selected data project on demand."""
+        from olf.project import ProjectSpec
+
+        return ProjectSpec.from_layout(self)
 
 
 @dataclass

--- a/tools/olf/olf/e2e/_runner.py
+++ b/tools/olf/olf/e2e/_runner.py
@@ -38,6 +38,7 @@ from olf.e2e._trino import (
     check_trino_product_tables_and_marts,
     check_trino_tables_and_marts,
 )
+from olf.project import ProjectSpec
 
 
 @dataclass(frozen=True)
@@ -98,8 +99,15 @@ def prepare_config(
     extracted under `OLF_HOME` - they only coincide in source-mode
     checkouts, where `distribution_root` defaults to `repo_root`.
     """
-    root = (repo_root or Path(os.environ.get("OPENLAKEFORGE_REPO_ROOT", "."))).resolve()
-    dist_root = (distribution_root or root).resolve()
+    legacy_project_root = os.environ.get("OPENLAKEFORGE_REPO_ROOT", ".")
+    default_project_root = Path(os.environ.get("OPENLAKEFORGE_PROJECT_ROOT", legacy_project_root))
+    default_distribution_root = Path(os.environ.get("OLF_DISTRIBUTION_ROOT", default_project_root))
+    project = ProjectSpec(
+        root=repo_root or default_project_root,
+        distribution_root=distribution_root or repo_root or default_distribution_root,
+    )
+    root = project.root
+    dist_root = project.distribution_root
     actual_suite = suite or default_suite(env)
     inventory = inventory_for(root)
     if env == "local":

--- a/tools/olf/olf/initialization.py
+++ b/tools/olf/olf/initialization.py
@@ -76,14 +76,16 @@ class ProjectInitializer:
             raise InitializationError(str(exc)) from exc
 
         target = layout.project_root / "lakehouse_code"
-        if target.exists():
-            raise InitializationError(f"refusing to overwrite existing project path: {target}")
+        profile_target = layout.project_root / "openlakeforge.yaml"
+        for path in (profile_target, target):
+            if path.exists():
+                raise InitializationError(f"refusing to overwrite existing project path: {path}")
         if not layout.project_root.is_dir():
             raise InitializationError(f"project root is not a directory: {layout.project_root}")
 
         tools = self._prepare_toolchain(layout, env)
         self._verify_docker(tools, env)
-        self._create_project(layout, target, empty=empty)
+        self._create_project(layout, target, profile_target, empty=empty)
         return InitializationResult(project_root=layout.project_root, lakehouse_root=target, empty=empty)
 
     def _prepare_toolchain(self, layout: RuntimeLayout, env: Mapping[str, str]) -> Toolkit:
@@ -114,9 +116,10 @@ class ProjectInitializer:
         if not health.ok:
             raise InitializationError(f"Docker engine is not reachable: {health.detail}")
 
-    def _create_project(self, layout: RuntimeLayout, target: Path, *, empty: bool) -> None:
+    def _create_project(self, layout: RuntimeLayout, target: Path, profile_target: Path, *, empty: bool) -> None:
         staging_parent = Path(tempfile.mkdtemp(prefix=".olf-init-", dir=layout.project_root))
         staging = staging_parent / "lakehouse_code"
+        profile_staging = staging_parent / "openlakeforge.yaml"
         try:
             if empty:
                 self._write_empty_project(layout.distribution_root, staging)
@@ -125,10 +128,19 @@ class ProjectInitializer:
                 if not template.is_dir():
                     raise InitializationError(f"distribution is missing demo template: {template}")
                 shutil.copytree(template, staging, ignore=shutil.ignore_patterns("__pycache__"))
-            self._make_user_writable(staging)
-            if target.exists():
-                raise InitializationError(f"refusing to overwrite existing project path: {target}")
-            os.replace(staging, target)
+            profile_template = layout.distribution_root / "openlakeforge.yaml"
+            if not profile_template.is_file():
+                raise InitializationError(f"distribution is missing project profile template: {profile_template}")
+            shutil.copy2(profile_template, profile_staging)
+            self._make_user_writable(staging_parent)
+            if target.exists() or profile_target.exists():
+                raise InitializationError(f"refusing to overwrite an existing project path under {layout.project_root}")
+            os.replace(profile_staging, profile_target)
+            try:
+                os.replace(staging, target)
+            except OSError:
+                profile_target.unlink(missing_ok=True)
+                raise
         except OSError as exc:
             raise InitializationError(f"could not create project at {target}: {exc}") from exc
         finally:

--- a/tools/olf/olf/project.py
+++ b/tools/olf/olf/project.py
@@ -1,0 +1,172 @@
+"""Typed contract for a writable OpenLakeForge data project."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from openlakeforge_domain import LakehouseDescriptorError, LakehouseInventory, load_lakehouse_inventory
+
+if TYPE_CHECKING:
+    from olf.distribution import RuntimeLayout
+
+
+@dataclass(frozen=True)
+class ProjectSpec:
+    """The writable project and immutable distribution selected for one run."""
+
+    root: Path
+    distribution_root: Path
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "root", self.root.resolve())
+        object.__setattr__(self, "distribution_root", self.distribution_root.resolve())
+
+    @classmethod
+    def from_layout(cls, layout: RuntimeLayout) -> ProjectSpec:
+        return cls(root=layout.project_root, distribution_root=layout.distribution_root)
+
+    @property
+    def profile_path(self) -> Path:
+        return self.root / "openlakeforge.yaml"
+
+    @property
+    def code_root(self) -> Path:
+        return self.root / "lakehouse_code"
+
+    @property
+    def lakehouse_path(self) -> Path:
+        return self.code_root / "lakehouse.yaml"
+
+    @property
+    def bronze_root(self) -> Path:
+        return self.code_root / "bronze"
+
+    @property
+    def silver_root(self) -> Path:
+        return self.code_root / "silver"
+
+    @property
+    def gold_root(self) -> Path:
+        return self.code_root / "gold"
+
+    @property
+    def dashboards_root(self) -> Path:
+        return self.code_root / "dashboards" / "superset"
+
+    @property
+    def pipelines_root(self) -> Path:
+        return self.code_root / "pipelines" / "dagster"
+
+    @property
+    def schema_root(self) -> Path:
+        return self.distribution_root / "docs" / "schema"
+
+
+@dataclass(frozen=True)
+class ProjectCheck:
+    name: str
+    ok: bool
+    detail: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {"name": self.name, "ok": self.ok, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class ProjectValidationReport:
+    project: ProjectSpec
+    checks: tuple[ProjectCheck, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(check.ok for check in self.checks)
+
+    def render_json(self) -> str:
+        return json.dumps(
+            {
+                "schema_version": 1,
+                "valid": self.ok,
+                "project_root": str(self.project.root),
+                "distribution_root": str(self.project.distribution_root),
+                "checks": [check.as_dict() for check in self.checks],
+            },
+            sort_keys=True,
+        )
+
+
+def validate_project(project: ProjectSpec) -> ProjectValidationReport:
+    """Validate the provider-neutral project files without resolving a profile."""
+    from olf.contracts_check import descriptor_schema_errors
+
+    checks = [_canonical_layout_check(project)]
+    descriptor_errors = descriptor_schema_errors(project.root, schema_root=project.schema_root)
+    checks.append(
+        ProjectCheck(
+            "descriptors",
+            not descriptor_errors,
+            "descriptors validated" if not descriptor_errors else "; ".join(descriptor_errors),
+        )
+    )
+
+    inventory: LakehouseInventory | None = None
+    try:
+        inventory = load_lakehouse_inventory(project.root)
+    except (LakehouseDescriptorError, OSError) as exc:
+        checks.append(ProjectCheck("inventory", False, str(exc)))
+    else:
+        checks.append(ProjectCheck("inventory", True, f"{len(inventory.products)} product(s) discovered"))
+
+    checks.append(_project_assets_check(project, inventory))
+    return ProjectValidationReport(project=project, checks=tuple(checks))
+
+
+def _canonical_layout_check(project: ProjectSpec) -> ProjectCheck:
+    required_files = {
+        "openlakeforge.yaml": project.profile_path,
+        "lakehouse_code/lakehouse.yaml": project.lakehouse_path,
+    }
+    required_directories = {
+        "lakehouse_code/": project.code_root,
+        "lakehouse_code/bronze/": project.bronze_root,
+        "lakehouse_code/silver/": project.silver_root,
+        "lakehouse_code/gold/": project.gold_root,
+        "lakehouse_code/dashboards/superset/": project.dashboards_root,
+        "lakehouse_code/pipelines/dagster/": project.pipelines_root,
+    }
+    missing = [name for name, path in required_files.items() if not path.is_file()]
+    missing.extend(name for name, path in required_directories.items() if not path.is_dir())
+    if missing:
+        return ProjectCheck("canonical_layout", False, f"missing: {', '.join(missing)}")
+    return ProjectCheck("canonical_layout", True, "canonical project paths are present")
+
+
+def _project_assets_check(project: ProjectSpec, inventory: LakehouseInventory | None) -> ProjectCheck:
+    if inventory is None:
+        return ProjectCheck("project_assets", False, "not evaluated because inventory validation failed")
+
+    missing: list[str] = []
+    for source in inventory.sources:
+        path = project.bronze_root / source.name / "dlt" / f"{source.name}.py"
+        if not path.is_file():
+            missing.append(path.relative_to(project.root).as_posix())
+    for domain in inventory.domains:
+        path = project.silver_root / domain.name / "contracts" / "floe" / f"{domain.name}.yml"
+        if not path.is_file():
+            missing.append(path.relative_to(project.root).as_posix())
+    for product in inventory.products:
+        dbt_path = project.gold_root / product.id / "dbt" / "dbt_project.yml"
+        pipeline_path = project.pipelines_root / f"{product.id}.py"
+        for path in (dbt_path, pipeline_path):
+            if not path.is_file():
+                missing.append(path.relative_to(project.root).as_posix())
+    for dashboard in inventory.dashboards:
+        path = project.root / dashboard.report_source_dir / "metadata.yaml"
+        if not path.is_file():
+            missing.append(path.relative_to(project.root).as_posix())
+
+    if missing:
+        return ProjectCheck("project_assets", False, f"missing: {', '.join(missing)}")
+    return ProjectCheck("project_assets", True, "declared project assets are present")

--- a/tools/olf/tests/conftest.py
+++ b/tools/olf/tests/conftest.py
@@ -7,6 +7,7 @@ live here once rather than duplicated per file.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -35,6 +36,16 @@ def _isolate_toolchain(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest
 
 E2E_REPO_ROOT = Path(__file__).resolve().parents[3]
 E2E_INVENTORY = inventory_for(E2E_REPO_ROOT)
+
+
+@pytest.fixture
+def external_project(tmp_path: Path) -> Path:
+    """Copy only the versioned data-project payload into a separate root."""
+    root = tmp_path / "external-project"
+    root.mkdir()
+    shutil.copy2(E2E_REPO_ROOT / "openlakeforge.yaml", root / "openlakeforge.yaml")
+    shutil.copytree(E2E_REPO_ROOT / "lakehouse_code", root / "lakehouse_code")
+    return root
 
 
 def e2e_cfg(tmp_path: Path, env: Environment = "local", suite: Suite = "full") -> E2EConfig:

--- a/tools/olf/tests/test_deployment_context.py
+++ b/tools/olf/tests/test_deployment_context.py
@@ -143,7 +143,10 @@ def test_distribution_root_defaults_to_repo_root(tmp_path: Path) -> None:
     assert ctx.paths.distribution_root == ctx.paths.repo_root
 
 
-def test_command_env_sets_expected_keys_without_mutating_parent(tmp_path: Path) -> None:
+def test_command_env_sets_expected_keys_without_mutating_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KUBECONFIG", raising=False)
     ctx = DeploymentContext.local(repo_root=tmp_path)
     assert "KUBECONFIG" not in os.environ
 
@@ -156,6 +159,9 @@ def test_command_env_sets_expected_keys_without_mutating_parent(tmp_path: Path) 
     assert env["BUILDKIT_PROGRESS"] == "plain"
     assert env["HELM_REPOSITORY_CONFIG"] == str(ctx.paths.helm_repository_config)
     assert env["HELM_REPOSITORY_CACHE"] == str(ctx.paths.helm_repository_cache)
+    assert env["OPENLAKEFORGE_PROJECT_ROOT"] == str(ctx.paths.project.root)
+    assert env["OPENLAKEFORGE_REPO_ROOT"] == str(ctx.paths.project.root)
+    assert env["OLF_DISTRIBUTION_ROOT"] == str(ctx.paths.project.distribution_root)
     assert "KUBECONFIG" not in os.environ
 
 

--- a/tools/olf/tests/test_distribution.py
+++ b/tools/olf/tests/test_distribution.py
@@ -76,6 +76,8 @@ def test_payload_archive_is_deterministic_for_the_same_checkout(tmp_path: Path) 
 
     assert one["sha256"] == two["sha256"]
     assert one["manifest_sha256"] == two["manifest_sha256"]
+    with tarfile.open(tmp_path / "one.tar.gz", "r:gz") as archive:
+        assert "openlakeforge.yaml" in archive.getnames()
 
 
 def test_payload_install_verify_and_clean_are_scoped_to_olf_home(tmp_path: Path) -> None:
@@ -173,3 +175,5 @@ def test_installed_layout_keeps_platform_assets_in_the_payload_when_a_project_is
     assert layout.project_root == project.resolve()
     assert layout.distribution_root == payload
     assert layout.catalog_path == payload / "release" / "component-catalog.yaml"
+    assert layout.project.root == project.resolve()
+    assert layout.project.distribution_root == payload

--- a/tools/olf/tests/test_e2e_runner.py
+++ b/tools/olf/tests/test_e2e_runner.py
@@ -53,6 +53,26 @@ def test_prepare_config_distribution_root_defaults_to_repo_root(monkeypatch: pyt
     assert cfg.foundation_terraform_dir == E2E_REPO_ROOT / "infra/terraform/foundations/local-kind"
 
 
+def test_prepare_config_uses_external_project_assets_and_distribution_terraform(
+    external_project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OPENLAKEFORGE_CONTRACT_TERRAFORM_DIR", raising=False)
+
+    cfg = _runner.prepare_config(
+        "local",
+        suite=None,
+        namespace="lakehouse",
+        kube_context="",
+        repo_root=external_project,
+        distribution_root=E2E_REPO_ROOT,
+    )
+
+    assert cfg.repo_root == external_project
+    assert cfg.distribution_root == E2E_REPO_ROOT
+    assert cfg.inventory.products[0].id == "order_revenue"
+    assert cfg.contract_terraform_dir == E2E_REPO_ROOT / "infra/terraform/environments/local"
+
+
 def test_aws_default_suite_includes_smoke_and_full_checks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     calls: list[str] = []
 

--- a/tools/olf/tests/test_initialization.py
+++ b/tools/olf/tests/test_initialization.py
@@ -22,6 +22,11 @@ runner = CliRunner()
 
 def _layout(tmp_path: Path) -> RuntimeLayout:
     distribution = tmp_path / "distribution"
+    (distribution / "openlakeforge.yaml").parent.mkdir(parents=True)
+    (distribution / "openlakeforge.yaml").write_text(
+        "apiVersion: openlakeforge.io/v1alpha1\nkind: DeploymentProfile\n",
+        encoding="utf-8",
+    )
     definitions = distribution / "lakehouse_code" / "definitions.py"
     definitions.parent.mkdir(parents=True)
     definitions.write_text("defs = object()\n", encoding="utf-8")
@@ -80,6 +85,7 @@ def test_default_init_copies_a_writable_demo_and_keeps_unowned_paths(tmp_path: P
     result = _initializer(layout, manager).initialize(environ={"OLF_TOOLCHAIN_MODE": "managed"})
 
     assert result.lakehouse_root == layout.project_root / "lakehouse_code"
+    assert (layout.project_root / "openlakeforge.yaml").is_file()
     assert result.next_command == "olf deploy --provider local --profile slim"
     assert (result.lakehouse_root / "demo.txt").read_text(encoding="utf-8") == "demo\n"
     assert os.access(result.lakehouse_root / "demo.txt", os.W_OK)
@@ -131,6 +137,27 @@ def test_init_refuses_an_existing_lakehouse_before_provisioning_tools(tmp_path: 
         _initializer(layout, manager).initialize()
 
     assert manager.calls == 0
+
+
+def test_init_refuses_an_existing_profile_before_provisioning_tools(tmp_path: Path) -> None:
+    layout = _layout(tmp_path)
+    (layout.project_root / "openlakeforge.yaml").write_text("existing\n", encoding="utf-8")
+    manager = _Manager()
+
+    with pytest.raises(InitializationError, match="refusing to overwrite"):
+        _initializer(layout, manager).initialize()
+
+    assert manager.calls == 0
+
+
+def test_init_cleans_staged_code_when_the_distribution_profile_is_missing(tmp_path: Path) -> None:
+    layout = _layout(tmp_path)
+    (layout.distribution_root / "openlakeforge.yaml").unlink()
+
+    with pytest.raises(InitializationError, match="missing project profile template"):
+        _initializer(layout).initialize()
+
+    assert list(layout.project_root.iterdir()) == []
 
 
 def test_init_leaves_no_project_when_docker_is_unreachable(tmp_path: Path) -> None:
@@ -282,6 +309,8 @@ def test_empty_init_writes_only_the_canonical_package_skeleton(tmp_path: Path) -
     layout = _layout(tmp_path)
 
     result = _initializer(layout).initialize(empty=True)
+
+    assert (result.project_root / "openlakeforge.yaml").is_file()
 
     tree = sorted(str(p.relative_to(result.lakehouse_root)) for p in result.lakehouse_root.rglob("*"))
     assert tree == [

--- a/tools/olf/tests/test_openmetadata_config.py
+++ b/tools/olf/tests/test_openmetadata_config.py
@@ -1,4 +1,8 @@
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from olf import openmetadata as om
 from olf.openmetadata._config import OpenMetadataConfig
@@ -224,3 +228,35 @@ def test_config_from_environment_preserves_explicit_empty_schema_contract() -> N
 
     assert cfg.catalog_silver_schema_fqns == {}
     assert cfg.catalog_gold_schema_fqns == {}
+
+
+def test_openmetadata_command_anchors_its_default_metadata_root_to_the_project(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from olf import k8s, openmetadata
+    from olf.commands import openmetadata as command
+
+    project = tmp_path / "project"
+    distribution = tmp_path / "distribution"
+    captured: dict[str, str] = {}
+    monkeypatch.setenv("OPENLAKEFORGE_PROJECT_ROOT", str(project))
+    monkeypatch.setenv("OLF_DISTRIBUTION_ROOT", str(distribution))
+    monkeypatch.setattr(k8s, "wait_for_rollout", lambda *_args: None)
+
+    @contextmanager
+    def _port_forward(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+        yield 18585
+
+    monkeypatch.setattr(k8s, "port_forward", _port_forward)
+
+    def _config(*_args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        captured["metadata_root"] = kwargs["metadata_root"]
+        return SimpleNamespace(base_url=kwargs["base_url"])
+
+    monkeypatch.setattr(openmetadata.OpenMetadataConfig, "from_environment", staticmethod(_config))
+    monkeypatch.setattr(openmetadata, "OpenMetadataClient", lambda _url: object())
+    monkeypatch.setattr(openmetadata, "OpenMetadataDeployer", lambda *_args: SimpleNamespace(deploy=lambda: None))
+
+    command.deploy_openmetadata_metadata()
+
+    assert captured["metadata_root"] == str(project / "lakehouse_code")

--- a/tools/olf/tests/test_project.py
+++ b/tools/olf/tests/test_project.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from olf.cli import app
+from olf.commands import checks
+from olf.project import ProjectSpec, validate_project
+
+runner = CliRunner()
+
+
+def test_project_spec_resolves_canonical_paths_for_a_split_root(tmp_path: Path) -> None:
+    project = ProjectSpec(root=tmp_path / "project", distribution_root=tmp_path / "distribution")
+
+    assert project.profile_path == tmp_path / "project/openlakeforge.yaml"
+    assert project.code_root == tmp_path / "project/lakehouse_code"
+    assert project.lakehouse_path == tmp_path / "project/lakehouse_code/lakehouse.yaml"
+    assert project.bronze_root == tmp_path / "project/lakehouse_code/bronze"
+    assert project.silver_root == tmp_path / "project/lakehouse_code/silver"
+    assert project.gold_root == tmp_path / "project/lakehouse_code/gold"
+    assert project.dashboards_root == tmp_path / "project/lakehouse_code/dashboards/superset"
+    assert project.pipelines_root == tmp_path / "project/lakehouse_code/pipelines/dagster"
+    assert project.schema_root == tmp_path / "distribution/docs/schema"
+
+
+def test_project_spec_keeps_project_paths_under_a_shared_root(tmp_path: Path) -> None:
+    project = ProjectSpec(root=tmp_path, distribution_root=tmp_path)
+
+    assert project.root == project.distribution_root
+    assert project.code_root == tmp_path / "lakehouse_code"
+
+
+def test_external_project_contains_no_distribution_assets(external_project: Path) -> None:
+    assert (external_project / "openlakeforge.yaml").is_file()
+    assert (external_project / "lakehouse_code").is_dir()
+    for path in (".git", "infra", "images", "libs", "packages", "infra/helm", "infra/terraform"):
+        assert not (external_project / path).exists()
+
+
+def test_project_validation_reports_a_valid_external_project(external_project: Path) -> None:
+    distribution = Path(__file__).resolve().parents[3]
+
+    report = validate_project(ProjectSpec(root=external_project, distribution_root=distribution))
+
+    assert report.ok
+    assert json.loads(report.render_json()) == {
+        "schema_version": 1,
+        "valid": True,
+        "project_root": str(external_project),
+        "distribution_root": str(distribution),
+        "checks": [
+            {"name": "canonical_layout", "ok": True, "detail": "canonical project paths are present"},
+            {"name": "descriptors", "ok": True, "detail": "descriptors validated"},
+            {"name": "inventory", "ok": True, "detail": "3 product(s) discovered"},
+            {"name": "project_assets", "ok": True, "detail": "declared project assets are present"},
+        ],
+    }
+
+
+def test_project_validation_reports_missing_profile_without_non_json_output(external_project: Path) -> None:
+    (external_project / "openlakeforge.yaml").unlink()
+    distribution = Path(__file__).resolve().parents[3]
+
+    result = runner.invoke(app, ["project", "validate", "--project", str(external_project)])
+
+    assert result.exit_code == 1
+    report = json.loads(result.output)
+    assert report["valid"] is False
+    assert report["checks"][0] == {
+        "name": "canonical_layout",
+        "ok": False,
+        "detail": "missing: openlakeforge.yaml",
+    }
+    assert report["distribution_root"] == str(distribution)
+
+
+def test_project_validation_reports_missing_plural_path(external_project: Path) -> None:
+    dashboards = external_project / "lakehouse_code/dashboards"
+    shutil.rmtree(dashboards)
+    distribution = Path(__file__).resolve().parents[3]
+
+    report = validate_project(ProjectSpec(root=external_project, distribution_root=distribution))
+
+    assert not report.ok
+    assert report.checks[0].detail == "missing: lakehouse_code/dashboards/superset/"
+
+
+def test_project_validation_reports_missing_declared_asset(external_project: Path) -> None:
+    (external_project / "lakehouse_code/pipelines/dagster/order_revenue.py").unlink()
+    distribution = Path(__file__).resolve().parents[3]
+
+    report = validate_project(ProjectSpec(root=external_project, distribution_root=distribution))
+
+    assert not report.ok
+    assert report.checks[-1].name == "project_assets"
+    assert "lakehouse_code/pipelines/dagster/order_revenue.py" in report.checks[-1].detail
+
+
+def test_project_validation_reports_invalid_descriptors(external_project: Path) -> None:
+    lakehouse = external_project / "lakehouse_code/lakehouse.yaml"
+    lakehouse.write_text("apiVersion: invalid\n", encoding="utf-8")
+    distribution = Path(__file__).resolve().parents[3]
+
+    report = validate_project(ProjectSpec(root=external_project, distribution_root=distribution))
+
+    assert not report.ok
+    assert report.checks[1].name == "descriptors"
+    assert report.checks[1].ok is False
+    assert report.checks[2].name == "inventory"
+    assert report.checks[2].ok is False
+
+
+def test_project_code_check_uses_external_code_and_distribution_dependencies(
+    external_project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _VersionInfo(tuple):
+        @property
+        def major(self) -> int:
+            return self[0]
+
+        @property
+        def minor(self) -> int:
+            return self[1]
+
+    calls: list[tuple[list[str], Path, dict[str, str]]] = []
+    monkeypatch.setattr(checks.sys, "version_info", _VersionInfo((3, 12, 0, "final", 0)))
+    monkeypatch.setattr(checks, "_uv_pip_install", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        checks,
+        "_run",
+        lambda argv, *, cwd, env=None: calls.append((argv, cwd, env or {})),
+    )
+
+    checks.project_code(str(external_project))
+
+    distribution = Path(__file__).resolve().parents[3]
+    argv, cwd, env = calls[-1]
+    assert argv[-1] == str(external_project)
+    assert cwd == external_project
+    assert env["PYTHONPATH"].split(os.pathsep)[-2:] == [str(external_project), str(distribution)]
+    assert not (external_project / ".cache").exists()


### PR DESCRIPTION
Closes #112

## Summary

Define the v0.3 external data-project boundary while retaining the existing v0.2 deployment shorthand. A writable project is now an explicit `ProjectSpec` containing `openlakeforge.yaml` and `lakehouse_code/`; Terraform, Helm, schemas, shared libraries, image definitions, state, work, and caches remain distribution-owned.

## Why

Several isolated paths already accepted an external project root, but consumers still used ambiguous repository roots. This made metadata discovery depend on the caller working directory and could assemble standalone project-code images from the wrong distribution tree.

## Changes

- Add frozen `ProjectSpec`, canonical project paths, and JSON-only `olf project validate --project PATH`.
- Package the structural `openlakeforge.yaml` profile marker and make `olf init` atomically create both project-owned targets without overwriting either.
- Route selected project/distribution roots through checks, build composition, scaffolding, dbt, Superset, OpenMetadata, catalog, artifacts, and E2E configuration.
- Anchor OpenMetadata metadata discovery to the selected project code root and compose external project-code builds from distribution platform assets plus selected project code.
- Document the boundary in ADR 0009, README, setup, architecture, and contributor guidance.

## Validation

- `uv run --python 3.12 --project tools/olf olf check all`
- `uv run --python 3.12 --project tools/olf ruff check tools/olf`
- `uv run --python 3.12 --project tools/olf pytest tools/olf/tests` (1,053 tests)
- External temporary project: `olf project validate` and `olf check contracts` passed with distribution assets outside the project.

## Runtime proof

The external local deploy resolved the expected split roots, then stopped at the existing local Docker configuration: Terraform local-exec received `DOCKER_HOST=unix:///var/run/docker.sock`, which is unavailable despite the Docker CLI working through its configured context. No platform or artifact phase ran, so E2E could not run.