### PR TITLE
feat: give PROD a stopped daily schedule scaffold (#134)

### DIFF
--- a/docs/architecture/project-revisions.md
+++ b/docs/architecture/project-revisions.md
@@ -58,6 +58,33 @@ provider contract. It writes an immutable `ProjectActivation` beneath
 the stage's `openlakeforge-project` Helm release is ready. Project revisions
 remain equal across stages; activation and Floe revisions intentionally differ.
 
+## Schedules are not a promotion side effect
+
+The same revision is deployed to every stage, so nothing about a schedule can
+be decided at build time. `libs.product_dagster.build_stage_schedules` decides
+it at load time from `OPENLAKEFORGE_STAGE`, which activation puts on the
+code-server container:
+`DeploymentContext.command_env` sets it, `applied_contract_environment` carries
+it into the contract environment, and `_user_values` forwards every
+`OPENLAKEFORGE_*` key onto the deployment.
+
+| Stage the pod reports | Schedules in the code location |
+| --- | --- |
+| `prod` | One `<product>_daily` per product, every one `STOPPED` |
+| `dev`, `uat` | None |
+| Unset or unrecognised | None |
+
+Two properties matter, and `olf check project-code` fails the build if either
+stops holding. DEV and UAT define no schedule at all, so the production-shaped
+daily job is not present to be switched on by mistake against the DEV catalog.
+The PROD schedules default to `STOPPED`, so deploying or promoting a revision
+never starts a run — enabling one is a deliberate act in the Dagster UI, and
+Dagster keeps that choice in the stage's own metadata database, which is not
+part of the revision.
+
+Asset keys are identical in every stage regardless: the stage is a runtime and
+catalog boundary, never part of an asset's identity.
+
 ## What is frozen
 
 | Component | Source | Notes |

--- a/libs/product_dagster.py
+++ b/libs/product_dagster.py
@@ -13,9 +13,11 @@ from dagster import (
     AssetKey,
     AssetOut,
     AssetSelection,
+    DefaultScheduleStatus,
     Definitions,
     MetadataValue,
     Output,
+    ScheduleDefinition,
     define_asset_job,
     multi_asset,
 )
@@ -35,6 +37,15 @@ _FLOE_MANIFEST_ACCESS_MODE_ENV = "OPENLAKEFORGE_FLOE_MANIFEST_ACCESS_MODE"
 _FLOE_MANIFEST_ACCESS_MODE_REMOTE = "remote"
 _FLOE_MANIFEST_ACCESS_MODE_LOCAL = "local"
 _FLOE_S3_REPORT_LOADER_INSTALLED = False
+
+_STAGE_ENV = "OPENLAKEFORGE_STAGE"
+# Only PROD carries the recurring-schedule scaffold. DEV and UAT stay manual:
+# the same immutable revision is deployed to every stage, so a schedule that
+# merely defaulted to stopped would still be present in the DEV instance for
+# someone to switch on, and the run it then launched would be a
+# production-shaped daily workload against the DEV catalog.
+_SCHEDULED_STAGES = frozenset({"prod"})
+_DAILY_SCHEDULE_CRON = "0 3 * * *"
 
 
 @dataclass(frozen=True)
@@ -213,7 +224,35 @@ def build_product_definitions(spec: ProductDefinitionSpec) -> Definitions:
     return Definitions(
         assets=[dbt_gold_assets],
         jobs=[product_pipeline],
+        schedules=build_stage_schedules(spec),
     )
+
+
+def build_stage_schedules(
+    spec: ProductDefinitionSpec, *, stage: str | None = None
+) -> list[ScheduleDefinition]:
+    """Build the daily schedule scaffold a stage is entitled to.
+
+    `stage` defaults to the deployed stage the activation release puts on the
+    pod. Anything else -- an unset variable, a workstation run, a stage this
+    scaffold does not cover -- gets no schedule at all, which is the safe
+    direction: a stage cannot acquire recurring runs by being unrecognised.
+
+    The schedule is `STOPPED` even where it exists, so deploying a revision
+    never starts it. Enabling it is a deliberate act in the Dagster UI.
+    """
+    resolved = (os.environ.get(_STAGE_ENV, "") if stage is None else stage).strip().lower()
+    if resolved not in _SCHEDULED_STAGES:
+        return []
+    return [
+        ScheduleDefinition(
+            name=f"{spec.product}_daily",
+            job_name=spec.job_name,
+            cron_schedule=_DAILY_SCHEDULE_CRON,
+            execution_timezone="UTC",
+            default_status=DefaultScheduleStatus.STOPPED,
+        )
+    ]
 
 
 def _install_floe_s3_report_loader() -> None:

--- a/tools/olf/olf/project_code_check.py
+++ b/tools/olf/olf/project_code_check.py
@@ -119,6 +119,7 @@ def validate(root: Path) -> None:
         _fail("merged definitions do not contain every product asset")
     _verify_immutable_manifest_replay(root, products[0], product_dagster_lib, load_manifest)
     _verify_shared_assets(inventory, merged_keys_list)
+    _verify_stage_schedules(inventory, product_dagster_lib)
     Definitions.validate_loadable(merged_defs)
     merged_defs.get_repository_def().load_all_definitions()
 
@@ -156,6 +157,42 @@ def _verify_sequential_floe_orchestration(product: object, manifest: object, job
         _fail(f"{product.job_name} is missing Floe orchestration concurrency")
     if max_concurrent != 1:
         _fail(f"{product.job_name} did not inherit Floe orchestration concurrency")
+
+
+def _verify_stage_schedules(inventory: object, library: object) -> None:
+    """Require the daily scaffold to exist only where a stage asks for it, and never to start itself.
+
+    Every stage runs the same immutable revision, so this is the only thing
+    standing between a promotion and a recurring production-shaped workload
+    appearing in DEV.
+    """
+    for product in inventory.products:
+        spec = library.ProductDefinitionSpec(
+            domain=product.domain_name,
+            product=product.id,
+            silver_inputs=(),
+            bronze_inputs=(),
+            gold_assets=(),
+        )
+        for stage in ("dev", "uat", ""):
+            if library.build_stage_schedules(spec, stage=stage):
+                _fail(f"stage {stage!r} must define no schedule for {product.job_name}")
+        schedules = library.build_stage_schedules(spec, stage="prod")
+        if len(schedules) != 1:
+            _fail(f"prod must define exactly one daily schedule for {product.job_name}")
+        schedule = schedules[0]
+        if schedule.job_name != product.job_name:
+            _fail(f"{schedule.name} targets {schedule.job_name}, not the descriptor job {product.job_name}")
+        status = getattr(schedule.default_status, "value", schedule.default_status)
+        if status != "STOPPED":
+            _fail(f"{schedule.name} defaults to {status}; deploying a revision must not start a schedule")
+        _verify_daily_cron(schedule)
+
+
+def _verify_daily_cron(schedule: object) -> None:
+    fields = str(schedule.cron_schedule).split()
+    if len(fields) != 5 or fields[2:] != ["*", "*", "*"] or not all(field.isdigit() for field in fields[:2]):
+        _fail(f"{schedule.name} must run once a day; got {schedule.cron_schedule!r}")
 
 
 def _verify_immutable_manifest_replay(root: Path, product: object, library: object, load_manifest: object) -> None:

--- a/tools/olf/tests/test_deployment_contract_env.py
+++ b/tools/olf/tests/test_deployment_contract_env.py
@@ -99,3 +99,22 @@ def test_uses_the_scoped_environment_for_contract_terraform(monkeypatch: pytest.
 
     assert observed["OLF_DISTRIBUTION_ROOT"] == str(tmp_path / "payload")
     assert observed["OPENLAKEFORGE_TERRAFORM_STATE_ROOT"] == str(tmp_path / "state/aws")
+
+
+def test_selected_stage_survives_into_the_contract_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`libs.product_dagster.build_stage_schedules` reads OPENLAKEFORGE_STAGE in the code-server
+    pod, and the only thing that puts it there is this environment: activation forwards every
+    `OPENLAKEFORGE_*` key it yields onto the container. A contract that dropped the key would
+    silently give PROD the unrecognised-stage behaviour, which is no schedules at all."""
+    from olf.deployment.context import DeploymentContext
+
+    monkeypatch.setattr(contracts_module, "load_provider_contracts", lambda terraform_dir, *, environ: None)
+    monkeypatch.setattr(contracts_module, "build_contract_env", lambda *args, **kwargs: ({}, []))
+    context = DeploymentContext.local(repo_root=tmp_path, stage="dev")
+
+    with contract_env.applied_contract_environment(
+        **_kwargs(tmp_path), environ=context.command_env()
+    ) as env:
+        assert env["OPENLAKEFORGE_STAGE"] == "dev"

--- a/tools/olf/tests/test_project_code_check.py
+++ b/tools/olf/tests/test_project_code_check.py
@@ -49,3 +49,48 @@ def test_sequential_floe_orchestration_requires_serial_manifest_and_job_config()
     job.run_config["execution"]["config"]["multiprocess"]["max_concurrent"] = 2
     with pytest.raises(RuntimeError, match="did not inherit Floe orchestration concurrency"):
         project_code_check._verify_sequential_floe_orchestration(product, manifest, job)
+
+
+def _schedule_library(
+    *,
+    stages: tuple[str, ...] = ("prod",),
+    job_name: str = "order_revenue_pipeline",
+    cron: str = "0 3 * * *",
+    status: str = "STOPPED",
+    count: int = 1,
+) -> SimpleNamespace:
+    schedule = SimpleNamespace(
+        name="order_revenue_daily",
+        job_name=job_name,
+        cron_schedule=cron,
+        default_status=SimpleNamespace(value=status),
+    )
+    return SimpleNamespace(
+        ProductDefinitionSpec=lambda **fields: SimpleNamespace(**fields),
+        build_stage_schedules=lambda spec, *, stage: [schedule] * count if stage in stages else [],
+    )
+
+
+def _inventory() -> SimpleNamespace:
+    product = SimpleNamespace(id="order_revenue", domain_name="sales", job_name="order_revenue_pipeline")
+    return SimpleNamespace(products=(product,))
+
+
+def test_stage_schedules_accept_a_stopped_daily_scaffold_in_prod_only() -> None:
+    project_code_check._verify_stage_schedules(_inventory(), _schedule_library())
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"stages": ("dev", "prod")}, "must define no schedule"),
+        ({"stages": ("", "prod")}, "must define no schedule"),
+        ({"count": 2}, "exactly one daily schedule"),
+        ({"job_name": "hand_written_job"}, "not the descriptor job"),
+        ({"status": "RUNNING"}, "must not start a schedule"),
+        ({"cron": "*/5 * * * *"}, "must run once a day"),
+    ],
+)
+def test_stage_schedules_reject_anything_a_promotion_could_start(overrides: dict, message: str) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        project_code_check._verify_stage_schedules(_inventory(), _schedule_library(**overrides))


### PR DESCRIPTION
Closes the two schedule acceptance criteria in #134. See the [scope
reconciliation comment](https://github.com/malon64/openlakeforge/issues/134#issuecomment-5604706972)
for why the rest of that issue was already delivered by #133/#114/#115.

## Why this exists

Both criteria were unfalsifiable. `grep -rn "ScheduleDefinition\|@schedule\|@sensor"`
over `lakehouse_code/`, `libs/` and `images/` returned nothing, so "DEV schedules are
inactive by default" and "promotion does not start a schedule" held over an empty set.

## Behaviour

| Stage the pod reports | Schedules in the code location |
| --- | --- |
| `prod` | One `<product>_daily` per product, every one `STOPPED` |
| `dev`, `uat` | None |
| Unset or unrecognised | None |

The stage is read at load time from `OPENLAKEFORGE_STAGE`. The same immutable
revision reaches every stage, so nothing about a schedule can be decided at build
time. The variable arrives via `DeploymentContext.command_env` →
`applied_contract_environment` → `_user_values`, which forwards every
`OPENLAKEFORGE_*` key onto the deployment; a new test in
`test_deployment_contract_env.py` pins that chain, since a contract that dropped the
key would silently give PROD the unrecognised-stage behaviour.

**DEV gets no schedule rather than a stopped one.** A stopped schedule still sits in
the DEV instance for someone to switch on, and the run it launches is a
production-shaped daily workload against the DEV catalog. Same reasoning for an
unrecognised stage: it must not be a way to acquire recurring runs.

## Where it is enforced

`olf check project-code` fails the build if either property stops holding. That check
runs inside the project-code image, where Dagster is importable — `tools/olf` has no
Dagster, so it is the only place the real function can be exercised. The unit tests
drive `_verify_stage_schedules` with invalid shapes (a DEV schedule, two schedules, a
hand-written job name, `RUNNING`, a five-minute cron) and assert each is rejected.

Asset keys are untouched: the stage stays a runtime and catalog boundary, never part
of an asset's identity, as #134 and #111 both require.

## Gates

All four pass from the repository root. Coverage 81.40% against the 81% floor.
`olf check all` exits 0, which includes the project-code runtime check above.

Runtime verification against a live cluster was **not** run — no kind cluster is
reachable here. It would prove the PROD code server actually loads the schedule
stopped and the DEV one loads none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)