### PR TITLE
fix: probe Colima's docker socket when ambient context resolution misses it

### DIFF
--- a/tools/olf/olf/deployment/cloud/provider.py
+++ b/tools/olf/olf/deployment/cloud/provider.py
@@ -51,7 +51,10 @@ class CloudProvider:
         environ: Mapping[str, str] | None = None,
     ) -> CloudProvider:
         return cls(
-            config=config, backend=backend, tools=toolkit or Toolkit.default(), _environ=environ or os.environ
+            config=config,
+            backend=backend,
+            tools=toolkit or Toolkit.default(),
+            _environ=environ if environ is not None else os.environ,
         )
 
     @property

--- a/tools/olf/olf/deployment/local/foundation.py
+++ b/tools/olf/olf/deployment/local/foundation.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping
 
 from olf import log
 from olf.deployment.engine import Toolkit
-from olf.deployment.errors import DeploymentPreconditionError
+from olf.deployment.errors import CommandExecutionError, DeploymentPreconditionError, ExecutableNotFoundError
 from olf.deployment.local.config import LocalDeploymentConfig
 from olf.tooling.kubectl import KubeContextUnreachableError
 
@@ -50,6 +50,8 @@ def foundation_up(config: LocalDeploymentConfig, tools: Toolkit, *, env: Mapping
     foundation_dir = config.paths.foundation_terraform_dir
     config.context.prepare_directories()
 
+    _require_docker_reachable(tools, env=env)
+
     log.step("Initializing Terraform local kind foundation...")
     tools.terraform.init(foundation_dir, env=env)
 
@@ -68,6 +70,24 @@ def foundation_up(config: LocalDeploymentConfig, tools: Toolkit, *, env: Mapping
         ) from exc
 
     log.step(f"Local foundation is ready. Kubernetes context: {config.kube_context}")
+
+
+def _require_docker_reachable(tools: Toolkit, *, env: Mapping[str, str]) -> None:
+    """Fail with an actionable message before Terraform's local-exec
+    provisioner (`infra/terraform/foundations/local-kind/main.tf`) hits its
+    own generic "Docker daemon is not running or not accessible" check - the
+    actual cause in #156 was a stale Docker Desktop socket surviving under a
+    scoped, context-less DOCKER_CONFIG on a Colima-only host.
+    """
+    try:
+        tools.docker.version(env=env)
+    except (CommandExecutionError, ExecutableNotFoundError) as exc:
+        endpoint = env.get("DOCKER_HOST", "the default Docker context (no DOCKER_HOST was resolved)")
+        raise DeploymentPreconditionError(
+            f"Docker is not reachable at {endpoint}: {exc}\n"
+            "Compare this against 'docker context show' on this host, or set DOCKER_HOST "
+            "explicitly to override endpoint resolution."
+        ) from exc
 
 
 def foundation_down(

--- a/tools/olf/olf/deployment/local/provider.py
+++ b/tools/olf/olf/deployment/local/provider.py
@@ -38,7 +38,11 @@ class LocalProvider:
         toolkit: Toolkit | None = None,
         environ: Mapping[str, str] | None = None,
     ) -> LocalProvider:
-        return cls(config=config, tools=toolkit or Toolkit.default(), _environ=environ or os.environ)
+        return cls(
+            config=config,
+            tools=toolkit or Toolkit.default(),
+            _environ=environ if environ is not None else os.environ,
+        )
 
     @property
     def context(self) -> DeploymentContext:

--- a/tools/olf/olf/tooling/docker.py
+++ b/tools/olf/olf/tooling/docker.py
@@ -11,6 +11,7 @@ back to probing Colima's own on-disk socket convention.
 
 from __future__ import annotations
 
+import socket
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
@@ -19,18 +20,37 @@ from olf.deployment.retry import RetryPolicy, RetryPredicate
 from olf.tooling.process import CommandResult, ProcessRunner
 from olf.tooling.resolver import ExecutableResolver
 
+_SOCKET_CONNECT_TIMEOUT_SECONDS = 0.5
+
+
+def _unix_socket_connectable(path: Path) -> bool:
+    """Whether a unix socket at `path` actually accepts a connection.
+
+    A daemon that exited without unlinking its socket can leave the inode
+    behind - `Path.is_socket()` stays true even though connecting fails with
+    ECONNREFUSED - so connectivity must be tested directly rather than
+    inferred from the file type alone.
+    """
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.settimeout(_SOCKET_CONNECT_TIMEOUT_SECONDS)
+        try:
+            sock.connect(str(path))
+        except OSError:
+            return False
+    return True
+
 
 def _is_reachable_unix_endpoint(endpoint: str) -> bool:
-    """Whether a `unix://` endpoint's socket file actually exists and is a socket.
+    """Whether a `unix://` endpoint's socket actually accepts a connection.
 
     Non-unix schemes (tcp://, npipe://, ssh://) are trusted without validation -
     remote/Windows engines are out of scope here. Catches the #156 failure
-    mode: a stale Docker Desktop symlink at the default socket path that
+    mode: a stale Docker Desktop socket at the default endpoint that
     `docker context inspect` still reports, even though nothing listens on it.
     """
     if not endpoint.startswith("unix://"):
         return True
-    return Path(endpoint.removeprefix("unix://")).is_socket()
+    return _unix_socket_connectable(Path(endpoint.removeprefix("unix://")))
 
 
 def _probe_colima_socket(*, env: Mapping[str, str] | None) -> str | None:
@@ -49,7 +69,7 @@ def _probe_colima_socket(*, env: Mapping[str, str] | None) -> str | None:
     colima_dir = Path(home) / ".colima"
     if not colima_dir.is_dir():
         return None
-    candidates = sorted(p for p in colima_dir.glob("*/docker.sock") if p.is_socket())
+    candidates = sorted(p for p in colima_dir.glob("*/docker.sock") if _unix_socket_connectable(p))
     if not candidates:
         return None
     default_socket = colima_dir / "default" / "docker.sock"

--- a/tools/olf/olf/tooling/docker.py
+++ b/tools/olf/olf/tooling/docker.py
@@ -4,6 +4,9 @@ Preserves the "resolve the selected engine endpoint before scoping
 DOCKER_CONFIG" behavior from `scripts/lib/common.sh::configure_deployment_scope`
 so an isolated DOCKER_CONFIG cannot silently fall back to
 `/var/run/docker.sock` on hosts using Colima or another non-default context.
+When that resolution itself misses (e.g. it returns a stale Docker Desktop
+socket on a Colima-only host - #156), `resolve_current_engine_endpoint` falls
+back to probing Colima's own on-disk socket convention.
 """
 
 from __future__ import annotations
@@ -15,6 +18,46 @@ from olf.deployment.errors import CommandExecutionError, ExecutableNotFoundError
 from olf.deployment.retry import RetryPolicy, RetryPredicate
 from olf.tooling.process import CommandResult, ProcessRunner
 from olf.tooling.resolver import ExecutableResolver
+
+
+def _is_reachable_unix_endpoint(endpoint: str) -> bool:
+    """Whether a `unix://` endpoint's socket file actually exists and is a socket.
+
+    Non-unix schemes (tcp://, npipe://, ssh://) are trusted without validation -
+    remote/Windows engines are out of scope here. Catches the #156 failure
+    mode: a stale Docker Desktop symlink at the default socket path that
+    `docker context inspect` still reports, even though nothing listens on it.
+    """
+    if not endpoint.startswith("unix://"):
+        return True
+    return Path(endpoint.removeprefix("unix://")).is_socket()
+
+
+def _probe_colima_socket(*, env: Mapping[str, str] | None) -> str | None:
+    """Look for a Colima-managed Docker socket under `$HOME/.colima`.
+
+    Only probes when `env` carries an explicit HOME - deliberately never
+    falls back to `Path.home()`, which would make this depend on whichever
+    machine runs the code, including tests that pass a HOME-less env to stay
+    isolated from ambient state. Prefers the `default` profile; an
+    unambiguous single non-default profile is used as-is; two or more
+    candidates are not guessed between.
+    """
+    home = env.get("HOME") if env else None
+    if not home:
+        return None
+    colima_dir = Path(home) / ".colima"
+    if not colima_dir.is_dir():
+        return None
+    candidates = sorted(p for p in colima_dir.glob("*/docker.sock") if p.is_socket())
+    if not candidates:
+        return None
+    default_socket = colima_dir / "default" / "docker.sock"
+    if default_socket in candidates:
+        return f"unix://{default_socket}"
+    if len(candidates) == 1:
+        return f"unix://{candidates[0]}"
+    return None
 
 
 class Docker:
@@ -147,13 +190,23 @@ class Docker:
         case. This must tolerate Docker being entirely absent (not just a
         failing command), since Docker-independent operations (status,
         platform/foundation teardown) also resolve a command environment.
+
+        When the resolved endpoint isn't actually reachable - #156's stale
+        Docker Desktop socket surviving under a scoped, context-less
+        DOCKER_CONFIG on a Colima-only host - probes Colima's on-disk socket
+        convention rather than handing the caller a dead endpoint. Falls back
+        to the original (possibly unreachable) result when the probe can't
+        disambiguate, so an already-correct non-Colima setup is never touched.
         """
         try:
             current = self.context_show(env=env)
-            endpoint = self.context_inspect(current, format_template="{{.Endpoints.docker.Host}}", env=env)
+            endpoint = self.context_inspect(current, format_template="{{.Endpoints.docker.Host}}", env=env) or None
         except (CommandExecutionError, ExecutableNotFoundError):
-            return None
-        return endpoint or None
+            endpoint = None
+
+        if endpoint is not None and _is_reachable_unix_endpoint(endpoint):
+            return endpoint
+        return _probe_colima_socket(env=env) or endpoint
 
     def build(
         self,

--- a/tools/olf/tests/test_local_foundation.py
+++ b/tools/olf/tests/test_local_foundation.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from _tooling_support import RecordingRunner
+from _tooling_support import RecordedCall, RecordingRunner
 
 from olf.deployment.context import DeploymentContext
 from olf.deployment.engine import Toolkit
-from olf.deployment.errors import DeploymentPreconditionError
+from olf.deployment.errors import CommandExecutionError, DeploymentPreconditionError
 from olf.deployment.local import foundation
 from olf.deployment.local.config import LocalDeploymentConfig
 from olf.tooling.process import CommandResult
@@ -114,12 +114,33 @@ def test_foundation_up_applies_exports_kubeconfig_and_checks_reachability(tmp_pa
 
     foundation.foundation_up(config, tools, env={})
 
-    assert ["terraform", "-chdir=" + str(config.paths.foundation_terraform_dir), "init"] == runner.calls[0].argv
-    assert runner.calls[1].argv[2] == "apply"
+    assert runner.calls[0].argv[:2] == ["docker", "version"]
+    assert ["terraform", "-chdir=" + str(config.paths.foundation_terraform_dir), "init"] == runner.calls[1].argv
+    assert runner.calls[2].argv[2] == "apply"
     export_call = next(c for c in runner.calls if "export" in c.argv)
     assert export_call.argv[:3] == ["kind", "export", "kubeconfig"]
     assert any("get-contexts" in c.argv for c in runner.calls)
     assert any("cluster-info" in c.argv for c in runner.calls)
+
+
+def test_foundation_up_raises_actionable_error_when_docker_is_unreachable(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+
+    class _DockerUnreachableRunner(RecordingRunner):
+        def run(self, command, **kwargs):  # type: ignore[override]
+            argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+            self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+            if argv[:2] == ["docker", "version"]:
+                raise CommandExecutionError(argv, 1, stderr="Cannot connect to the Docker daemon")
+            return _ok()
+
+    runner = _DockerUnreachableRunner()
+    tools = _toolkit_with_runner(runner)
+
+    with pytest.raises(DeploymentPreconditionError, match="Docker is not reachable"):
+        foundation.foundation_up(config, tools, env={})
+
+    assert not any(c.argv[0] == "terraform" for c in runner.calls)
 
 
 def test_foundation_down_is_idempotent_when_nothing_exists(tmp_path: Path) -> None:

--- a/tools/olf/tests/test_local_provider.py
+++ b/tools/olf/tests/test_local_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import socket
 import tempfile
 from pathlib import Path
@@ -104,13 +105,24 @@ def test_env_resolves_docker_host_from_ambient_context_when_unset(tmp_path: Path
     assert provider.env["DOCKER_HOST"] == "unix:///colima/docker.sock"
 
 
-def test_env_falls_back_to_colima_socket_when_ambient_context_resolution_is_stale(tmp_path: Path) -> None:
+def test_env_falls_back_to_colima_socket_when_ambient_context_resolution_is_dead(tmp_path: Path) -> None:
+    """The endpoint `docker context show`/`inspect` returns can point at a
+    socket file left behind by a daemon that exited without unlinking it -
+    #156's stale Docker Desktop socket. `LocalProvider.env` must not accept
+    it just because the inode exists; it must fall back to a live Colima
+    socket."""
     with tempfile.TemporaryDirectory(dir="/tmp") as home:
-        stale_socket = Path(home) / "stale" / "docker.sock"  # never bound - not a socket
+        stale_socket = Path(home) / "stale" / "docker.sock"
+        stale_socket.parent.mkdir(parents=True, exist_ok=True)
+        dead = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        dead.bind(str(stale_socket))
+        dead.close()  # leaves the socket-type inode behind with nothing listening
+
         default_socket = Path(home) / ".colima" / "default" / "docker.sock"
         default_socket.parent.mkdir(parents=True, exist_ok=True)
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.bind(str(default_socket))
+        live = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        live.bind(str(default_socket))
+        live.listen(1)
 
         class _ScriptedRunner(RecordingRunner):
             def run(self, command, **kwargs):  # type: ignore[override]
@@ -119,23 +131,24 @@ def test_env_falls_back_to_colima_socket_when_ambient_context_resolution_is_stal
                 stdout = "colima\n" if argv[-2:] == ["context", "show"] else f"unix://{stale_socket}\n"
                 return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
 
-        runner = _ScriptedRunner()
-        resolver = PathExecutableResolver(overrides={tool: Path(tool) for tool in _TOOLS})
-        toolkit = Toolkit(
-            runner=runner,
-            resolver=resolver,
-            terraform=Terraform(runner, resolver),
-            helm=Helm(runner, resolver),
-            kubectl=Kubectl(runner, resolver),
-            docker=Docker(runner, resolver),
-            kind=Kind(runner, resolver),
-            aws=AwsCli(runner, resolver),
-            azure=AzureCli(runner, resolver),
-        )
+        with contextlib.closing(live):
+            runner = _ScriptedRunner()
+            resolver = PathExecutableResolver(overrides={tool: Path(tool) for tool in _TOOLS})
+            toolkit = Toolkit(
+                runner=runner,
+                resolver=resolver,
+                terraform=Terraform(runner, resolver),
+                helm=Helm(runner, resolver),
+                kubectl=Kubectl(runner, resolver),
+                docker=Docker(runner, resolver),
+                kind=Kind(runner, resolver),
+                aws=AwsCli(runner, resolver),
+                azure=AzureCli(runner, resolver),
+            )
 
-        provider = LocalProvider.create(_config(tmp_path), toolkit=toolkit, environ={"HOME": home})
+            provider = LocalProvider.create(_config(tmp_path), toolkit=toolkit, environ={"HOME": home})
 
-        assert provider.env["DOCKER_HOST"] == f"unix://{default_socket}"
+            assert provider.env["DOCKER_HOST"] == f"unix://{default_socket}"
 
 
 def test_foundation_doctor_does_not_require_helm(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001

--- a/tools/olf/tests/test_local_provider.py
+++ b/tools/olf/tests/test_local_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import socket
+import tempfile
 from pathlib import Path
 
 from _tooling_support import RecordedCall, RecordingRunner
@@ -100,6 +102,40 @@ def test_env_resolves_docker_host_from_ambient_context_when_unset(tmp_path: Path
     provider = LocalProvider.create(_config(tmp_path), toolkit=toolkit, environ={})
 
     assert provider.env["DOCKER_HOST"] == "unix:///colima/docker.sock"
+
+
+def test_env_falls_back_to_colima_socket_when_ambient_context_resolution_is_stale(tmp_path: Path) -> None:
+    with tempfile.TemporaryDirectory(dir="/tmp") as home:
+        stale_socket = Path(home) / "stale" / "docker.sock"  # never bound - not a socket
+        default_socket = Path(home) / ".colima" / "default" / "docker.sock"
+        default_socket.parent.mkdir(parents=True, exist_ok=True)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(str(default_socket))
+
+        class _ScriptedRunner(RecordingRunner):
+            def run(self, command, **kwargs):  # type: ignore[override]
+                argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+                self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+                stdout = "colima\n" if argv[-2:] == ["context", "show"] else f"unix://{stale_socket}\n"
+                return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
+
+        runner = _ScriptedRunner()
+        resolver = PathExecutableResolver(overrides={tool: Path(tool) for tool in _TOOLS})
+        toolkit = Toolkit(
+            runner=runner,
+            resolver=resolver,
+            terraform=Terraform(runner, resolver),
+            helm=Helm(runner, resolver),
+            kubectl=Kubectl(runner, resolver),
+            docker=Docker(runner, resolver),
+            kind=Kind(runner, resolver),
+            aws=AwsCli(runner, resolver),
+            azure=AzureCli(runner, resolver),
+        )
+
+        provider = LocalProvider.create(_config(tmp_path), toolkit=toolkit, environ={"HOME": home})
+
+        assert provider.env["DOCKER_HOST"] == f"unix://{default_socket}"
 
 
 def test_foundation_doctor_does_not_require_helm(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001

--- a/tools/olf/tests/test_tooling_docker.py
+++ b/tools/olf/tests/test_tooling_docker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import socket
+import tempfile
 from pathlib import Path
 
 from _tooling_support import RecordedCall, RecordingRunner
@@ -7,6 +9,15 @@ from _tooling_support import RecordedCall, RecordingRunner
 from olf.tooling.docker import Docker
 from olf.tooling.process import CommandResult
 from olf.tooling.resolver import PathExecutableResolver
+
+
+def _bind_unix_socket(path: Path) -> None:
+    """Bind a real AF_UNIX socket at `path`, under a short /tmp-rooted dir -
+    macOS/BSD sun_path is capped at ~104 bytes, which pytest's deeply nested
+    tmp_path can exceed once `.colima/<profile>/docker.sock` is appended."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(str(path))
 
 
 def _docker(result: CommandResult | None = None) -> tuple[Docker, RecordingRunner]:
@@ -108,6 +119,98 @@ def test_resolve_current_engine_endpoint_chains_show_and_inspect() -> None:
         "--format",
         "{{.Endpoints.docker.Host}}",
     ]
+
+
+def test_resolve_current_engine_endpoint_falls_back_to_default_colima_socket_when_resolution_fails() -> None:
+    from olf.deployment.errors import CommandExecutionError
+
+    class FailingRunner(RecordingRunner):
+        def run(self, command, **kwargs):  # type: ignore[override]
+            raise CommandExecutionError(["docker", "context", "show"], 1, stderr="no context")
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as home:
+        default_socket = Path(home) / ".colima" / "default" / "docker.sock"
+        _bind_unix_socket(default_socket)
+        docker = Docker(FailingRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+
+        endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
+
+        assert endpoint == f"unix://{default_socket}"
+
+
+def test_resolve_current_engine_endpoint_falls_back_when_resolved_socket_is_stale() -> None:
+    with tempfile.TemporaryDirectory(dir="/tmp") as home:
+        stale_socket = Path(home) / "stale" / "docker.sock"  # never bound - not a socket
+        default_socket = Path(home) / ".colima" / "default" / "docker.sock"
+        _bind_unix_socket(default_socket)
+
+        class ScriptedRunner(RecordingRunner):
+            def run(self, command, **kwargs):  # type: ignore[override]
+                argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+                self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+                stdout = "default\n" if argv[-2:] == ["context", "show"] else f"unix://{stale_socket}\n"
+                return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
+
+        docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+
+        endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
+
+        assert endpoint == f"unix://{default_socket}"
+
+
+def test_resolve_current_engine_endpoint_does_not_guess_between_ambiguous_colima_profiles() -> None:
+    with tempfile.TemporaryDirectory(dir="/tmp") as home:
+        stale_socket = Path(home) / "stale" / "docker.sock"  # never bound - not a socket
+        _bind_unix_socket(Path(home) / ".colima" / "profileA" / "docker.sock")
+        _bind_unix_socket(Path(home) / ".colima" / "profileB" / "docker.sock")
+
+        class ScriptedRunner(RecordingRunner):
+            def run(self, command, **kwargs):  # type: ignore[override]
+                argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+                self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+                stdout = "default\n" if argv[-2:] == ["context", "show"] else f"unix://{stale_socket}\n"
+                return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
+
+        docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+
+        endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
+
+        assert endpoint == f"unix://{stale_socket}"
+
+
+def test_resolve_current_engine_endpoint_skips_colima_probe_when_resolved_socket_is_reachable() -> None:
+    with tempfile.TemporaryDirectory(dir="/tmp") as home:
+        reachable_socket = Path(home) / "reachable" / "docker.sock"
+        _bind_unix_socket(reachable_socket)
+        _bind_unix_socket(Path(home) / ".colima" / "default" / "docker.sock")
+
+        class ScriptedRunner(RecordingRunner):
+            def run(self, command, **kwargs):  # type: ignore[override]
+                argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+                self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+                stdout = "default\n" if argv[-2:] == ["context", "show"] else f"unix://{reachable_socket}\n"
+                return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
+
+        docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+
+        endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
+
+        assert endpoint == f"unix://{reachable_socket}"
+
+
+def test_resolve_current_engine_endpoint_trusts_non_unix_schemes_without_validation() -> None:
+    class ScriptedRunner(RecordingRunner):
+        def run(self, command, **kwargs):  # type: ignore[override]
+            argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+            self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+            stdout = "remote\n" if argv[-2:] == ["context", "show"] else "tcp://host:2375\n"
+            return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
+
+    docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+
+    endpoint = docker.resolve_current_engine_endpoint()
+
+    assert endpoint == "tcp://host:2375"
 
 
 def test_server_arch_returns_stripped_output() -> None:

--- a/tools/olf/tests/test_tooling_docker.py
+++ b/tools/olf/tests/test_tooling_docker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import socket
 import tempfile
 from pathlib import Path
@@ -11,13 +12,29 @@ from olf.tooling.process import CommandResult
 from olf.tooling.resolver import PathExecutableResolver
 
 
-def _bind_unix_socket(path: Path) -> None:
-    """Bind a real AF_UNIX socket at `path`, under a short /tmp-rooted dir -
-    macOS/BSD sun_path is capped at ~104 bytes, which pytest's deeply nested
-    tmp_path can exceed once `.colima/<profile>/docker.sock` is appended."""
+def _listening_socket(path: Path) -> socket.socket:
+    """Bind and listen on a real AF_UNIX socket at `path`, under a short
+    /tmp-rooted dir - macOS/BSD sun_path is capped at ~104 bytes, which
+    pytest's deeply nested tmp_path can exceed once
+    `.colima/<profile>/docker.sock` is appended. The caller must keep the
+    returned socket alive (e.g. via `contextlib.closing`) for as long as it
+    should be connectable - connectivity, not just the inode type, is what
+    `resolve_current_engine_endpoint` now checks."""
     path.parent.mkdir(parents=True, exist_ok=True)
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.bind(str(path))
+    sock.listen(1)
+    return sock
+
+
+def _dead_socket_file(path: Path) -> None:
+    """Leave a socket-type inode at `path` with nothing listening - models a
+    daemon (e.g. a quit Docker Desktop) that exited without unlinking its
+    socket file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(str(path))
+    sock.close()
 
 
 def _docker(result: CommandResult | None = None) -> tuple[Docker, RecordingRunner]:
@@ -130,19 +147,24 @@ def test_resolve_current_engine_endpoint_falls_back_to_default_colima_socket_whe
 
     with tempfile.TemporaryDirectory(dir="/tmp") as home:
         default_socket = Path(home) / ".colima" / "default" / "docker.sock"
-        _bind_unix_socket(default_socket)
-        docker = Docker(FailingRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+        with contextlib.closing(_listening_socket(default_socket)):
+            docker = Docker(FailingRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
 
-        endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
+            endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
 
-        assert endpoint == f"unix://{default_socket}"
+            assert endpoint == f"unix://{default_socket}"
 
 
-def test_resolve_current_engine_endpoint_falls_back_when_resolved_socket_is_stale() -> None:
+def test_resolve_current_engine_endpoint_falls_back_when_resolved_socket_is_dead() -> None:
+    """A daemon can exit without unlinking its socket file, so the endpoint
+    `docker context inspect` reports can still look like a valid socket on
+    disk while nothing actually accepts a connection - #156's exact failure
+    mode with a stale Docker Desktop socket. `is_socket()` alone would miss
+    this; connecting to it must not."""
     with tempfile.TemporaryDirectory(dir="/tmp") as home:
-        stale_socket = Path(home) / "stale" / "docker.sock"  # never bound - not a socket
+        stale_socket = Path(home) / "stale" / "docker.sock"
+        _dead_socket_file(stale_socket)
         default_socket = Path(home) / ".colima" / "default" / "docker.sock"
-        _bind_unix_socket(default_socket)
 
         class ScriptedRunner(RecordingRunner):
             def run(self, command, **kwargs):  # type: ignore[override]
@@ -151,18 +173,21 @@ def test_resolve_current_engine_endpoint_falls_back_when_resolved_socket_is_stal
                 stdout = "default\n" if argv[-2:] == ["context", "show"] else f"unix://{stale_socket}\n"
                 return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
 
-        docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+        with contextlib.closing(_listening_socket(default_socket)):
+            docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
 
-        endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
+            endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
 
-        assert endpoint == f"unix://{default_socket}"
+            assert endpoint == f"unix://{default_socket}"
 
 
-def test_resolve_current_engine_endpoint_does_not_guess_between_ambiguous_colima_profiles() -> None:
+def test_resolve_current_engine_endpoint_ignores_a_dead_colima_candidate() -> None:
+    """A dead socket file under `~/.colima` must not be treated as a usable
+    fallback candidate - only a live, connectable one counts."""
     with tempfile.TemporaryDirectory(dir="/tmp") as home:
-        stale_socket = Path(home) / "stale" / "docker.sock"  # never bound - not a socket
-        _bind_unix_socket(Path(home) / ".colima" / "profileA" / "docker.sock")
-        _bind_unix_socket(Path(home) / ".colima" / "profileB" / "docker.sock")
+        stale_socket = Path(home) / "stale" / "docker.sock"
+        _dead_socket_file(stale_socket)
+        _dead_socket_file(Path(home) / ".colima" / "default" / "docker.sock")
 
         class ScriptedRunner(RecordingRunner):
             def run(self, command, **kwargs):  # type: ignore[override]
@@ -178,11 +203,32 @@ def test_resolve_current_engine_endpoint_does_not_guess_between_ambiguous_colima
         assert endpoint == f"unix://{stale_socket}"
 
 
+def test_resolve_current_engine_endpoint_does_not_guess_between_ambiguous_colima_profiles() -> None:
+    with tempfile.TemporaryDirectory(dir="/tmp") as home:
+        stale_socket = Path(home) / "stale" / "docker.sock"
+        _dead_socket_file(stale_socket)
+
+        class ScriptedRunner(RecordingRunner):
+            def run(self, command, **kwargs):  # type: ignore[override]
+                argv = list(command.argv) if hasattr(command, "argv") else [str(p) for p in command]
+                self.calls.append(RecordedCall(argv=argv, kwargs=kwargs))
+                stdout = "default\n" if argv[-2:] == ["context", "show"] else f"unix://{stale_socket}\n"
+                return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
+
+        profile_a = _listening_socket(Path(home) / ".colima" / "profileA" / "docker.sock")
+        profile_b = _listening_socket(Path(home) / ".colima" / "profileB" / "docker.sock")
+        with contextlib.closing(profile_a), contextlib.closing(profile_b):
+            docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+
+            endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
+
+            assert endpoint == f"unix://{stale_socket}"
+
+
 def test_resolve_current_engine_endpoint_skips_colima_probe_when_resolved_socket_is_reachable() -> None:
     with tempfile.TemporaryDirectory(dir="/tmp") as home:
         reachable_socket = Path(home) / "reachable" / "docker.sock"
-        _bind_unix_socket(reachable_socket)
-        _bind_unix_socket(Path(home) / ".colima" / "default" / "docker.sock")
+        _dead_socket_file(Path(home) / ".colima" / "default" / "docker.sock")
 
         class ScriptedRunner(RecordingRunner):
             def run(self, command, **kwargs):  # type: ignore[override]
@@ -191,11 +237,12 @@ def test_resolve_current_engine_endpoint_skips_colima_probe_when_resolved_socket
                 stdout = "default\n" if argv[-2:] == ["context", "show"] else f"unix://{reachable_socket}\n"
                 return CommandResult(argv=tuple(argv), returncode=0, stdout=stdout, stderr="", duration_seconds=0.0)
 
-        docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
+        with contextlib.closing(_listening_socket(reachable_socket)):
+            docker = Docker(ScriptedRunner(), PathExecutableResolver(overrides={"docker": Path("docker")}))
 
-        endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
+            endpoint = docker.resolve_current_engine_endpoint(env={"HOME": home})
 
-        assert endpoint == f"unix://{reachable_socket}"
+            assert endpoint == f"unix://{reachable_socket}"
 
 
 def test_resolve_current_engine_endpoint_trusts_non_unix_schemes_without_validation() -> None:


### PR DESCRIPTION
## Summary

Fixes #156. On a machine running Docker exclusively through Colima (no
Docker Desktop), `olf deploy --provider local` failed at the foundation
phase with a generic Terraform error, even though `docker` worked fine
interactively.

- `Docker.resolve_current_engine_endpoint()` now falls back to probing
  `~/.colima/<profile>/docker.sock` when the ambient-resolved endpoint is
  missing or points at a dead/stale unix socket — the exact failure mode
  reported (a stale Docker Desktop symlink surviving under a scoped,
  context-less `DOCKER_CONFIG`). Prefers the `default` profile; won't guess
  between ambiguous non-default profiles. This is the single shared Docker
  adapter both `LocalProvider` and `CloudProvider` use, so both benefit with
  no duplicated logic.
- `foundation_up()` now preflights Docker reachability before invoking
  Terraform, raising an actionable `DeploymentPreconditionError` (mentioning
  `DOCKER_HOST` and `docker context show`) instead of letting Terraform's
  generic `local-exec` "Docker daemon is not running or not accessible"
  error surface.
- Fixes a latent bug the new tests exposed: `LocalProvider.create()` and
  `CloudProvider.create()` used `environ or os.environ`, which silently
  substituted the real `os.environ` whenever a caller passed an empty
  `environ={}` for test isolation (`{}` is falsy). Harmless before this
  change since nothing keyed off environment content for filesystem
  probing; my new Colima probe made it observable as flaky tests on any
  dev machine that happens to run real Colima.

Root-causing *why* the resolution subprocess's `docker context show`
diverged from an interactive shell's result in the original report is left
open — `ProcessRunner._run_once` always overlays a full `os.environ`
snapshot, so there's no missing-env explanation visible from static
reading; it would need live instrumentation on an affected Colima machine.
This PR implements the issue's resilience-improvement and better-error-message
asks, which are independent of that root cause and fully resolve the
reported symptom.

## Test plan

- [x] `uv run --project tools/olf pytest tools/olf/tests` — 1047 passed
- [x] `uv run --project tools/olf ruff check tools/olf` — clean
- [x] `uv run --project tools/olf olf check all` — infra/component checks
      pass; the `project-code` Python-version check fails on this machine
      (system has 3.14, project requires `>=3.12,<3.13`) — pre-existing,
      unrelated to this change
- [x] No Colima install was available in this environment to reproduce the
      original failure end-to-end. Strongest verification would be
      unsetting `DOCKER_HOST` and running
      `olf deploy --provider local --profile slim` on a Colima-only host.